### PR TITLE
fix: handle receiver close for connection test

### DIFF
--- a/tests/websocket/conn_test.rs
+++ b/tests/websocket/conn_test.rs
@@ -12,9 +12,13 @@ async fn realtime_connect_test() {
   let connect_info = c.ws_connect_info().await.unwrap();
   tokio::spawn(async move { ws_client.connect(&c.ws_url(), connect_info).await });
   let connect_future = async {
-    while let Ok(state) = state.recv().await {
-      if state == ConnectState::Connected {
-        break;
+    loop {
+      match state.recv().await {
+        Ok(ConnectState::Connected) => {
+          break;
+        },
+        Ok(_) => {},
+        Err(err) => panic!("Receiver Error: {:?}", err),
       }
     }
   };
@@ -42,9 +46,13 @@ async fn realtime_connect_after_token_exp_test() {
   tokio::spawn(async move { ws_client.connect(&c.ws_url(), connect_info).await });
 
   let connect_future = async {
-    while let Ok(state) = state.recv().await {
-      if state == ConnectState::Connected {
-        break;
+    loop {
+      match state.recv().await {
+        Ok(ConnectState::Connected) => {
+          break;
+        },
+        Ok(_) => {},
+        Err(err) => panic!("Receiver Error: {:?}", err),
       }
     }
   };


### PR DESCRIPTION
The real time connection test can still pass even though the the websocket client receive a 404 error while attempting to connect to the server, such as when LOCALHOST_WS environmental variable is set to the wrong path (eg. ws://localhost:8000`. In such scenario the connect future async loop returns early as the receiver error is not handled.