### PR TITLE
fix: make sure test for offline user connect then sync failed when one or more future task failed

### DIFF
--- a/tests/collab/single_device_edit.rs
+++ b/tests/collab/single_device_edit.rs
@@ -643,7 +643,10 @@ async fn simulate_50_offline_user_connect_and_then_sync_document_test() {
     });
     tasks.push(task);
   }
-  let _results = futures::future::join_all(tasks).await;
+  let results = futures::future::join_all(tasks).await;
+  for result in results {
+    result.unwrap()
+  }
 }
 
 // #[tokio::test]


### PR DESCRIPTION
The test, `simulate_50_offline_user_connect_and_then_sync_document_test` , currently passed even though one or more task failed due to sync failures. Added a check to make sure that all the task completed successfully.
