### PR TITLE
fix: update the S3 env vars in docker-compose.yml to not have `AWS` in them

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,10 +149,10 @@ services:
       - APP__GOTRUE__ADMIN_PASSWORD=${GOTRUE_ADMIN_PASSWORD}
       - APP__S3__USE_MINIO=${USE_MINIO}
       - APP__S3__MINIO_URL=${MINIO_URL:-http://minio:9000}
-      - APP__S3__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - APP__S3__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - APP__S3__AWS_S3_BUCKET=${AWS_S3_BUCKET}
-      - APP__S3__AWS_REGION=${AWS_REGION}
+      - APP__S3__ACCESS_KEY=${AWS_ACCESS_KEY_ID}
+      - APP__S3__SECRET_KEY=${AWS_SECRET_ACCESS_KEY}
+      - APP__S3__BUCKET=${AWS_S3_BUCKET}
+      - APP__S3__REGION=${AWS_REGION}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Thanks to https://github.com/AppFlowy-IO/AppFlowy-Cloud/issues/204#issuecomment-1851285350 I was able to test using these env vars and Appflowy-Cloud is able to initialize it's app state using the minio bucket I specified.

This PR updates those environment variables in the docker-compose.yml file to help others.