### PR TITLE
feat: using transaction to write multiple records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "infra",
  "itertools 0.11.0",
  "lazy_static",
+ "log",
  "mime",
  "once_cell",
  "opener",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ collab-stream.workspace = true
 collab-rt.workspace = true
 serde_repr = "0.1.18"
 tonic-build = "0.11.0"
+log = "0.4.20"
 
 
 [dev-dependencies]

--- a/libs/collab-rt/Cargo.toml
+++ b/libs/collab-rt/Cargo.toml
@@ -14,7 +14,7 @@ tracing = "0.1.40"
 futures-util = "0.3.30"
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-tokio = { workspace = true, features = ["net", "sync", "macros"] }
+tokio = { workspace = true, features = ["net", "sync", "macros", "rt-multi-thread"] }
 async-trait = "0.1.77"
 serde.workspace = true
 serde_json.workspace = true
@@ -45,4 +45,4 @@ lazy_static = "1.4.0"
 rand = "0.8.5"
 
 [features]
-multi-thread = ["tokio/rt-multi-thread"]
+multi-thread = []

--- a/libs/collab-rt/src/group/group_init.rs
+++ b/libs/collab-rt/src/group/group_init.rs
@@ -292,10 +292,8 @@ mod tests {
 
   #[test]
   fn edit_state_test() {
-    let edit_state = EditState::new(10, 10, true);
+    let edit_state = EditState::new(10, 10, false);
     edit_state.increment_edit_count();
-    assert!(edit_state.should_save_to_disk());
-    edit_state.tick();
 
     for _ in 0..10 {
       edit_state.increment_edit_count();

--- a/libs/collab-rt/src/group/persistence.rs
+++ b/libs/collab-rt/src/group/persistence.rs
@@ -93,7 +93,6 @@ where
 
     // Check if conditions for saving to disk are not met
     if !self.edit_state.should_save_to_disk() {
-      trace!("skip save collab to disk: {}", self.object_id);
       return Ok(());
     }
     self.save(false).await?;

--- a/libs/collab-rt/src/group/persistence.rs
+++ b/libs/collab-rt/src/group/persistence.rs
@@ -139,7 +139,10 @@ where
         if err.is_panic() {
           // reason:
           // 1. Couldn't get item's parent
-          warn!("encode collab panic:{}=>{:?}", self.object_id, err);
+          warn!(
+            "encode collab panic:{}:{}=>{:?}",
+            self.object_id, self.collab_type, err
+          );
         } else {
           error!("fail to spawn a task to get encode collab: {:?}", err)
         }

--- a/libs/collab-rt/src/group/persistence.rs
+++ b/libs/collab-rt/src/group/persistence.rs
@@ -125,7 +125,6 @@ where
           .await
         {
           Ok(_) => {
-            trace!("[realtime] did save collab to disk: {}", self.object_id);
             // Update the edit state on successful save
             self.edit_state.tick();
           },

--- a/libs/collab-rt/src/group/plugin/history_plugin.rs
+++ b/libs/collab-rt/src/group/plugin/history_plugin.rs
@@ -60,7 +60,6 @@ where
 
     let old = self.edit_count.fetch_add(1, Ordering::SeqCst);
     if old < 20 {
-      trace!("skip snapshot creation, edit_count: {}", old);
       return;
     }
 

--- a/libs/database/src/collab/collab_db_ops.rs
+++ b/libs/database/src/collab/collab_db_ops.rs
@@ -239,22 +239,6 @@ struct QueryCollabData {
   blob: RawData,
 }
 
-#[inline]
-pub async fn delete_collab(pg_pool: &PgPool, object_id: &str) -> Result<(), sqlx::Error> {
-  sqlx::query!(
-    r#"
-        UPDATE af_collab
-        SET deleted_at = $2
-        WHERE oid = $1;
-        "#,
-    object_id,
-    chrono::Utc::now()
-  )
-  .execute(pg_pool)
-  .await?;
-  Ok(())
-}
-
 pub async fn create_snapshot(
   pg_pool: &PgPool,
   object_id: &str,
@@ -589,6 +573,9 @@ fn transform_record_not_found_error(
   }
 }
 
+/// Checks for the existence of a collaboration entry in the `af_collab` table using a specified `oid`.
+/// Use this method to verify if a specific collaboration object is already registered in the database.
+/// For a more efficient lookup, especially in frequent checks, consider using the cached method [CollabCache::is_exist].
 #[inline]
 pub async fn is_collab_exists<'a, E: Executor<'a, Database = Postgres>>(
   oid: &str,

--- a/libs/database/src/collab/collab_storage.rs
+++ b/libs/database/src/collab/collab_storage.rs
@@ -76,6 +76,13 @@ pub trait CollabStorage: Send + Sync + 'static {
     write_immediately: bool,
   ) -> AppResult<()>;
 
+  async fn insert_new_collab(
+    &self,
+    workspace_id: &str,
+    uid: &i64,
+    params: CollabParams,
+  ) -> AppResult<()>;
+
   /// Insert a new collaboration in the storage.
   ///
   /// # Arguments
@@ -160,6 +167,18 @@ where
     self
       .as_ref()
       .insert_or_update_collab(workspace_id, uid, params, write_immediately)
+      .await
+  }
+
+  async fn insert_new_collab(
+    &self,
+    workspace_id: &str,
+    uid: &i64,
+    params: CollabParams,
+  ) -> AppResult<()> {
+    self
+      .as_ref()
+      .insert_new_collab(workspace_id, uid, params)
       .await
   }
 

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -419,6 +419,16 @@ async fn create_collab_handler(
   };
 
   let (params, workspace_id) = params.split();
+  if let Err(err) = params.check_encode_collab().await {
+    return Err(
+      AppError::NoRequiredData(format!(
+        "collab doc state is not correct:{},{}",
+        params.object_id, err
+      ))
+      .into(),
+    );
+  }
+
   let mut transaction = state
     .pg_pool
     .begin()

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -791,6 +791,16 @@ async fn add_collab_member_handler(
   state: Data<AppState>,
 ) -> Result<Json<AppResponse<()>>> {
   let payload = payload.into_inner();
+  if !state.collab_cache.is_exist(&payload.object_id).await? {
+    return Err(
+      AppError::RecordNotFound(format!(
+        "Fail to insert collab member. The Collab with object_id {} does not exist",
+        payload.object_id
+      ))
+      .into(),
+    );
+  }
+
   biz::collab::ops::create_collab_member(&state.pg_pool, &payload, &state.collab_access_control)
     .await?;
   Ok(Json(AppResponse::Ok()))
@@ -803,6 +813,16 @@ async fn update_collab_member_handler(
   state: Data<AppState>,
 ) -> Result<Json<AppResponse<()>>> {
   let payload = payload.into_inner();
+
+  if !state.collab_cache.is_exist(&payload.object_id).await? {
+    return Err(
+      AppError::RecordNotFound(format!(
+        "Fail to update collab member. The Collab with object_id {} does not exist",
+        payload.object_id
+      ))
+      .into(),
+    );
+  }
   biz::collab::ops::upsert_collab_member(
     &state.pg_pool,
     &user_uuid,

--- a/src/application.rs
+++ b/src/application.rs
@@ -231,6 +231,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: RTCommandSender) -> Result<A
     snapshot_control,
     rt_cmd_tx,
     redis_conn_manager.clone(),
+    metrics.collab_metrics.clone(),
   ));
 
   #[cfg(feature = "history")]

--- a/src/biz/collab/cache.rs
+++ b/src/biz/collab/cache.rs
@@ -5,7 +5,7 @@ use collab::core::collab_plugin::EncodedCollab;
 
 use crate::state::RedisConnectionManager;
 
-use database_entity::dto::{CollabParams, QueryCollab, QueryCollabParams, QueryCollabResult};
+use database_entity::dto::{CollabParams, QueryCollab, QueryCollabResult};
 use futures_util::{stream, StreamExt};
 use itertools::{Either, Itertools};
 use sqlx::{PgPool, Transaction};
@@ -34,28 +34,28 @@ impl CollabCache {
     }
   }
 
-  pub async fn get_collab_encode_data(
+  pub async fn get_encode_collab(
     &self,
     uid: &i64,
-    params: QueryCollabParams,
+    query: QueryCollab,
   ) -> Result<EncodedCollab, AppError> {
     self.total_attempts.fetch_add(1, Ordering::Relaxed);
     // Attempt to retrieve encoded collab from memory cache, falling back to disk cache if necessary.
-    if let Some(encoded_collab) = self.mem_cache.get_encode_collab(&params.object_id).await {
+    if let Some(encoded_collab) = self.mem_cache.get_encode_collab(&query.object_id).await {
       event!(
         Level::DEBUG,
         "Get encode collab:{} from cache",
-        params.object_id
+        query.object_id
       );
       self.success_attempts.fetch_add(1, Ordering::Relaxed);
       return Ok(encoded_collab);
     }
 
     // Retrieve from disk cache as fallback. After retrieval, the value is inserted into the memory cache.
-    let object_id = params.object_id.clone();
+    let object_id = query.object_id.clone();
     let encode_collab = self
       .disk_cache
-      .get_collab_encoded_from_disk(uid, params)
+      .get_collab_encoded_from_disk(uid, query)
       .await?;
 
     // spawn a task to insert the encoded collab into the memory cache
@@ -70,11 +70,13 @@ impl CollabCache {
     Ok(encode_collab)
   }
 
-  pub async fn batch_get_encode_collab(
+  /// Batch get the encoded collab data from the cache.
+  /// returns a hashmap of the object_id to the encoded collab data.
+  pub async fn batch_get_encode_collab<T: Into<QueryCollab>>(
     &self,
-    uid: &i64,
-    queries: Vec<QueryCollab>,
+    queries: Vec<T>,
   ) -> HashMap<String, QueryCollabResult> {
+    let queries = queries.into_iter().map(Into::into).collect::<Vec<_>>();
     let mut results = HashMap::new();
     // 1. Processes valid queries against the in-memory cache to retrieve cached values.
     //    - Queries not found in the cache are earmarked for disk retrieval.
@@ -102,7 +104,7 @@ impl CollabCache {
 
     // 2. Retrieves remaining values from the disk cache for queries not satisfied by the memory cache.
     //    - These values are then merged into the final result set.
-    let values_from_disk_cache = self.disk_cache.batch_get_collab(uid, disk_queries).await;
+    let values_from_disk_cache = self.disk_cache.batch_get_collab(disk_queries).await;
     results.extend(values_from_disk_cache);
     results
   }
@@ -140,6 +142,32 @@ impl CollabCache {
       );
     }
 
+    Ok(())
+  }
+
+  pub async fn get_encode_collab_from_disk(
+    &self,
+    uid: &i64,
+    query: QueryCollab,
+  ) -> Result<EncodedCollab, AppError> {
+    let encode_collab = self
+      .disk_cache
+      .get_collab_encoded_from_disk(uid, query)
+      .await?;
+    Ok(encode_collab)
+  }
+
+  pub async fn insert_encode_collab_in_disk(
+    &self,
+    workspace_id: &str,
+    uid: &i64,
+    params: CollabParams,
+    transaction: &mut Transaction<'_, sqlx::Postgres>,
+  ) -> Result<(), AppError> {
+    self
+      .disk_cache
+      .upsert_collab_with_transaction(workspace_id, uid, params, transaction)
+      .await?;
     Ok(())
   }
 

--- a/src/biz/collab/cache.rs
+++ b/src/biz/collab/cache.rs
@@ -194,7 +194,7 @@ impl CollabCache {
     }
   }
 
-  pub async fn remove_collab(&self, object_id: &str) -> Result<(), AppError> {
+  pub async fn delete_collab(&self, object_id: &str) -> Result<(), AppError> {
     self.mem_cache.remove_encode_collab(object_id).await?;
     self.disk_cache.delete_collab(object_id).await?;
     Ok(())

--- a/src/biz/collab/cache.rs
+++ b/src/biz/collab/cache.rs
@@ -115,7 +115,7 @@ impl CollabCache {
     &self,
     workspace_id: &str,
     uid: &i64,
-    params: CollabParams,
+    params: &CollabParams,
     transaction: &mut Transaction<'_, sqlx::Postgres>,
   ) -> Result<(), AppError> {
     let object_id = params.object_id.clone();
@@ -166,7 +166,7 @@ impl CollabCache {
   ) -> Result<(), AppError> {
     self
       .disk_cache
-      .upsert_collab_with_transaction(workspace_id, uid, params, transaction)
+      .upsert_collab_with_transaction(workspace_id, uid, &params, transaction)
       .await?;
     Ok(())
   }

--- a/src/biz/collab/disk_cache.rs
+++ b/src/biz/collab/disk_cache.rs
@@ -31,10 +31,10 @@ impl CollabDiskCache {
     &self,
     workspace_id: &str,
     uid: &i64,
-    params: CollabParams,
+    params: &CollabParams,
     transaction: &mut Transaction<'_, sqlx::Postgres>,
   ) -> AppResult<()> {
-    insert_into_af_collab(transaction, uid, workspace_id, &params).await?;
+    insert_into_af_collab(transaction, uid, workspace_id, params).await?;
     Ok(())
   }
 
@@ -46,7 +46,7 @@ impl CollabDiskCache {
   ) -> Result<EncodedCollab, AppError> {
     event!(
       Level::INFO,
-      "Get {}:{} from disk",
+      "try get {}:{} from disk",
       query.collab_type,
       query.object_id
     );

--- a/src/biz/collab/metrics.rs
+++ b/src/biz/collab/metrics.rs
@@ -7,6 +7,8 @@ pub struct CollabMetrics {
   total_write_snapshot_count: Gauge,
   success_write_collab_count: Gauge,
   total_write_collab_count: Gauge,
+  total_queue_collab_count: Gauge,
+  success_queue_collab_count: Gauge,
 }
 
 impl CollabMetrics {
@@ -16,6 +18,8 @@ impl CollabMetrics {
       total_write_snapshot_count: Default::default(),
       success_write_collab_count: Default::default(),
       total_write_collab_count: Default::default(),
+      total_queue_collab_count: Default::default(),
+      success_queue_collab_count: Default::default(),
     }
   }
 
@@ -42,6 +46,16 @@ impl CollabMetrics {
       "total write collab",
       metrics.total_write_collab_count.clone(),
     );
+    realtime_registry.register(
+      "success_queue_collab_count",
+      "success queue collab",
+      metrics.success_queue_collab_count.clone(),
+    );
+    realtime_registry.register(
+      "total_queue_collab_count",
+      "total queue pending collab",
+      metrics.total_queue_collab_count.clone(),
+    );
 
     metrics
   }
@@ -54,5 +68,10 @@ impl CollabMetrics {
   pub fn record_write_collab(&self, success_attempt: i64, total_attempt: i64) {
     self.success_write_collab_count.set(success_attempt);
     self.total_write_collab_count.set(total_attempt);
+  }
+
+  pub fn record_queue_collab(&self, success_attempt: i64, total_attempt: i64) {
+    self.success_queue_collab_count.set(success_attempt);
+    self.total_queue_collab_count.set(total_attempt);
   }
 }

--- a/src/biz/collab/metrics.rs
+++ b/src/biz/collab/metrics.rs
@@ -5,6 +5,8 @@ use prometheus_client::registry::Registry;
 pub struct CollabMetrics {
   success_write_snapshot_count: Gauge,
   total_write_snapshot_count: Gauge,
+  success_write_collab_count: Gauge,
+  total_write_collab_count: Gauge,
 }
 
 impl CollabMetrics {
@@ -12,6 +14,8 @@ impl CollabMetrics {
     Self {
       success_write_snapshot_count: Gauge::default(),
       total_write_snapshot_count: Default::default(),
+      success_write_collab_count: Default::default(),
+      total_write_collab_count: Default::default(),
     }
   }
 
@@ -28,6 +32,16 @@ impl CollabMetrics {
       "total attempt write snapshot to db",
       metrics.total_write_snapshot_count.clone(),
     );
+    realtime_registry.register(
+      "success_write_collab_count",
+      "success write collab",
+      metrics.success_write_collab_count.clone(),
+    );
+    realtime_registry.register(
+      "total_write_collab_count",
+      "total write collab",
+      metrics.total_write_collab_count.clone(),
+    );
 
     metrics
   }
@@ -35,5 +49,10 @@ impl CollabMetrics {
   pub fn record_write_snapshot(&self, success_attempt: i64, total_attempt: i64) {
     self.success_write_snapshot_count.set(success_attempt);
     self.total_write_snapshot_count.set(total_attempt);
+  }
+
+  pub fn record_write_collab(&self, success_attempt: i64, total_attempt: i64) {
+    self.success_write_collab_count.set(success_attempt);
+    self.total_write_collab_count.set(total_attempt);
   }
 }

--- a/src/biz/collab/mod.rs
+++ b/src/biz/collab/mod.rs
@@ -4,4 +4,6 @@ pub mod disk_cache;
 pub mod mem_cache;
 pub mod metrics;
 pub mod ops;
+pub mod queue;
+mod queue_redis_ops;
 pub mod storage;

--- a/src/biz/collab/mod.rs
+++ b/src/biz/collab/mod.rs
@@ -6,4 +6,5 @@ pub mod metrics;
 pub mod ops;
 pub mod queue;
 mod queue_redis_ops;
+pub use queue_redis_ops::{PendingWrite, RedisSortedSet, WritePriority};
 pub mod storage;

--- a/src/biz/collab/queue.rs
+++ b/src/biz/collab/queue.rs
@@ -1,0 +1,391 @@
+use crate::biz::collab::cache::CollabCache;
+use crate::biz::collab::queue_redis_ops::{
+  get_pending_meta, get_remaining_pending_write, insert_pending_meta, remove_pending_meta,
+  storage_cache_key,
+};
+
+use crate::state::RedisConnectionManager;
+use anyhow::Context;
+use app_error::AppError;
+use collab_entity::CollabType;
+use database_entity::dto::{CollabParams, QueryCollab, QueryCollabResult};
+use serde::{Deserialize, Serialize};
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+
+use sqlx::PgPool;
+use std::sync::atomic::AtomicI64;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::{interval, sleep, sleep_until, Instant};
+use tracing::{error, info, trace, warn};
+
+/// The maximum size of a batch payload in bytes.
+const MAXIMUM_BATCH_PAYLOAD_SIZE: usize = 2 * 1024 * 1024;
+type PendingWriteHeap = Arc<Mutex<BinaryHeap<PendingWrite>>>;
+#[derive(Clone)]
+pub struct StorageQueue {
+  collab_cache: CollabCache,
+  connection_manager: RedisConnectionManager,
+  pending_write: PendingWriteHeap,
+  pending_id_counter: Arc<AtomicI64>,
+  next_duration: Arc<Mutex<Duration>>,
+}
+
+impl StorageQueue {
+  pub fn new(collab_cache: CollabCache, connection_manager: RedisConnectionManager) -> Self {
+    let next_duration = Arc::new(Mutex::new(Duration::from_secs(2)));
+    let pending_id_counter = Arc::new(AtomicI64::new(0));
+    let pending_write = Arc::new(Mutex::new(BinaryHeap::new()));
+
+    // spawn a task that fetches remaining pending writes from the Redis cache.
+    //
+    spawn_fetch_remaining_pending_write(
+      connection_manager.clone(),
+      pending_write.clone(),
+      pending_id_counter.clone(),
+    );
+
+    // Spawns a task that periodically writes pending collaboration objects to the database.
+    spawn_period_write(
+      next_duration.clone(),
+      collab_cache.clone(),
+      connection_manager.clone(),
+      pending_write.clone(),
+    );
+
+    spawn_period_check_pg_conn_count(collab_cache.pg_pool().clone(), next_duration.clone());
+
+    Self {
+      collab_cache,
+      connection_manager,
+      pending_write,
+      pending_id_counter,
+      next_duration,
+    }
+  }
+
+  /// Enqueues a object for deferred processing.
+  ///
+  /// adds a write task to a pending queue, which is periodically flushed by another task that batches
+  /// and writes the queued collaboration objects to a PostgreSQL database.
+  ///
+  /// This data is stored temporarily in the `collab_cache` and is intended for later persistent storage
+  /// in the database. It can also be retrieved during subsequent calls in the [CollabStorageImpl::get_encode_collab]
+  /// to enhance performance and reduce database reads.
+  pub async fn push(
+    &self,
+    workspace_id: &str,
+    uid: &i64,
+    params: &CollabParams,
+  ) -> Result<(), AppError> {
+    trace!(
+      "Queueing {} object for deferred writing to disk",
+      params.object_id
+    );
+    self
+      .collab_cache
+      .insert_encode_collab_data_in_mem(params)
+      .await?;
+
+    self
+      .queue_pending(&params.object_id, params.encoded_collab_v1.len())
+      .await;
+    insert_pending_meta(
+      uid,
+      workspace_id,
+      &params.object_id,
+      params.encoded_collab_v1.len(),
+      &params.collab_type,
+      self.connection_manager.clone(),
+    )
+    .await?;
+
+    Ok(())
+  }
+
+  #[inline]
+  async fn queue_pending(&self, object_id: &str, size: usize) {
+    let pending = PendingWrite {
+      object_id: object_id.to_string(),
+      seq: self
+        .pending_id_counter
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+      data_len: size,
+    };
+    self.pending_write.lock().await.push(pending);
+  }
+}
+
+/// Initializes and fetches any pending writes from the Redis cache at server startup and populates
+/// them into the pending write heap.
+///
+/// This function assumes that the cache data in Redis is designed to be long-lived, with each cached
+/// item set to expire after [PENDING_WRITE_EXPIRE_IN_SECS]. Given this configuration, it is safe to attempt to fetch all
+/// extant pending writes from the cache upon initialization.
+///
+fn spawn_fetch_remaining_pending_write(
+  mut connection_manager: RedisConnectionManager,
+  pending_heap: PendingWriteHeap,
+  counter: Arc<AtomicI64>,
+) {
+  tokio::task::spawn(async move {
+    if let Ok(records) = get_remaining_pending_write(&counter, &mut connection_manager).await {
+      info!("Fetched {} remaining pending writes", records.len());
+      pending_heap
+        .lock()
+        .await
+        .extend(records.into_iter().map(|record| PendingWrite {
+          object_id: record.object_id,
+          seq: counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+          data_len: record.data_len,
+        }));
+    }
+  });
+}
+
+/// Spawn a task that periodically checks the number of active connections in the PostgreSQL pool
+/// It aims to adjust the write interval based on the number of active connections.
+fn spawn_period_check_pg_conn_count(pg_pool: PgPool, next_duration: Arc<Mutex<Duration>>) {
+  let mut interval = interval(tokio::time::Duration::from_secs(5));
+  tokio::spawn(async move {
+    loop {
+      interval.tick().await;
+
+      // these range values are arbitrary and can be adjusted as needed
+      match pg_pool.size() {
+        0..=20 => {
+          *next_duration.lock().await = Duration::from_secs(2);
+        },
+        21..=40 => {
+          *next_duration.lock().await = Duration::from_secs(4);
+        },
+        _ => {
+          *next_duration.lock().await = Duration::from_secs(6);
+        },
+      }
+    }
+  });
+}
+
+/// Maximum number of retry attempts
+const MAX_RETRY_ATTEMPTS: usize = 3;
+/// Base duration to wait for between retries
+const RETRY_BASE_DURATION: u64 = 2; // seconds
+
+fn spawn_period_write(
+  next_duration: Arc<Mutex<Duration>>,
+  collab_cache: CollabCache,
+  mut connection_manager: RedisConnectionManager,
+  pending_heap: PendingWriteHeap,
+) {
+  tokio::spawn(async move {
+    loop {
+      let duration = next_duration.lock().await.clone();
+      trace!("Next write attempt in {:?}", duration);
+      let instant = Instant::now() + duration;
+      sleep_until(instant).await;
+
+      let keys = consume_pending_write_keys(&pending_heap, MAXIMUM_BATCH_PAYLOAD_SIZE).await;
+      if let Ok(metas) = get_pending_meta(&keys, &mut connection_manager).await {
+        match invoke_write(&collab_cache, &metas).await {
+          Ok(_) => {
+            trace!(
+              "Successfully wrote pending {:?} to disk",
+              metas.iter().map(|m| &m.object_id).collect::<Vec<_>>()
+            );
+          },
+          Err(err) => {
+            error!("Failed to write pending collaboration data: {:?}", err);
+          },
+        }
+        let _ = remove_pending_meta(&keys, &mut connection_manager).await;
+      }
+    }
+  });
+}
+
+async fn invoke_write(
+  collab_cache: &CollabCache,
+  metas: &[PendingWriteMeta],
+) -> Result<(), AppError> {
+  let mut retry_count = 0;
+  loop {
+    match write_pending_to_disk(metas, collab_cache).await {
+      Ok(_) => return Ok(()),
+      Err(err) if retry_count < MAX_RETRY_ATTEMPTS => {
+        warn!(
+          "Attempt {} failed, retrying... Error: {:?}",
+          retry_count + 1,
+          err
+        );
+        sleep(Duration::from_secs(RETRY_BASE_DURATION)).await;
+        retry_count += 1;
+      },
+      Err(err) => {
+        warn!(
+          "Failed to write pending collab to disk after {} attempts: {:?}",
+          MAX_RETRY_ATTEMPTS, err
+        );
+        return Err(err);
+      },
+    }
+  }
+}
+
+async fn write_pending_to_disk(
+  pending_metas: &[PendingWriteMeta],
+  collab_cache: &CollabCache,
+) -> Result<(), AppError> {
+  // Convert pending metadata into query parameters for batch fetching
+  let queries = pending_metas
+    .iter()
+    .map(QueryCollab::from)
+    .collect::<Vec<_>>();
+
+  // Retrieve encoded collaboration data in batch
+  let results = collab_cache.batch_get_encode_collab(queries).await;
+
+  // Create a mapping from object IDs to their corresponding metadata
+  let meta_map = pending_metas
+    .iter()
+    .map(|meta| (meta.object_id.clone(), meta))
+    .collect::<HashMap<_, _>>();
+
+  // Prepare collaboration data for writing to the database
+  let records = results
+    .into_iter()
+    .filter_map(|(object_id, result)| {
+      if let QueryCollabResult::Success { encode_collab_v1 } = result {
+        meta_map.get(&object_id).map(|meta| PendingWriteData {
+          uid: meta.uid,
+          workspace_id: meta.workspace_id.clone(),
+          object_id: meta.object_id.clone(),
+          collab_type: meta.collab_type.clone(),
+          encode_collab_v1,
+        })
+      } else {
+        None
+      }
+    })
+    .collect::<Vec<_>>();
+
+  // Start a database transaction
+  let mut transaction = collab_cache
+    .pg_pool()
+    .begin()
+    .await
+    .context("Failed to acquire transaction for writing pending collaboration data")
+    .map_err(AppError::from)?;
+
+  // Insert each record into the database within the transaction context
+  for record in records {
+    let params = CollabParams {
+      object_id: record.object_id,
+      collab_type: record.collab_type,
+      encoded_collab_v1: record.encode_collab_v1,
+    };
+    collab_cache
+      .insert_encode_collab_in_disk(&record.workspace_id, &record.uid, params, &mut transaction)
+      .await?;
+  }
+
+  // Commit the transaction to finalize all writes
+  transaction
+    .commit()
+    .await
+    .context("Failed to commit the transaction for pending collaboration data")
+    .map_err(AppError::from)?;
+
+  Ok(())
+}
+
+#[inline]
+async fn consume_pending_write_keys(
+  pending_heap: &PendingWriteHeap,
+  maximum_payload_size: usize,
+) -> Vec<String> {
+  const NUM_ITEMS: usize = 5;
+  let mut pending_lock = pending_heap.lock().await;
+  let mut write_items = Vec::with_capacity(NUM_ITEMS);
+  while let Some(item) = pending_lock.pop() {
+    write_items.push(item);
+    if write_items.iter().map(|v| v.data_len).sum::<usize>() > maximum_payload_size {
+      break;
+    }
+    if write_items.len() >= NUM_ITEMS {
+      break;
+    }
+  }
+  drop(pending_lock);
+
+  write_items
+    .iter()
+    .map(|pending| storage_cache_key(&pending.object_id, pending.data_len))
+    .collect()
+}
+
+#[derive(Clone)]
+pub(crate) struct PendingWrite {
+  pub object_id: String,
+  pub seq: i64,
+  pub data_len: usize,
+}
+
+impl Eq for PendingWrite {}
+impl PartialEq for PendingWrite {
+  fn eq(&self, other: &Self) -> bool {
+    self.object_id == other.object_id
+  }
+}
+
+impl Ord for PendingWrite {
+  fn cmp(&self, other: &Self) -> Ordering {
+    // smaller timestamp has higher priority
+    self.seq.cmp(&other.seq).reverse()
+  }
+}
+
+impl PartialOrd for PendingWrite {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+pub struct PendingWriteMeta {
+  pub uid: i64,
+  pub workspace_id: String,
+  pub object_id: String,
+  pub collab_type: CollabType,
+}
+
+impl From<&PendingWriteMeta> for QueryCollab {
+  fn from(meta: &PendingWriteMeta) -> Self {
+    QueryCollab {
+      object_id: meta.object_id.clone(),
+      collab_type: meta.collab_type.clone(),
+    }
+  }
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+pub struct PendingWriteData {
+  pub uid: i64,
+  pub workspace_id: String,
+  pub object_id: String,
+  pub collab_type: CollabType,
+  pub encode_collab_v1: Vec<u8>,
+}
+
+impl From<PendingWriteData> for CollabParams {
+  fn from(data: PendingWriteData) -> Self {
+    CollabParams {
+      object_id: data.object_id,
+      collab_type: data.collab_type,
+      encoded_collab_v1: data.encode_collab_v1,
+    }
+  }
+}

--- a/src/biz/collab/queue_redis_ops.rs
+++ b/src/biz/collab/queue_redis_ops.rs
@@ -1,0 +1,231 @@
+use crate::biz::collab::queue::{PendingWrite, PendingWriteMeta};
+use crate::state::RedisConnectionManager;
+use app_error::AppError;
+use collab_entity::CollabType;
+use futures_util::StreamExt;
+use redis::{AsyncCommands, AsyncIter};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+
+pub(crate) const PENDING_WRITE_EXPIRE_IN_SECS: u64 = 604800; // 7 days in seconds
+#[inline]
+pub(crate) async fn insert_pending_meta(
+  uid: &i64,
+  workspace_id: &str,
+  object_id: &str,
+  data_len: usize,
+  collab_type: &CollabType,
+  mut connection_manager: RedisConnectionManager,
+) -> Result<(), AppError> {
+  let queue_item = PendingWriteMeta {
+    uid: *uid,
+    workspace_id: workspace_id.to_string(),
+    object_id: object_id.to_string(),
+    collab_type: collab_type.clone(),
+  };
+
+  let key = storage_cache_key(&queue_item.object_id, data_len);
+  let value = serde_json::to_string(&queue_item)?;
+
+  // set the key with a timeout of 7 days
+  connection_manager
+    .set_ex(&key, &value, PENDING_WRITE_EXPIRE_IN_SECS)
+    .await
+    .map_err(|err| AppError::Internal(err.into()))?;
+
+  Ok(())
+}
+
+#[inline]
+pub(crate) async fn get_pending_meta(
+  keys: &[String],
+  connection_manager: &mut RedisConnectionManager,
+) -> Result<Vec<PendingWriteMeta>, AppError> {
+  let results: Vec<Option<String>> = connection_manager
+    .get(keys)
+    .await
+    .map_err(|err| AppError::Internal(err.into()))?;
+
+  let metas = results
+    .into_iter()
+    .filter_map(|value| value.and_then(|data| serde_json::from_str(&data).ok()))
+    .collect::<Vec<PendingWriteMeta>>();
+
+  Ok(metas)
+}
+
+pub(crate) async fn get_remaining_pending_write(
+  counter: &Arc<AtomicI64>,
+  connection_manager: &mut RedisConnectionManager,
+) -> Result<Vec<PendingWrite>, AppError> {
+  let keys = scan_all_keys(connection_manager).await?;
+  Ok(
+    keys
+      .into_iter()
+      .flat_map(|cache_object_id| {
+        pending_write_from_cache_object_id(&cache_object_id, counter).ok()
+      })
+      .collect::<Vec<_>>(),
+  )
+}
+
+async fn scan_all_keys(conn_manager: &mut RedisConnectionManager) -> Result<Vec<String>, AppError> {
+  let pattern = format!("{}*", QUEUE_COLLAB_PREFIX);
+  let iter: AsyncIter<String> = conn_manager
+    .scan_match(pattern)
+    .await
+    .map_err(|err| AppError::Internal(err.into()))?;
+  let keys: Vec<_> = iter.collect().await;
+  Ok(keys)
+}
+
+#[inline]
+pub(crate) async fn remove_pending_meta(
+  keys: &[String],
+  connection_manager: &mut RedisConnectionManager,
+) -> Result<(), AppError> {
+  connection_manager
+    .del(keys)
+    .await
+    .map_err(|err| AppError::Internal(err.into()))?;
+  Ok(())
+}
+
+pub(crate) const QUEUE_COLLAB_PREFIX: &str = "storage_pending_meta_v0:";
+
+#[inline]
+pub(crate) fn storage_cache_key(object_id: &str, data_len: usize) -> String {
+  format!("{}{}:{}", QUEUE_COLLAB_PREFIX, object_id, data_len)
+}
+
+pub(crate) fn pending_write_from_cache_object_id(
+  key: &str,
+  counter: &Arc<AtomicI64>,
+) -> Result<PendingWrite, String> {
+  let trimmed_key = key.trim_start_matches(QUEUE_COLLAB_PREFIX);
+  let parts: Vec<&str> = trimmed_key.split(':').collect();
+
+  if parts.len() != 2 {
+    return Err(format!("Invalid key format: {}", key));
+  }
+
+  let object_id = parts[0].to_owned();
+  let data_len = usize::from_str(parts[1]).map_err(|e| e.to_string())?;
+
+  Ok(PendingWrite {
+    object_id,
+    seq: counter.fetch_add(1, Ordering::SeqCst),
+    data_len,
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::biz::collab::queue::PendingWriteMeta;
+  use crate::biz::collab::queue_redis_ops::{
+    get_pending_meta, get_remaining_pending_write, insert_pending_meta, remove_pending_meta,
+    storage_cache_key,
+  };
+  use anyhow::Context;
+  use collab_entity::CollabType;
+  use std::sync::atomic::AtomicI64;
+  use std::sync::Arc;
+
+  #[tokio::test]
+  async fn pending_write_meta_insert_get_test() {
+    let data_len = 100;
+    let mut conn = redis_client().await.get_connection_manager().await.unwrap();
+    let metas = vec![
+      PendingWriteMeta {
+        uid: 1,
+        workspace_id: "w1".to_string(),
+        object_id: "o1".to_string(),
+        collab_type: CollabType::Document,
+      },
+      PendingWriteMeta {
+        uid: 2,
+        workspace_id: "w2".to_string(),
+        object_id: "o2".to_string(),
+        collab_type: CollabType::Document,
+      },
+    ];
+
+    for meta in metas.iter() {
+      insert_pending_meta(
+        &meta.uid,
+        &meta.workspace_id,
+        &meta.object_id,
+        data_len,
+        &meta.collab_type,
+        conn.clone(),
+      )
+      .await
+      .unwrap();
+    }
+
+    let keys = metas
+      .iter()
+      .map(|meta| storage_cache_key(&meta.object_id, data_len))
+      .collect::<Vec<String>>();
+
+    let metas_from_cache = get_pending_meta(&keys, &mut conn).await.unwrap();
+    assert_eq!(metas, metas_from_cache);
+
+    remove_pending_meta(&keys, &mut conn).await.unwrap();
+    let metas = get_pending_meta(&keys, &mut conn).await.unwrap();
+    assert!(metas.is_empty());
+  }
+
+  #[tokio::test]
+  async fn get_all_remaining_write_test() {
+    let mut conn = redis_client().await.get_connection_manager().await.unwrap();
+    let o1 = uuid::Uuid::new_v4().to_string();
+    let o2 = uuid::Uuid::new_v4().to_string();
+    insert_pending_meta(&1, "w1", &o1, 100, &CollabType::Document, conn.clone())
+      .await
+      .unwrap();
+    insert_pending_meta(&2, "w2", &o2, 101, &CollabType::Document, conn.clone())
+      .await
+      .unwrap();
+
+    let counter = Arc::new(AtomicI64::new(0));
+    let pending_writes = get_remaining_pending_write(&counter, &mut conn)
+      .await
+      .unwrap()
+      .into_iter()
+      .filter(|item| item.object_id == o1 || item.object_id == o2)
+      .collect::<Vec<_>>();
+
+    // the returns pending writes are not guaranteed to be in order
+    assert_eq!(pending_writes.len(), 2);
+    // assert the content of the pending writes
+    assert!(pending_writes.iter().any(|item| item.object_id == o1));
+    assert!(pending_writes.iter().any(|item| item.object_id == o2));
+
+    let keys = pending_writes
+      .iter()
+      .map(|item| storage_cache_key(&item.object_id, item.data_len))
+      .collect::<Vec<String>>();
+    remove_pending_meta(&keys, &mut conn).await.unwrap();
+
+    let pending_writes = get_remaining_pending_write(&counter, &mut conn)
+      .await
+      .unwrap()
+      .into_iter()
+      .filter(|item| item.object_id == o1 || item.object_id == o2)
+      .collect::<Vec<_>>();
+    assert!(
+      pending_writes.is_empty(),
+      "expect no pending writes, but got {:?}",
+      pending_writes.len()
+    );
+  }
+
+  async fn redis_client() -> redis::Client {
+    let redis_uri = "redis://localhost:6379";
+    redis::Client::open(redis_uri)
+      .context("failed to connect to redis")
+      .unwrap()
+  }
+}

--- a/src/biz/collab/queue_redis_ops.rs
+++ b/src/biz/collab/queue_redis_ops.rs
@@ -1,4 +1,4 @@
-use crate::biz::collab::queue::{PendingWrite, PendingWriteMeta};
+use crate::biz::collab::queue::{PendingWrite, PendingWriteMeta, WritePriority};
 use crate::state::RedisConnectionManager;
 use app_error::AppError;
 use collab_entity::CollabType;
@@ -137,6 +137,7 @@ pub(crate) fn pending_write_from_cache_object_id(
     object_id,
     seq: counter.fetch_add(1, Ordering::SeqCst),
     data_len,
+    priority: WritePriority::Low,
   })
 }
 

--- a/src/biz/collab/storage.rs
+++ b/src/biz/collab/storage.rs
@@ -22,6 +22,7 @@ use sqlx::Transaction;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::biz::collab::metrics::CollabMetrics;
 use crate::biz::collab::queue::{StorageQueue, REDIS_PENDING_WRITE_QUEUE};
 use crate::biz::collab::queue_redis_ops::WritePriority;
 use std::time::Duration;
@@ -55,11 +56,13 @@ where
     snapshot_control: SnapshotControl,
     rt_cmd_sender: RTCommandSender,
     redis_conn_manager: RedisConnectionManager,
+    metrics: Arc<CollabMetrics>,
   ) -> Self {
-    let queue = Arc::new(StorageQueue::new(
+    let queue = Arc::new(StorageQueue::new_with_metrics(
       cache.clone(),
       redis_conn_manager,
       REDIS_PENDING_WRITE_QUEUE,
+      Some(metrics),
     ));
     Self {
       cache,

--- a/src/biz/collab/storage.rs
+++ b/src/biz/collab/storage.rs
@@ -22,7 +22,7 @@ use sqlx::Transaction;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::biz::collab::queue::StorageQueue;
+use crate::biz::collab::queue::{StorageQueue, REDIS_PENDING_WRITE_QUEUE};
 use crate::biz::collab::queue_redis_ops::WritePriority;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -56,7 +56,11 @@ where
     rt_cmd_sender: RTCommandSender,
     redis_conn_manager: RedisConnectionManager,
   ) -> Self {
-    let queue = Arc::new(StorageQueue::new(cache.clone(), redis_conn_manager));
+    let queue = Arc::new(StorageQueue::new(
+      cache.clone(),
+      redis_conn_manager,
+      REDIS_PENDING_WRITE_QUEUE,
+    ));
     Self {
       cache,
       access_control,

--- a/src/biz/collab/storage.rs
+++ b/src/biz/collab/storage.rs
@@ -22,7 +22,8 @@ use sqlx::Transaction;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::biz::collab::queue::{StorageQueue, WritePriority};
+use crate::biz::collab::queue::StorageQueue;
+use crate::biz::collab::queue_redis_ops::WritePriority;
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::time::timeout;

--- a/tests/collab/collab_curd_test.rs
+++ b/tests/collab/collab_curd_test.rs
@@ -27,7 +27,7 @@ async fn batch_insert_collab_with_empty_payload_test() {
     .await
     .unwrap_err();
 
-  assert_eq!(error.code, ErrorCode::InvalidRequest);
+  assert_eq!(error.code, ErrorCode::NoRequiredData);
 }
 
 #[tokio::test]

--- a/tests/collab/collab_curd_test.rs
+++ b/tests/collab/collab_curd_test.rs
@@ -27,7 +27,7 @@ async fn batch_insert_collab_with_empty_payload_test() {
     .await
     .unwrap_err();
 
-  assert_eq!(error.code, ErrorCode::NoRequiredData);
+  assert_eq!(error.code, ErrorCode::InvalidRequest);
 }
 
 #[tokio::test]

--- a/tests/collab/data_write_test.rs
+++ b/tests/collab/data_write_test.rs
@@ -34,7 +34,7 @@ async fn insert_empty_data_test() {
       .create_collab(params)
       .await
       .unwrap_err();
-    assert_eq!(error.code, ErrorCode::InvalidRequest);
+    assert_eq!(error.code, ErrorCode::NoRequiredData);
   }
 }
 

--- a/tests/collab/mod.rs
+++ b/tests/collab/mod.rs
@@ -5,6 +5,7 @@ mod edit_permission;
 mod member_crud;
 mod missing_update_test;
 mod multi_devices_edit;
+mod pending_write_test;
 mod single_device_edit;
 mod storage_test;
 mod util;

--- a/tests/collab/pending_write_test.rs
+++ b/tests/collab/pending_write_test.rs
@@ -1,7 +1,7 @@
 use crate::collab::util::redis_connection_manager;
 use crate::sql_test::util::{setup_db, test_create_user};
 use appflowy_cloud::biz::collab::cache::CollabCache;
-use appflowy_cloud::biz::collab::queue::{consume_pending_write, StorageQueue};
+use appflowy_cloud::biz::collab::queue::StorageQueue;
 use appflowy_cloud::biz::collab::WritePriority;
 use client_api_test_util::setup_log;
 use collab::core::collab_plugin::EncodedCollab;
@@ -26,9 +26,8 @@ async fn pending_queue_write_test(pool: PgPool) {
     .unwrap();
 
   let collab_cache = CollabCache::new(conn.clone(), pool);
-  let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
-  storage_queue.clear().await.unwrap();
-  sleep(Duration::from_secs(3)).await;
+  let queue_name = uuid::Uuid::new_v4().to_string();
+  let storage_queue = StorageQueue::new(collab_cache.clone(), conn, &queue_name);
 
   let mut queries = Vec::new();
   for i in 0..50 {

--- a/tests/collab/pending_write_test.rs
+++ b/tests/collab/pending_write_test.rs
@@ -1,4 +1,4 @@
-use crate::collab::util::redis_connection_manager;
+use crate::collab::util::{generate_random_bytes, redis_connection_manager};
 use crate::sql_test::util::{setup_db, test_create_user};
 use appflowy_cloud::biz::collab::cache::CollabCache;
 use appflowy_cloud::biz::collab::queue::StorageQueue;
@@ -8,11 +8,85 @@ use collab::core::collab_plugin::EncodedCollab;
 use collab_entity::CollabType;
 use database_entity::dto::{CollabParams, QueryCollab};
 use sqlx::PgPool;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
 use tokio::time::sleep;
 
 #[sqlx::test(migrations = false)]
-async fn pending_queue_write_test(pool: PgPool) {
+async fn simulate_small_data_set_write(pool: PgPool) {
+  // prepare test prerequisites
+  setup_db(&pool).await.unwrap();
+  setup_log();
+  let conn = redis_connection_manager().await;
+  let user_uuid = uuid::Uuid::new_v4();
+  let name = user_uuid.to_string();
+  let email = format!("{}@appflowy.io", name);
+  let user = test_create_user(&pool, user_uuid, &email, &name)
+    .await
+    .unwrap();
+
+  let collab_cache = CollabCache::new(conn.clone(), pool);
+  let queue_name = uuid::Uuid::new_v4().to_string();
+  let storage_queue = StorageQueue::new(collab_cache.clone(), conn, &queue_name);
+
+  let queries = Arc::new(Mutex::new(Vec::new()));
+  for i in 0..100 {
+    // sleep random seconds less than 2 seconds. because the runtime is single-threaded,
+    // we need sleep a little time to let the runtime switch to other tasks.
+    sleep(Duration::from_millis(i % 2)).await;
+
+    let cloned_storage_queue = storage_queue.clone();
+    let cloned_queries = queries.clone();
+    let cloned_user = user.clone();
+    let encode_collab = EncodedCollab::new_v1(
+      generate_random_bytes(1024),
+      generate_random_bytes(1024 * 1024),
+    );
+    let params = CollabParams {
+      object_id: format!("object_id_{}", i),
+      collab_type: CollabType::Unknown,
+      encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
+    };
+    cloned_storage_queue
+      .push(
+        &cloned_user.workspace_id,
+        &cloned_user.uid,
+        &params,
+        WritePriority::Low,
+      )
+      .await
+      .unwrap();
+    cloned_queries.lock().await.push((params, encode_collab));
+  }
+
+  // Allow some time for processing
+  sleep(Duration::from_secs(30)).await;
+
+  // Check that all items are processed correctly
+  for (params, original_encode_collab) in queries.lock().await.iter() {
+    let query = QueryCollab {
+      object_id: params.object_id.clone(),
+      collab_type: params.collab_type.clone(),
+    };
+    let encode_collab_from_disk = collab_cache
+      .get_encode_collab_from_disk(&user.uid, query)
+      .await
+      .unwrap();
+
+    assert_eq!(
+      encode_collab_from_disk.doc_state,
+      original_encode_collab.doc_state
+    );
+    assert_eq!(
+      encode_collab_from_disk.state_vector,
+      original_encode_collab.state_vector
+    );
+  }
+}
+
+#[sqlx::test(migrations = false)]
+async fn simulate_large_data_set_write(pool: PgPool) {
   // prepare test prerequisites
   setup_db(&pool).await.unwrap();
   setup_log();
@@ -29,43 +103,46 @@ async fn pending_queue_write_test(pool: PgPool) {
   let queue_name = uuid::Uuid::new_v4().to_string();
   let storage_queue = StorageQueue::new(collab_cache.clone(), conn, &queue_name);
 
-  let mut queries = Vec::new();
-  for i in 0..50 {
-    let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
-    let params = CollabParams {
-      object_id: uuid::Uuid::new_v4().to_string(),
-      collab_type: CollabType::Unknown,
-      encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
-    };
+  let queries = Arc::new(Mutex::new(Vec::new()));
+  for i in 0..10 {
+    let cloned_storage_queue = storage_queue.clone();
+    let cloned_queries = queries.clone();
+    let cloned_user = user.clone();
+    tokio::spawn(async move {
+      // sleep random seconds less than 2 seconds. because the runtime is single-threaded,
+      // we need sleep a little time to let the runtime switch to other tasks.
+      sleep(Duration::from_millis(i % 2)).await;
 
-    if i % 2 == 0 {
-      // Simulate a failure scenario by using a non-existent user ID. This is designed to test the
-      // robustness of the write operation. The objective is to ensure that valid records still get
-      // written to disk despite the presence of some invalid entries.
-      storage_queue
-        .push(&user.workspace_id, &1, &params, WritePriority::Low)
+      let encode_collab = EncodedCollab::new_v1(
+        generate_random_bytes(10 * 1024),
+        generate_random_bytes(2 * 1024 * 1024),
+      );
+      let params = CollabParams {
+        object_id: format!("object_id_{}", i),
+        collab_type: CollabType::Unknown,
+        encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
+      };
+      cloned_storage_queue
+        .push(
+          &cloned_user.workspace_id,
+          &cloned_user.uid,
+          &params,
+          WritePriority::Low,
+        )
         .await
         .unwrap();
-    } else {
-      storage_queue
-        .push(&user.workspace_id, &user.uid, &params, WritePriority::Low)
-        .await
-        .unwrap();
-      queries.push((params, encode_collab));
-    }
+      cloned_queries.lock().await.push((params, encode_collab));
+    });
   }
 
-  // let a = storage_queue.pending_write_set.pop(100).await.unwrap();
-  // let a2 = consume_pending_write(&storage_queue.pending_write_set, 100, 6).await;
-
   // Allow some time for processing
-  sleep(Duration::from_secs(20)).await;
+  sleep(Duration::from_secs(30)).await;
 
   // Check that all items are processed correctly
-  for (params, original_encode_collab) in queries {
+  for (params, original_encode_collab) in queries.lock().await.iter() {
     let query = QueryCollab {
       object_id: params.object_id.clone(),
-      collab_type: params.collab_type,
+      collab_type: params.collab_type.clone(),
     };
     let encode_collab_from_disk = collab_cache
       .get_encode_collab_from_disk(&user.uid, query)

--- a/tests/collab/pending_write_test.rs
+++ b/tests/collab/pending_write_test.rs
@@ -31,7 +31,7 @@ async fn simulate_small_data_set_write(pool: PgPool) {
   let storage_queue = StorageQueue::new(collab_cache.clone(), conn, &queue_name);
 
   let queries = Arc::new(Mutex::new(Vec::new()));
-  for i in 0..100 {
+  for i in 0..50 {
     // sleep random seconds less than 2 seconds. because the runtime is single-threaded,
     // we need sleep a little time to let the runtime switch to other tasks.
     sleep(Duration::from_millis(i % 2)).await;
@@ -115,7 +115,7 @@ async fn simulate_large_data_set_write(pool: PgPool) {
 
       let encode_collab = EncodedCollab::new_v1(
         generate_random_bytes(10 * 1024),
-        generate_random_bytes(2 * 1024 * 1024),
+        generate_random_bytes(1024 * 1024),
       );
       let params = CollabParams {
         object_id: format!("object_id_{}", i),

--- a/tests/collab/pending_write_test.rs
+++ b/tests/collab/pending_write_test.rs
@@ -1,7 +1,7 @@
 use crate::collab::util::redis_connection_manager;
 use crate::sql_test::util::{setup_db, test_create_user};
 use appflowy_cloud::biz::collab::cache::CollabCache;
-use appflowy_cloud::biz::collab::queue::StorageQueue;
+use appflowy_cloud::biz::collab::queue::{consume_pending_write, StorageQueue};
 use appflowy_cloud::biz::collab::WritePriority;
 use client_api_test_util::setup_log;
 use collab::core::collab_plugin::EncodedCollab;
@@ -31,7 +31,7 @@ async fn pending_queue_write_test(pool: PgPool) {
   sleep(Duration::from_secs(3)).await;
 
   let mut queries = Vec::new();
-  for i in 0..30 {
+  for i in 0..50 {
     let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
     let params = CollabParams {
       object_id: uuid::Uuid::new_v4().to_string(),
@@ -55,6 +55,9 @@ async fn pending_queue_write_test(pool: PgPool) {
       queries.push((params, encode_collab));
     }
   }
+
+  // let a = storage_queue.pending_write_set.pop(100).await.unwrap();
+  // let a2 = consume_pending_write(&storage_queue.pending_write_set, 100, 6).await;
 
   // Allow some time for processing
   sleep(Duration::from_secs(20)).await;

--- a/tests/collab/pending_write_test.rs
+++ b/tests/collab/pending_write_test.rs
@@ -1,0 +1,82 @@
+use crate::collab::util::redis_connection_manager;
+use crate::sql_test::util::{setup_db, test_create_user};
+use appflowy_cloud::biz::collab::cache::CollabCache;
+use appflowy_cloud::biz::collab::queue::StorageQueue;
+use appflowy_cloud::biz::collab::WritePriority;
+use client_api_test_util::setup_log;
+use collab::core::collab_plugin::EncodedCollab;
+use collab_entity::CollabType;
+use database_entity::dto::{CollabParams, QueryCollab};
+use sqlx::PgPool;
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[sqlx::test(migrations = false)]
+async fn pending_queue_write_test(pool: PgPool) {
+  // prepare test prerequisites
+  setup_db(&pool).await.unwrap();
+  setup_log();
+
+  let conn = redis_connection_manager().await;
+  let user_uuid = uuid::Uuid::new_v4();
+  let name = user_uuid.to_string();
+  let email = format!("{}@appflowy.io", name);
+  let user = test_create_user(&pool, user_uuid, &email, &name)
+    .await
+    .unwrap();
+
+  let collab_cache = CollabCache::new(conn.clone(), pool);
+  let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
+  storage_queue.clear().await.unwrap();
+  sleep(Duration::from_secs(3)).await;
+
+  let mut queries = Vec::new();
+  for i in 0..30 {
+    let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
+    let params = CollabParams {
+      object_id: uuid::Uuid::new_v4().to_string(),
+      collab_type: CollabType::Unknown,
+      encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
+    };
+
+    if i % 2 == 0 {
+      // Simulate a failure scenario by using a non-existent user ID. This is designed to test the
+      // robustness of the write operation. The objective is to ensure that valid records still get
+      // written to disk despite the presence of some invalid entries.
+      storage_queue
+        .push(&user.workspace_id, &1, &params, WritePriority::Low)
+        .await
+        .unwrap();
+    } else {
+      storage_queue
+        .push(&user.workspace_id, &user.uid, &params, WritePriority::Low)
+        .await
+        .unwrap();
+      queries.push((params, encode_collab));
+    }
+  }
+
+  // Allow some time for processing
+  sleep(Duration::from_secs(20)).await;
+
+  // Check that all items are processed correctly
+  for (params, original_encode_collab) in queries {
+    let query = QueryCollab {
+      object_id: params.object_id.clone(),
+      collab_type: params.collab_type,
+    };
+    let encode_collab_from_disk = collab_cache
+      .get_encode_collab_from_disk(&user.uid, query)
+      .await
+      .unwrap();
+
+    assert_eq!(
+      encode_collab_from_disk.doc_state,
+      original_encode_collab.doc_state
+    );
+    assert_eq!(
+      encode_collab_from_disk.state_vector,
+      original_encode_collab.state_vector
+    );
+  }
+}

--- a/tests/collab/pending_write_test.rs
+++ b/tests/collab/pending_write_test.rs
@@ -104,7 +104,7 @@ async fn simulate_large_data_set_write(pool: PgPool) {
   let storage_queue = StorageQueue::new(collab_cache.clone(), conn, &queue_name);
 
   let queries = Arc::new(Mutex::new(Vec::new()));
-  for i in 0..10 {
+  for i in 0..5 {
     let cloned_storage_queue = storage_queue.clone();
     let cloned_queries = queries.clone();
     let cloned_user = user.clone();

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -326,7 +326,7 @@ async fn pending_queue_write_test(pool: PgPool) {
   sleep(Duration::from_secs(3)).await;
 
   let mut queries = Vec::new();
-  for i in 0..20 {
+  for i in 0..30 {
     let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
     let params = CollabParams {
       object_id: uuid::Uuid::new_v4().to_string(),

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -7,7 +7,6 @@ use appflowy_cloud::biz::collab::queue::StorageQueue;
 use client_api_test_util::*;
 use collab::core::collab_plugin::EncodedCollab;
 use collab_entity::CollabType;
-use database::collab::insert_into_af_collab;
 use database_entity::dto::{
   CollabParams, CreateCollabParams, DeleteCollabParams, QueryCollab, QueryCollabParams,
   QueryCollabResult,
@@ -312,50 +311,6 @@ async fn pending_write_queue_test(pool: PgPool) {
   // prepare test prerequisites
   setup_db(&pool).await.unwrap();
   setup_log();
-  let conn = redis_connection_manager().await;
-  let user_uuid = uuid::Uuid::new_v4();
-  let name = user_uuid.to_string();
-  let email = format!("{}@appflowy.io", name);
-  let user = test_create_user(&pool, user_uuid, &email, &name)
-    .await
-    .unwrap();
-
-  let collab_cache = CollabCache::new(conn.clone(), pool);
-  let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
-
-  let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
-  let params = CollabParams {
-    object_id: uuid::Uuid::new_v4().to_string(),
-    collab_type: CollabType::Unknown,
-    encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
-  };
-  storage_queue
-    .push(&user.workspace_id, &user.uid, &params)
-    .await
-    .unwrap();
-
-  sleep(Duration::from_secs(5)).await;
-  let query = QueryCollab {
-    object_id: params.object_id.clone(),
-    collab_type: params.collab_type,
-  };
-  let encode_collab_from_disk = collab_cache
-    .get_encode_collab_from_disk(&user.uid, query)
-    .await
-    .unwrap();
-
-  assert_eq!(encode_collab_from_disk.doc_state, encode_collab.doc_state);
-  assert_eq!(
-    encode_collab_from_disk.state_vector,
-    encode_collab.state_vector
-  );
-}
-
-#[sqlx::test(migrations = false)]
-async fn pending_write_queue_test2(pool: PgPool) {
-  // prepare test prerequisites
-  setup_db(&pool).await.unwrap();
-  setup_log();
 
   let conn = redis_connection_manager().await;
   let user_uuid = uuid::Uuid::new_v4();
@@ -367,6 +322,8 @@ async fn pending_write_queue_test2(pool: PgPool) {
 
   let collab_cache = CollabCache::new(conn.clone(), pool);
   let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
+  storage_queue.clear().await.unwrap();
+  sleep(Duration::from_secs(3)).await;
 
   // Push data 20 times into the queue
   let mut queries = Vec::new();

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -201,7 +201,7 @@ async fn fail_insert_collab_with_empty_payload_test() {
     .await
     .unwrap_err();
 
-  assert_eq!(error.code, ErrorCode::InvalidRequest);
+  assert_eq!(error.code, ErrorCode::NoRequiredData);
 }
 
 #[tokio::test]

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -1,14 +1,22 @@
 use crate::collab::util::{redis_connection_manager, test_encode_collab_v1};
+use crate::sql_test::util::{setup_db, test_create_user};
 use app_error::ErrorCode;
+use appflowy_cloud::biz::collab::cache::CollabCache;
 use appflowy_cloud::biz::collab::mem_cache::CollabMemCache;
+use appflowy_cloud::biz::collab::queue::StorageQueue;
 use client_api_test_util::*;
 use collab::core::collab_plugin::EncodedCollab;
 use collab_entity::CollabType;
+use database::collab::insert_into_af_collab;
 use database_entity::dto::{
-  CreateCollabParams, DeleteCollabParams, QueryCollab, QueryCollabParams, QueryCollabResult,
+  CollabParams, CreateCollabParams, DeleteCollabParams, QueryCollab, QueryCollabParams,
+  QueryCollabResult,
 };
 use sqlx::types::Uuid;
+use sqlx::PgPool;
 use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn success_insert_collab_test() {
@@ -224,7 +232,6 @@ async fn fail_insert_collab_with_invalid_workspace_id_test() {
 #[tokio::test]
 async fn collab_mem_cache_read_write_test() {
   let conn = redis_connection_manager().await;
-
   let mem_cache = CollabMemCache::new(conn);
   let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
 
@@ -298,4 +305,108 @@ async fn collab_mem_cache_insert_override_test() {
   let encode_collab_from_cache = mem_cache.get_encode_collab(&object_id).await.unwrap();
   assert_eq!(encode_collab_from_cache.doc_state, vec![15, 16, 17]);
   assert_eq!(encode_collab_from_cache.state_vector, vec![12, 13, 14]);
+}
+
+#[sqlx::test(migrations = false)]
+async fn pending_write_queue_test(pool: PgPool) {
+  // prepare test prerequisites
+  setup_db(&pool).await.unwrap();
+  setup_log();
+  let conn = redis_connection_manager().await;
+  let user_uuid = uuid::Uuid::new_v4();
+  let name = user_uuid.to_string();
+  let email = format!("{}@appflowy.io", name);
+  let user = test_create_user(&pool, user_uuid, &email, &name)
+    .await
+    .unwrap();
+
+  let collab_cache = CollabCache::new(conn.clone(), pool);
+  let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
+
+  let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
+  let params = CollabParams {
+    object_id: uuid::Uuid::new_v4().to_string(),
+    collab_type: CollabType::Unknown,
+    encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
+  };
+  storage_queue
+    .push(&user.workspace_id, &user.uid, &params)
+    .await
+    .unwrap();
+
+  sleep(Duration::from_secs(5)).await;
+  let query = QueryCollab {
+    object_id: params.object_id.clone(),
+    collab_type: params.collab_type,
+  };
+  let encode_collab_from_disk = collab_cache
+    .get_encode_collab_from_disk(&user.uid, query)
+    .await
+    .unwrap();
+
+  assert_eq!(encode_collab_from_disk.doc_state, encode_collab.doc_state);
+  assert_eq!(
+    encode_collab_from_disk.state_vector,
+    encode_collab.state_vector
+  );
+}
+
+#[sqlx::test(migrations = false)]
+async fn pending_write_queue_test2(pool: PgPool) {
+  // prepare test prerequisites
+  setup_db(&pool).await.unwrap();
+  setup_log();
+
+  let conn = redis_connection_manager().await;
+  let user_uuid = uuid::Uuid::new_v4();
+  let name = user_uuid.to_string();
+  let email = format!("{}@appflowy.io", name);
+  let user = test_create_user(&pool, user_uuid, &email, &name)
+    .await
+    .unwrap();
+
+  let collab_cache = CollabCache::new(conn.clone(), pool);
+  let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
+
+  // Push data 20 times into the queue
+  let mut queries = Vec::new();
+  for _ in 0..10 {
+    let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
+    let params = CollabParams {
+      object_id: uuid::Uuid::new_v4().to_string(),
+      collab_type: CollabType::Unknown,
+      encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
+    };
+    storage_queue
+      .push(&user.workspace_id, &user.uid, &params)
+      .await
+      .unwrap();
+
+    // Save query for later validation
+    queries.push((params, encode_collab));
+  }
+
+  // Allow some time for processing
+  sleep(Duration::from_secs(10)).await;
+
+  // Check that all items are processed correctly
+  for (params, original_encode_collab) in queries {
+    let query = QueryCollab {
+      object_id: params.object_id.clone(),
+      collab_type: params.collab_type,
+    };
+    let encode_collab_from_disk = collab_cache
+      .get_encode_collab_from_disk(&user.uid, query)
+      .await
+      .unwrap();
+
+    assert_eq!(
+      encode_collab_from_disk.doc_state,
+      original_encode_collab.doc_state
+    );
+    assert_eq!(
+      encode_collab_from_disk.state_vector,
+      original_encode_collab.state_vector
+    );
+  }
 }

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -1,21 +1,18 @@
 use crate::collab::util::{redis_connection_manager, test_encode_collab_v1};
-use crate::sql_test::util::{setup_db, test_create_user};
+
 use app_error::ErrorCode;
-use appflowy_cloud::biz::collab::cache::CollabCache;
+
 use appflowy_cloud::biz::collab::mem_cache::CollabMemCache;
-use appflowy_cloud::biz::collab::queue::{StorageQueue, WritePriority};
+
 use client_api_test_util::*;
 use collab::core::collab_plugin::EncodedCollab;
 use collab_entity::CollabType;
 use database_entity::dto::{
-  CollabParams, CreateCollabParams, DeleteCollabParams, QueryCollab, QueryCollabParams,
-  QueryCollabResult,
+  CreateCollabParams, DeleteCollabParams, QueryCollab, QueryCollabParams, QueryCollabResult,
 };
 use sqlx::types::Uuid;
-use sqlx::PgPool;
+
 use std::collections::HashMap;
-use std::time::Duration;
-use tokio::time::sleep;
 
 #[tokio::test]
 async fn success_insert_collab_test() {
@@ -304,74 +301,4 @@ async fn collab_mem_cache_insert_override_test() {
   let encode_collab_from_cache = mem_cache.get_encode_collab(&object_id).await.unwrap();
   assert_eq!(encode_collab_from_cache.doc_state, vec![15, 16, 17]);
   assert_eq!(encode_collab_from_cache.state_vector, vec![12, 13, 14]);
-}
-
-#[sqlx::test(migrations = false)]
-async fn pending_queue_write_test(pool: PgPool) {
-  // prepare test prerequisites
-  setup_db(&pool).await.unwrap();
-  setup_log();
-
-  let conn = redis_connection_manager().await;
-  let user_uuid = uuid::Uuid::new_v4();
-  let name = user_uuid.to_string();
-  let email = format!("{}@appflowy.io", name);
-  let user = test_create_user(&pool, user_uuid, &email, &name)
-    .await
-    .unwrap();
-
-  let collab_cache = CollabCache::new(conn.clone(), pool);
-  let storage_queue = StorageQueue::new(collab_cache.clone(), conn);
-  storage_queue.clear().await.unwrap();
-  sleep(Duration::from_secs(3)).await;
-
-  let mut queries = Vec::new();
-  for i in 0..30 {
-    let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
-    let params = CollabParams {
-      object_id: uuid::Uuid::new_v4().to_string(),
-      collab_type: CollabType::Unknown,
-      encoded_collab_v1: encode_collab.encode_to_bytes().unwrap(),
-    };
-
-    if i % 2 == 0 {
-      // Simulate a failure scenario by using a non-existent user ID. This is designed to test the
-      // robustness of the write operation. The objective is to ensure that valid records still get
-      // written to disk despite the presence of some invalid entries.
-      storage_queue
-        .push(&user.workspace_id, &1, &params, WritePriority::Low)
-        .await
-        .unwrap();
-    } else {
-      storage_queue
-        .push(&user.workspace_id, &user.uid, &params, WritePriority::Low)
-        .await
-        .unwrap();
-      queries.push((params, encode_collab));
-    }
-  }
-
-  // Allow some time for processing
-  sleep(Duration::from_secs(20)).await;
-
-  // Check that all items are processed correctly
-  for (params, original_encode_collab) in queries {
-    let query = QueryCollab {
-      object_id: params.object_id.clone(),
-      collab_type: params.collab_type,
-    };
-    let encode_collab_from_disk = collab_cache
-      .get_encode_collab_from_disk(&user.uid, query)
-      .await
-      .unwrap();
-
-    assert_eq!(
-      encode_collab_from_disk.doc_state,
-      original_encode_collab.doc_state
-    );
-    assert_eq!(
-      encode_collab_from_disk.state_vector,
-      original_encode_collab.state_vector
-    );
-  }
 }

--- a/tests/collab/util.rs
+++ b/tests/collab/util.rs
@@ -47,7 +47,6 @@ pub fn test_encode_collab_v1(object_id: &str, key: &str, value: &str) -> Encoded
     .unwrap()
 }
 
-#[allow(dead_code)]
 pub async fn redis_client() -> redis::Client {
   let redis_uri = "redis://localhost:6379";
   redis::Client::open(redis_uri)
@@ -55,7 +54,6 @@ pub async fn redis_client() -> redis::Client {
     .unwrap()
 }
 
-#[allow(dead_code)]
 pub async fn redis_connection_manager() -> ConnectionManager {
   let mut attempt = 0;
   let max_attempts = 5;

--- a/tests/sql_test/mod.rs
+++ b/tests/sql_test/mod.rs
@@ -1,3 +1,3 @@
 mod history_test;
-mod util;
+pub(crate) mod util;
 mod workspace_test;

--- a/tests/sql_test/util.rs
+++ b/tests/sql_test/util.rs
@@ -65,6 +65,7 @@ pub async fn test_create_user(
   })
 }
 
+#[derive(Clone)]
 pub struct TestUser {
   pub uid: i64,
   pub workspace_id: String,


### PR DESCRIPTION
Spawns a background task that periodically writes cached collaboration data to disk in a single transaction. It consolidates multiple write operations into one transaction with the goal of minimizing database transaction pool usage,
thereby enhancing performance and reducing resource contention.
