### PR TITLE
feat: add more detailed logging around errors in Transaction::try_encode_state_as_update_v1

### DIFF
--- a/services/appflowy-collaborate/src/group/protocol.rs
+++ b/services/appflowy-collaborate/src/group/protocol.rs
@@ -21,7 +21,12 @@ impl CollabSyncProtocol for ServerSyncProtocol {
     })?;
 
     let client_step2_update = txn.try_encode_state_as_update_v1(&sv).map_err(|err| {
-      RTProtocolError::YrsEncodeState(format!("fail to encode state as update. error: {}", err))
+      RTProtocolError::YrsEncodeState(format!(
+        "fail to encode state as update. error: {}\ninit state vector: {:?}\ndocument state: {:#?}",
+        err,
+        sv,
+        txn.store()
+      ))
     })?;
 
     // Retrieve the latest document state from the client after they return online from offline editing.


### PR DESCRIPTION
This would allow us to attach internal document state to errors, that cause panics during applying CRDT state updates.

I suspect that the reason behind these panics was fixed in https://github.com/y-crdt/y-crdt/pull/405 but we won't be able to confirm that until we upgrade to the latest version or get the log data.