### PR TITLE
fix: env variable load sequence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,13 @@ async fn main() -> anyhow::Result<()> {
   filters.push(format!("database={}", level));
   filters.push(format!("storage={}", level));
   filters.push(format!("gotrue={}", level));
-  let conf =
-    get_configuration().map_err(|e| anyhow::anyhow!("Failed to read configuration: {}", e))?;
-  init_subscriber(&conf.app_env, filters);
 
   // Load environment variables from .env file
   dotenvy::dotenv().ok();
+
+  let conf =
+    get_configuration().map_err(|e| anyhow::anyhow!("Failed to read configuration: {}", e))?;
+  init_subscriber(&conf.app_env, filters);
 
   let (tx, rx) = tokio::sync::mpsc::channel(1000);
   let state = init_state(&conf, tx)


### PR DESCRIPTION
The environmental variable is loaded after the configuration has been initialized. As a result, some configuration will always use the default configuration value and not the override value in the env file, such as APPFLOWY_GOTRUE_BASE_URL.