### PR TITLE
Update minio root user & pass variable to match DEPLOYMENT.MD & deploy.env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
     image: minio/minio
     environment:
       - MINIO_BROWSER_REDIRECT_URL=http://localhost/minio
-      - MINIO_ROOT_USER=${AWS_ACCESS_KEY_ID:-minioadmin}
-      - MINIO_ROOT_PASSWORD=${AWS_SECRET_ACCESS_KEY:-minioadmin}
+      - MINIO_ROOT_USER=${APPFLOWY_S3_ACCESS_KEY:-minioadmin}
+      - MINIO_ROOT_PASSWORD=${APPFLOWY_S3_SECRET_KEY:-minioadmin}
     command: server /data --console-address ":9001"
     volumes:
       - minio_data:/data


### PR DESCRIPTION
This change allows for following variables found in lines 94 and 95 of DEPLOYMENT.MD .env example and lines 58 and 59 of deploy.env - Without this change, deployment easily deploys with default user/pass of minioadmin/minioadmin