### PR TITLE
Update README.md - fix link to deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and real-time WebSocket communication for an efficient and collaborative user ex
 
 
 ## 🚀 Deployment
-- See [deployment guide](./doc/deployment.md)
+- See [deployment guide](./doc/DEPLOYMENT.md)
 
 ## 💻 Development
 


### PR DESCRIPTION
The `docs/DEPLOYMENT.md` is all caps now, so the link in the root README.md didn't work. This PR updates that to point to the new file name.