### PR TITLE
feat: Custom nginx ports

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -1,6 +1,10 @@
 # This file is a template for docker compose deployment
 # Copy this file to .env and change the values as needed
 
+# Nginx ports
+NGINX_HTTP_PORT=80
+NGINX_HTTPS_PORT=443
+
 # AppFlowy Cloud
 ## URL that connects to the gotrue docker container
 APPFLOWY_GOTRUE_BASE_URL=http://gotrue:9999

--- a/dev.env
+++ b/dev.env
@@ -1,3 +1,7 @@
+# Nginx ports
+NGINX_HTTP_PORT=80
+NGINX_HTTPS_PORT=443
+
 # gotrue URL that the appflowy service will use to connect to gotrue
 APPFLOWY_GOTRUE_BASE_URL=http://localhost:9999
 APPFLOWY_DATABASE_URL=postgres://postgres:password@localhost:5432/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     restart: on-failure
     image: nginx
     ports:
-      - ${NGINX_HTTP_PORT}:80   # Disable this if you are using TLS
-      - ${NGINX_HTTPS_PORT}:443
+      - ${NGINX_HTTP_PORT:-80}:80   # Disable this if you are using TLS
+      - ${NGINX_HTTPS_PORT:-443}:443
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/ssl/certificate.crt:/etc/nginx/ssl/certificate.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     restart: on-failure
     image: nginx
     ports:
-      - 80:80   # Disable this if you are using TLS
-      - 443:443
+      - ${NGINX_HTTP_PORT}:80   # Disable this if you are using TLS
+      - ${NGINX_HTTPS_PORT}:443
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/ssl/certificate.crt:/etc/nginx/ssl/certificate.crt


### PR DESCRIPTION
Allow users to set the Nginx port themselves, defaulting to 80 and 443 if not set in the .env file.
Avoid ports conflicts, likely synology nas 80, 443 already used
