### PR TITLE
feat: S3 compatiblity with garage

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -48,7 +48,7 @@ USE_MINIO=true
 AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin
 AWS_S3_BUCKET=appflowy
-AWS_REGION=us-east-1
+#AWS_REGION=us-east-1
 
 RUST_LOG=info
 

--- a/dev.env
+++ b/dev.env
@@ -55,7 +55,7 @@ USE_MINIO=true
 AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin
 AWS_S3_BUCKET=appflowy
-AWS_REGION=us-east-1
+#AWS_REGION=us-east-1
 
 RUST_LOG=info
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -294,7 +294,7 @@ async fn get_aws_s3_bucket(s3_setting: &S3Setting) -> Result<s3::Bucket, Error> 
   let region = {
     match s3_setting.use_minio {
       true => s3::Region::Custom {
-        region: "".to_owned(),
+        region: s3_setting.region.to_owned(),
         endpoint: s3_setting.minio_url.to_owned(),
       },
       false => s3_setting

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -116,7 +116,7 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
       access_key: get_env_var("APPFLOWY_S3_ACCESS_KEY", "minioadmin"),
       secret_key: get_env_var("APPFLOWY_S3_SECRET_KEY", "minioadmin").into(),
       bucket: get_env_var("APPFLOWY_S3_BUCKET", "appflowy"),
-      region: get_env_var("APPFLOWY_S3_REGION", "us-east-1"),
+      region: get_env_var("APPFLOWY_S3_REGION", ""),
     },
     casbin: CasbinSetting {
       pool_size: get_env_var("APPFLOWY_CASBIN_POOL_SIZE", "8").parse()?,


### PR DESCRIPTION
This PR allows to use custom S3 providers apart from minio that require a correctly set region, e.g. [garage](https://garagehq.deuxfleurs.fr/) (designed for self-hosting, uses far less RAM than minio, also written in Rust)