### PR TITLE
Draft: feat: Add realtime service as proxy to websocket server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4545,6 +4545,24 @@ dependencies = [
 [[package]]
 name = "realtime"
 version = "0.1.0"
+dependencies = [
+ "actix",
+ "actix-http",
+ "actix-rt",
+ "actix-web",
+ "actix-web-actors",
+ "anyhow",
+ "app-error",
+ "async-trait",
+ "bytes",
+ "client-websocket",
+ "dotenvy",
+ "futures-util",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+]
 
 [[package]]
 name = "redis"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.13.3"
-actix-web = { version = "4.5.1", default-features = false, features = ["openssl", "compress-brotli", "compress-gzip"] }
+actix.workspace = true
+actix-web = { workspace = true, default-features = false, features = ["openssl", "compress-brotli", "compress-gzip"] }
 actix-http = { workspace = true, default-features = false, features = ["openssl", "compress-brotli", "compress-gzip"] }
-actix-rt = "2.9.0"
-actix-web-actors = { version = "4.3" }
+actix-rt.workspace = true
+actix-web-actors.workspace = true
 actix-service = "2.0.2"
 actix-identity = "0.6.0"
 actix-router = "0.5.2"
@@ -58,8 +58,8 @@ async-trait.workspace = true
 prometheus-client.workspace = true
 itertools = "0.11"
 uuid = "1.6.1"
-tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
-dotenvy = "0.15.7"
+tokio-tungstenite = { workspace = true, features = ["native-tls"] }
+dotenvy.workspace = true
 url = "2.5.0"
 brotli = "3.4.0"
 dashmap.workspace = true
@@ -155,11 +155,17 @@ members = [
 ]
 
 [workspace.dependencies]
+actix = "0.13.3"
+actix-web-actors = { version = "4.3" }
+actix-rt = "2.9.0"
+actix-web = { version = "4.5.1", default-features = false, features = ["openssl", "compress-brotli", "compress-gzip"] }
 collab-rt-entity = { path = "libs/collab-rt-entity" }
 collab-rt-protocol = { path = "libs/collab-rt-protocol" }
 database = { path = "libs/database" }
 database-entity = { path = "libs/database-entity" }
+dotenvy = "0.15.7"
 shared-entity = { path = "libs/shared-entity" }
+tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 access-control = { path = "libs/access-control" }
 app-error = { path = "libs/app-error" }
 async-trait = "0.1.77"

--- a/services/realtime/Cargo.toml
+++ b/services/realtime/Cargo.toml
@@ -6,3 +6,27 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+app-error = { workspace = true, features = ["actix_web_error", "tokio_error"] }
+actix.workspace = true
+actix-web = { workspace = true, default-features = false, features = ["openssl", "compress-brotli", "compress-gzip", "macros"] }
+actix-http = { workspace = true, default-features = false, features = ["openssl","compress-brotli", "compress-gzip"] }
+actix-rt.workspace = true
+actix-web-actors = { workspace = true }
+anyhow.workspace = true
+async-trait.workspace = true
+bytes.workspace = true
+client-websocket.workspace = true
+dotenvy.workspace = true
+futures-util.workspace = true
+thiserror = "1.0.58"
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "fs",
+    "time",
+] }
+tokio-tungstenite.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]

--- a/services/realtime/src/api.rs
+++ b/services/realtime/src/api.rs
@@ -1,0 +1,51 @@
+use crate::session::RealtimeClient;
+use crate::state::AppState;
+use actix_web::web::{Data, Payload};
+use actix_web::{web, HttpRequest, HttpResponse, Result, Scope};
+use actix_web_actors::ws;
+use std::collections::HashMap;
+use tracing::{debug, error, instrument};
+
+pub fn ws_scope() -> Scope {
+  web::scope("/ws").service(web::resource("/v1").route(web::get().to(establish_ws_connection_v1)))
+}
+const MAX_FRAME_SIZE: usize = 65_536; // 64 KiB
+
+#[instrument(skip_all, err)]
+pub async fn establish_ws_connection_v1(
+  request: HttpRequest,
+  payload: Payload,
+  state: Data<AppState>,
+  web::Query(_query_params): web::Query<HashMap<String, String>>,
+) -> Result<HttpResponse> {
+  debug!("🚀new websocket connect: request={:?}", request);
+
+  start_connect(&request, payload, &state).await
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline]
+async fn start_connect(
+  request: &HttpRequest,
+  payload: Payload,
+  state: &Data<AppState>,
+) -> Result<HttpResponse> {
+  let session_act = RealtimeClient::new(request.headers().clone().into(), &state.config.ws_client);
+  match session_act.connect().await {
+    Ok(_) => (),
+    Err(e) => {
+      error!("🔴ws connection error: {:?}", e);
+      return Err(actix_web::error::ErrorInternalServerError(e));
+    },
+  }
+  match ws::WsResponseBuilder::new(session_act, request, payload)
+    .frame_size(MAX_FRAME_SIZE * 2)
+    .start()
+  {
+    Ok(response) => Ok(response),
+    Err(e) => {
+      error!("🔴ws connection error: {:?}", e);
+      Err(e)
+    },
+  }
+}

--- a/services/realtime/src/application.rs
+++ b/services/realtime/src/application.rs
@@ -1,0 +1,45 @@
+use crate::api::ws_scope;
+use crate::config::Config;
+use crate::state::AppState;
+use actix_web::dev::Server;
+use actix_web::web::Data;
+use actix_web::{App, HttpServer};
+use anyhow::Error;
+use std::net::TcpListener;
+use std::sync::Arc;
+
+pub struct Application {
+  server: Server,
+}
+
+impl Application {
+  pub async fn build(config: Config, state: AppState) -> Result<Self, Error> {
+    let address = format!("{}:{}", config.application.host, config.application.port);
+    let listener = TcpListener::bind(&address)?;
+    let server = run(listener, state, config).await?;
+
+    Ok(Self { server })
+  }
+
+  pub async fn run_until_stopped(self) -> Result<(), std::io::Error> {
+    self.server.await
+  }
+}
+
+pub async fn run(listener: TcpListener, state: AppState, config: Config) -> Result<Server, Error> {
+  let mut server = HttpServer::new(move || {
+    App::new()
+      .app_data(Data::new(state.clone()))
+      .service(ws_scope())
+  });
+  server = server.listen(listener)?;
+
+  Ok(server.run())
+}
+
+pub async fn init_state(config: &Config) -> Result<AppState, Error> {
+  let app_state = AppState {
+    config: Arc::new(config.clone()),
+  };
+  Ok(app_state)
+}

--- a/services/realtime/src/config.rs
+++ b/services/realtime/src/config.rs
@@ -1,0 +1,42 @@
+#[derive(Clone, Debug)]
+pub struct Config {
+  pub application: ApplicationSetting,
+  pub ws_client: WSClientConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct ApplicationSetting {
+  pub port: u16,
+  pub host: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct WSClientConfig {
+  pub url: String,
+  pub buffer_capacity: usize,
+}
+
+pub fn get_env_var(key: &str, default: &str) -> String {
+  std::env::var(key).unwrap_or_else(|e| {
+    tracing::warn!(
+      "failed to read environment variable: {}, using default value: {}",
+      e,
+      default
+    );
+    default.to_owned()
+  })
+}
+
+pub fn get_configuration() -> Result<Config, anyhow::Error> {
+  let config = Config {
+    application: ApplicationSetting {
+      port: get_env_var("APPFLOWY_APPLICATION_PORT", "8001").parse()?,
+      host: get_env_var("APPFLOWY_APPLICATION_HOST", "0.0.0.0"),
+    },
+    ws_client: WSClientConfig {
+      url: get_env_var("APPFLOWY_WS_SERVER_URL", "ws://localhost:8000/ws/v1"),
+      buffer_capacity: get_env_var("APPFLOWY_WS_CLIENT_BUFFER_CAPACITY", "1000").parse()?,
+    },
+  };
+  Ok(config)
+}

--- a/services/realtime/src/lib.rs
+++ b/services/realtime/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod api;
+pub mod application;
+pub mod config;
+pub mod session;
+pub mod state;

--- a/services/realtime/src/main.rs
+++ b/services/realtime/src/main.rs
@@ -1,3 +1,13 @@
-fn main() {
-  println!("Hello, world!");
+use realtime::application::{init_state, Application};
+use realtime::config::get_configuration;
+
+#[actix_web::main]
+async fn main() -> anyhow::Result<()> {
+  dotenvy::dotenv().ok();
+  let conf =
+    get_configuration().map_err(|e| anyhow::anyhow!("Failed to read configuration: {}", e))?;
+  let state = init_state(&conf).await?;
+  let application = Application::build(conf, state).await?;
+  application.run_until_stopped().await?;
+  Ok(())
 }

--- a/services/realtime/src/session.rs
+++ b/services/realtime/src/session.rs
@@ -1,0 +1,157 @@
+use actix::{
+  Actor, ActorContext, AsyncContext, Handler, Message as ActixMessage, Recipient, Running,
+  StreamHandler,
+};
+use actix_http::header::HeaderMap;
+use actix_web_actors::ws;
+use actix_web_actors::ws::ProtocolError;
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::broadcast::{channel, Sender};
+use tracing::{error, trace};
+
+use client_websocket::{connect_async, Message, WebSocketStream};
+
+use crate::config::WSClientConfig;
+
+#[derive(Clone, Debug, ActixMessage)]
+#[rtype(result = "()")]
+pub struct MessageEnvelope(pub Message);
+
+pub struct RealtimeClient {
+  url: String,
+  header_map: HeaderMap,
+  server_msg_sender: Sender<MessageEnvelope>,
+  client_msg_sender: Sender<MessageEnvelope>,
+}
+
+impl RealtimeClient {
+  pub fn new(header_map: HeaderMap, config: &WSClientConfig) -> Self {
+    let (server_msg_sender, _) = channel(config.buffer_capacity);
+    let (client_msg_sender, _) = channel(config.buffer_capacity);
+    Self {
+      url: config.url.clone(),
+      header_map,
+      server_msg_sender,
+      client_msg_sender,
+    }
+  }
+
+  pub async fn connect(&self) -> client_websocket::Result<()> {
+    let conn_result = connect_async(&self.url, self.header_map.clone().into()).await;
+    match conn_result {
+      Ok(ws_stream) => {
+        let (sink, stream) = ws_stream.split();
+        self.spawn_pass_client_message_to_server(sink);
+        self.spawn_receive_server_message(stream);
+        Ok(())
+      },
+      Err(err) => Err(err),
+    }
+  }
+
+  fn spawn_pass_client_message_to_server(&self, mut ws_sink: SplitSink<WebSocketStream, Message>) {
+    let mut rx = self.client_msg_sender.subscribe();
+    tokio::spawn(async move {
+      while let Ok(msg) = rx.recv().await {
+        match ws_sink.send(msg.0).await {
+          Ok(_) => (),
+          Err(e) => error!("Failed to send message to the websocket: {:?}", e),
+        }
+      }
+    });
+  }
+
+  fn spawn_receive_server_message(&self, mut ws_stream: SplitStream<WebSocketStream>) {
+    let server_msg_sender = self.server_msg_sender.clone();
+    tokio::spawn(async move {
+      while let Some(msg) = ws_stream.next().await {
+        match msg {
+          Ok(msg) => match server_msg_sender.send(MessageEnvelope(msg)) {
+            Ok(_) => (),
+            Err(e) => error!("Failed to send message to the channel: {:?}", e),
+          },
+          Err(e) => error!("Failed to receive message from the websocket: {:?}", e),
+        }
+      }
+    });
+  }
+}
+
+impl Actor for RealtimeClient {
+  type Context = ws::WebsocketContext<Self>;
+
+  fn started(&mut self, ctx: &mut Self::Context) {
+    let recipient: Recipient<MessageEnvelope> = ctx.address().recipient();
+    let mut rx = self.server_msg_sender.subscribe();
+    tokio::spawn(async move {
+      while let Ok(msg_envelope) = rx.recv().await {
+        match recipient.send(msg_envelope).await {
+          Ok(_) => (),
+          Err(e) => error!("Failed to send message to the websocket: {:?}", e),
+        }
+      }
+    });
+  }
+
+  fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+    trace!("stopping websocket connect");
+    Running::Stop
+  }
+}
+
+impl Handler<MessageEnvelope> for RealtimeClient {
+  type Result = ();
+
+  fn handle(&mut self, msg_envelope: MessageEnvelope, ctx: &mut Self::Context) {
+    match msg_envelope.0 {
+      Message::Text(_) => {},
+      Message::Binary(bytes) => ctx.binary(bytes),
+      Message::Close(_close_frame) => {
+        // TODO: Convert close frame to close reason
+        ctx.close(None)
+      },
+      Message::Ping(bytes) => ctx.ping(bytes.as_slice()),
+      Message::Pong(bytes) => ctx.pong(bytes.as_slice()),
+    }
+  }
+}
+
+/// Handle the messages sent from the client
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for RealtimeClient {
+  fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+    if let Err(err) = &msg {
+      if let ProtocolError::Overflow = err {
+        ctx.stop();
+      }
+      return;
+    }
+    match msg.unwrap() {
+      ws::Message::Ping(bytes) => {
+        let _ = self
+          .client_msg_sender
+          .send(MessageEnvelope(Message::Ping(bytes.to_vec())));
+      },
+      ws::Message::Pong(bytes) => {
+        let _ = self
+          .client_msg_sender
+          .send(MessageEnvelope(Message::Pong(bytes.to_vec())));
+      },
+      ws::Message::Text(_) => {},
+      ws::Message::Binary(bytes) => {
+        let _ = self
+          .client_msg_sender
+          .send(MessageEnvelope(Message::Binary(bytes.to_vec())));
+      },
+      ws::Message::Close(_close_reason) => {
+        // TODO: Convert close reason to frame
+        let _ = self
+          .client_msg_sender
+          .send(MessageEnvelope(Message::Close(None)));
+        ctx.stop();
+      },
+      ws::Message::Continuation(_) => {},
+      ws::Message::Nop => (),
+    }
+  }
+}

--- a/services/realtime/src/state.rs
+++ b/services/realtime/src/state.rs
@@ -1,0 +1,7 @@
+use crate::config::Config;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct AppState {
+  pub config: Arc<Config>,
+}


### PR DESCRIPTION
This is the draft PR based on the version 2 design as proposed in https://github.com/AppFlowy-IO/AppFlowy-Cloud/issues/411#issuecomment-2030966504 .

As of the moment the realtime service is purely acting as a proxy without any connection retry like https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/main/libs/client-api/src/native/retry.rs#L107 and https://github.com/AppFlowy-IO/AppFlowy/blob/9b4fd3bf57cf27dff70592233c9b45430a7a00a1/frontend/rust-lib/flowy-server/src/af_cloud/server.rs#L244 , so the connection to the client will still be disrupted in the event of appflowy server restart.

Even with retry added on the real time service, the stability is probably not much better than client side retry, though it does help that we can configure the retry configuration anytime via the real time service as opposed to updating every client.

Version 3 should be the long term solution, though there doesn't appear to be much code that we can reuse from refactoring version 2 to version 3, since the actor design will be very different.

I will be looking into the collab-rt server to see how much effort will be needed if we jump straight to version 3.

Other items that are not implemented yet beside connection retry:
- This does not handle the scenario of larger websocket payload, which is not handled via the ws/v1 endpoint.
- Haven't properly handled all message delivery failure scenario yet

