### PR TITLE
feat: Add cloudflare tunnel

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -66,3 +66,6 @@ PORTAINER_PASSWORD=password1234
 # Grafana Dashboard
 GF_SECURITY_ADMIN_USER=admin
 GF_SECURITY_ADMIN_PASSWORD=password
+
+# Cloudflare tunnel token
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,15 @@
 version: '3'
 services:
+  tunnel:
+    container_name: cloudflared-tunnel
+    image: cloudflare/cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - nginx
+
   portainer:
     restart: on-failure
     image: portainer/portainer-ce:latest

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,15 +1,5 @@
 version: '3'
 services:
-  tunnel:
-    container_name: cloudflared-tunnel
-    image: cloudflare/cloudflared
-    restart: unless-stopped
-    command: tunnel --no-autoupdate run
-    environment:
-      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
-    depends_on:
-      - nginx
-
   portainer:
     restart: on-failure
     image: portainer/portainer-ce:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,15 @@
 version: '3'
 services:
+  tunnel:
+    container_name: cloudflared-tunnel
+    image: cloudflare/cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - nginx
+
   portainer:
     restart: on-failure
     image: portainer/portainer-ce:latest


### PR DESCRIPTION
Use cloudflare tunnel to protect Appflowy Cloud so that the server does not need to expose the port to avoid port scanning

1. CloudFlare zero trust setting create a tunnel
  ![image](https://github.com/AppFlowy-IO/AppFlowy-Cloud/assets/12424898/8f4e3325-c0db-4bf0-897d-9db56234ccaa)

2. Get tunnel token
  ![image](https://github.com/AppFlowy-IO/AppFlowy-Cloud/assets/12424898/cd5b98ba-1a2e-4098-950a-a92be73a3d65)

3. put token to env
  ```bash
  CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoiOWRiODVlM2Nm...
  ```
4. start services
  ```bash
  docker compose up -d 
  ```

5. Setting cloudflare tunnel public host
  ![image](https://github.com/AppFlowy-IO/AppFlowy-Cloud/assets/12424898/80295c0a-fe8a-4f76-8930-55723ff236e7)
