### PR TITLE
Workspace token usage

### DIFF
--- a/libs/database/src/index/search_ops.rs
+++ b/libs/database/src/index/search_ops.rs
@@ -12,11 +12,17 @@ pub async fn search_documents(
 ) -> Result<Vec<SearchDocumentItem>, sqlx::Error> {
   let query = sqlx::query_as::<_, SearchDocumentItem>(
     r#"
-    UPDATE af_workspace SET search_token_usage = search_token_usage + $6 WHERE workspace_id = $2;
+    WITH workspace AS (
+      UPDATE af_workspace
+      SET search_token_usage = search_token_usage + $6
+      WHERE workspace_id = $2
+      RETURNING workspace_id
+    )
     SELECT
       em.oid AS object_id,
       collab.workspace_id,
       em.partition_key AS collab_type,
+      em.content_type,
       LEFT(em.content, $4) AS content_preview,
       u.name AS created_by,
       collab.created_at AS created_at,

--- a/migrations/20240529054858_workspace_add_token_usage.sql
+++ b/migrations/20240529054858_workspace_add_token_usage.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+ALTER TABLE af_workspace ADD COLUMN search_token_usage BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE af_workspace ADD COLUMN index_token_usage BIGINT NOT NULL DEFAULT 0;

--- a/services/appflowy-indexer/src/error.rs
+++ b/services/appflowy-indexer/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
   Sql(#[from] sqlx::Error),
   #[error("OpenAI failed to process request: {0}")]
   OpenAI(String),
+  #[error("invalid workspace ID: {0}")]
+  InvalidWorkspace(uuid::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/services/appflowy-indexer/src/indexer.rs
+++ b/services/appflowy-indexer/src/indexer.rs
@@ -7,6 +7,7 @@ use openai_dive::v1::resources::embedding::{
 };
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
+use uuid::Uuid;
 
 use database::index::{has_collab_embeddings, remove_collab_embeddings, upsert_collab_embeddings};
 use database_entity::dto::{AFCollabEmbeddingParams, EmbeddingContentType};
@@ -17,7 +18,7 @@ use crate::error::Result;
 pub trait Indexer: Send + Sync {
   /// Check if document with given id has been already a corresponding index entry.
   async fn was_indexed(&self, object_id: &str) -> Result<bool>;
-  async fn update_index(&self, documents: Vec<Fragment>) -> Result<()>;
+  async fn update_index(&self, workspace_id: &Uuid, documents: Vec<Fragment>) -> Result<()>;
   async fn remove(&self, ids: &[FragmentID]) -> Result<()>;
 }
 
@@ -99,7 +100,7 @@ impl PostgresIndexer {
     Self { openai, db }
   }
 
-  async fn get_embeddings(&self, fragments: Vec<Fragment>) -> Result<Vec<EmbedFragment>> {
+  async fn get_embeddings(&self, fragments: Vec<Fragment>) -> Result<Embeddings> {
     let inputs: Vec<_> = fragments
       .iter()
       .map(|fragment| fragment.content.clone())
@@ -118,10 +119,12 @@ impl PostgresIndexer {
       .map_err(|e| crate::error::Error::OpenAI(e.to_string()))?;
 
     tracing::trace!("fetched {} embeddings", resp.data.len());
-    if let Some(usage) = resp.usage {
+    let tokens_used = if let Some(usage) = resp.usage {
       tracing::info!("OpenAI API usage: {}", usage.total_tokens);
-      //TODO: report usage statistics
-    }
+      usage.total_tokens
+    } else {
+      0
+    };
 
     let mut fragments: Vec<_> = fragments.into_iter().map(EmbedFragment::from).collect();
     for e in resp.data.into_iter() {
@@ -135,23 +138,37 @@ impl PostgresIndexer {
       };
       fragments[e.index as usize].embedding = Some(embedding);
     }
-    Ok(fragments)
+    Ok(Embeddings {
+      tokens_used,
+      fragments,
+    })
   }
 
-  async fn store_embeddings(&self, fragments: Vec<EmbedFragment>) -> Result<()> {
+  async fn store_embeddings(&self, workspace_id: &Uuid, embeddings: Embeddings) -> Result<()> {
     tracing::trace!(
       "storing {} embeddings inside of vector database",
-      fragments.len()
+      embeddings.fragments.len()
     );
     let mut tx = self.db.begin().await?;
     upsert_collab_embeddings(
       &mut tx,
-      fragments.into_iter().map(EmbedFragment::into).collect(),
+      workspace_id,
+      embeddings.tokens_used,
+      embeddings
+        .fragments
+        .into_iter()
+        .map(EmbedFragment::into)
+        .collect(),
     )
     .await?;
     tx.commit().await?;
     Ok(())
   }
+}
+
+struct Embeddings {
+  tokens_used: u32,
+  fragments: Vec<EmbedFragment>,
 }
 
 #[async_trait]
@@ -161,9 +178,9 @@ impl Indexer for PostgresIndexer {
     Ok(found)
   }
 
-  async fn update_index(&self, documents: Vec<Fragment>) -> Result<()> {
+  async fn update_index(&self, workspace_id: &Uuid, documents: Vec<Fragment>) -> Result<()> {
     let embeddings = self.get_embeddings(documents).await?;
-    self.store_embeddings(embeddings).await?;
+    self.store_embeddings(workspace_id, embeddings).await?;
     Ok(())
   }
 
@@ -191,7 +208,7 @@ mod test {
     let db = db_pool().await;
     let object_id = uuid::Uuid::new_v4();
     let uid = rand::random();
-    setup_collab(&db, uid, object_id, vec![]).await;
+    let workspace_id = setup_collab(&db, uid, object_id, vec![]).await;
 
     let openai = openai_client();
 
@@ -209,10 +226,13 @@ mod test {
 
     // resolve embeddings from OpenAI
     let embeddings = indexer.get_embeddings(fragments).await.unwrap();
-    assert_eq!(embeddings[0].embedding.is_some(), true);
+    assert_eq!(embeddings.fragments[0].embedding.is_some(), true);
 
     // store embeddings in DB
-    indexer.store_embeddings(embeddings).await.unwrap();
+    indexer
+      .store_embeddings(&workspace_id, embeddings)
+      .await
+      .unwrap();
 
     // search for embedding
     let mut tx = indexer.db.begin().await.unwrap();

--- a/services/appflowy-indexer/src/indexer.rs
+++ b/services/appflowy-indexer/src/indexer.rs
@@ -120,7 +120,7 @@ impl PostgresIndexer {
 
     tracing::trace!("fetched {} embeddings", resp.data.len());
     let tokens_used = if let Some(usage) = resp.usage {
-      tracing::info!("OpenAI API usage: {}", usage.total_tokens);
+      tracing::info!("OpenAI API index tokens used: {}", usage.total_tokens);
       usage.total_tokens
     } else {
       0

--- a/src/biz/search/ops.rs
+++ b/src/biz/search/ops.rs
@@ -30,9 +30,12 @@ pub async fn search_document(
     .await
     .map_err(|e| AppResponseError::new(ErrorCode::Internal, e.to_string()))?;
 
-  if let Some(usage) = embeddings.usage {
-    tracing::info!("OpenAI API usage: {}", usage.total_tokens)
-  }
+  let tokens_used = if let Some(usage) = embeddings.usage {
+    tracing::info!("OpenAI API usage: {}", usage.total_tokens);
+    usage.total_tokens
+  } else {
+    0
+  };
 
   let embedding = embeddings
     .data
@@ -61,6 +64,7 @@ pub async fn search_document(
       preview: request.preview_size.unwrap_or(180) as i32,
       embedding,
     },
+    tokens_used,
   )
   .await?;
   Ok(

--- a/src/biz/search/ops.rs
+++ b/src/biz/search/ops.rs
@@ -31,7 +31,11 @@ pub async fn search_document(
     .map_err(|e| AppResponseError::new(ErrorCode::Internal, e.to_string()))?;
 
   let tokens_used = if let Some(usage) = embeddings.usage {
-    tracing::info!("OpenAI API usage: {}", usage.total_tokens);
+    tracing::info!(
+      "workspace {} OpenAI API search tokens used: {}",
+      workspace_id,
+      usage.total_tokens
+    );
     usage.total_tokens
   } else {
     0
@@ -67,6 +71,7 @@ pub async fn search_document(
     tokens_used,
   )
   .await?;
+  tx.commit().await?;
   Ok(
     results
       .into_iter()


### PR DESCRIPTION
This PR introduces two new columns to `af_workspace` called `search_token_usage` and `index_token_usage` which are used to track spending of OpenAI tokens for both indexing and searching purposes at the workspace level.

This PR doesn't introduce any kind of workspace token limit control, it's just about tracking.