### PR TITLE
Update DEPLOYMENT.md / Hardware Requirements

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -3,12 +3,12 @@
 - The following document will walk you through the steps to deploy your own AppFlowy-Cloud
 
 ## Hardware Requirements
-- Because AppFlowy-Cloud will have to be running persistently (or at least when one of the user is using),
-we recommend using cloud compute services (as your host server) such as
- - [Amazon EC2](https://aws.amazon.com/ec2/) or
- - [Azure Virtual Machines](https://azure.microsoft.com/en-gb/products/virtual-machines/)
 - Minimum 2GB Ram (4GB Recommended)
 - Ports 80/443 available
+- Because AppFlowy-Cloud will have to be running persistently (or at least whenever users need access),
+we recommend deploying it on a cloud compute services as host server (if deploying it on a home server is not an option for you) such as
+    - [Amazon EC2](https://aws.amazon.com/ec2/) or
+    - [Azure Virtual Machines](https://azure.microsoft.com/en-gb/products/virtual-machines/)
 
 
 ## Software Requirements


### PR DESCRIPTION
I find it unintuitive that the deployment guide for AppFlowy Cloud suggests using AMZ EC2 or Microsoft Azure VMs, which are paid services that are hosted at Amazon / Microsoft data servers. I get that the point is that the server needs to be available / reliable and those cloud compute services are. But aren't we targeting people who want to use free opensource software here?