### PR TITLE
fix: remove tunnel service container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   tunnel:
-    container_name: cloudflared-tunnel
     image: cloudflare/cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run


### PR DESCRIPTION
[Bug] tunnel service container name already in use

**Describe the bug**
tunnel service container name already in use, it will let tunnel service can't up.


**Screenshots**
![image](https://github.com/AppFlowy-IO/AppFlowy-Cloud/assets/12424898/9add7426-6f23-4640-b07f-32026cfef420)