### PR TITLE
feat: add postgres listeners for collab service

### DIFF
--- a/libs/database/src/lib.rs
+++ b/libs/database/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chat;
 pub mod collab;
 pub mod file;
 pub mod history;
+pub mod listener;
 pub mod pg_row;
 pub mod resource_usage;
 pub mod user;

--- a/libs/database/src/listener.rs
+++ b/libs/database/src/listener.rs
@@ -1,0 +1,42 @@
+use anyhow::Error;
+use serde::de::DeserializeOwned;
+use sqlx::postgres::PgListener;
+use sqlx::PgPool;
+use tokio::sync::broadcast;
+use tracing::{error, trace};
+
+pub struct PostgresDBListener<T: Clone> {
+  pub notify: broadcast::Sender<T>,
+}
+
+impl<T> PostgresDBListener<T>
+where
+  T: Clone + DeserializeOwned + Send + 'static,
+{
+  pub async fn new(pg_pool: &PgPool, channel: &str) -> Result<Self, Error> {
+    let mut listener = PgListener::connect_with(pg_pool).await?;
+    // TODO(nathan): using listen_all
+    listener.listen(channel).await?;
+
+    let (tx, _) = broadcast::channel(1000);
+    let notify = tx.clone();
+    tokio::spawn(async move {
+      while let Ok(notification) = listener.recv().await {
+        trace!("Received notification: {}", notification.payload());
+        match serde_json::from_str::<T>(notification.payload()) {
+          Ok(change) => {
+            let _ = tx.send(change);
+          },
+          Err(err) => {
+            error!(
+              "Failed to deserialize change: {:?}, payload: {}",
+              err,
+              notification.payload()
+            );
+          },
+        }
+      }
+    });
+    Ok(Self { notify })
+  }
+}

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -312,7 +312,6 @@ impl EditState {
   }
 }
 
-#[allow(dead_code)]
 struct CollabUpdateStreamingImpl {
   sender: mpsc::UnboundedSender<Vec<u8>>,
   stopped: Arc<AtomicBool>,

--- a/services/appflowy-collaborate/src/lib.rs
+++ b/services/appflowy-collaborate/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 mod group;
 pub mod metrics;
 mod permission;
+mod pg_listener;
 mod rt_server;
 pub mod shared_state;
 pub mod snapshot;

--- a/services/appflowy-collaborate/src/pg_listener.rs
+++ b/services/appflowy-collaborate/src/pg_listener.rs
@@ -1,17 +1,19 @@
+use crate::collab::notification::CollabMemberNotification;
 use anyhow::Error;
-use appflowy_collaborate::collab::notification::CollabMemberNotification;
 use database::listener::PostgresDBListener;
 use database::pg_row::AFUserNotification;
 use sqlx::PgPool;
 use tokio::sync::broadcast;
 use workspace_access::notification::WorkspaceMemberNotification;
 
+#[allow(dead_code)]
 pub struct PgListeners {
   user_listener: UserListener,
   workspace_member_listener: WorkspaceMemberListener,
   collab_member_listener: CollabMemberListener,
 }
 
+#[allow(dead_code)]
 impl PgListeners {
   pub async fn new(pg_pool: &PgPool) -> Result<Self, Error> {
     let user_listener = UserListener::new(pg_pool, "af_user_channel").await?;
@@ -55,6 +57,9 @@ impl PgListeners {
   }
 }
 
+#[allow(dead_code)]
 pub type CollabMemberListener = PostgresDBListener<CollabMemberNotification>;
+#[allow(dead_code)]
 pub type UserListener = PostgresDBListener<AFUserNotification>;
+#[allow(dead_code)]
 pub type WorkspaceMemberListener = PostgresDBListener<WorkspaceMemberNotification>;

--- a/src/biz/user/user_verify.rs
+++ b/src/biz/user/user_verify.rs
@@ -6,7 +6,6 @@ use tracing::{event, instrument, trace};
 
 use access_control::workspace::WorkspaceAccessControl;
 use app_error::AppError;
-use database::pg_row::AFUserNotification;
 use database::user::{create_user, is_user_exist};
 use database::workspace::select_workspace;
 use database_entity::dto::AFRole;
@@ -79,7 +78,6 @@ pub async fn verify_token(access_token: &str, state: &AppState) -> Result<bool, 
   Ok(is_new)
 }
 
-pub type UserListener = crate::biz::pg_listener::PostgresDBListener<AFUserNotification>;
 // Best effort to get user's name after oauth
 fn name_from_user_metadata(value: &serde_json::Value) -> String {
   value


### PR DESCRIPTION
Changes:
- PostgresDBListener is moved to database crate so that the listeners can be shared between different services.
- Add PgListeners to Collab service.  As of now, the PgListener implementation is not extracted to a common crate, nor does the Appflowy API service import the implementation from the Collab Service. That is due to the possibility that the listener implementation for the main API service might eventually diverge from the implementation for the collab service.