### PR TITLE
chore: fix clippy linting errors and warnings

### DIFF
--- a/libs/client-api/src/http_billing.rs
+++ b/libs/client-api/src/http_billing.rs
@@ -39,7 +39,7 @@ impl Client {
         ("recurring_interval", recurring_interval.as_str()),
         (
           "workspace_subscription_plan",
-          &workspace_subscription_plan.as_str(),
+          workspace_subscription_plan.as_str(),
         ),
         ("success_url", success_url),
       ])

--- a/services/appflowy-collaborate/src/group/broadcast.rs
+++ b/services/appflowy-collaborate/src/group/broadcast.rs
@@ -189,7 +189,6 @@ impl CollabBroadcast {
     Stream: StreamExt<Item = MessageByObjectId> + Send + Sync + Unpin + 'static,
     <Sink as futures_util::Sink<CollabMessage>>::Error: std::error::Error + Send + Sync,
   {
-    let cloned_origin = subscriber_origin.clone();
     let sink_stop_tx = {
       let mut sink = sink.clone();
       let (stop_tx, mut stop_rx) = tokio::sync::mpsc::channel::<()>(1);
@@ -266,7 +265,6 @@ impl CollabBroadcast {
     };
 
     Subscription {
-      origin: cloned_origin,
       sink_stop_tx: Some(sink_stop_tx),
       stream_stop_tx: Some(stream_stop_tx),
     }
@@ -540,7 +538,6 @@ fn ack_code_from_error(error: &RTProtocolError) -> AckCode {
 /// connection error or closed connection).
 #[derive(Debug)]
 pub struct Subscription {
-  pub origin: CollabOrigin,
   sink_stop_tx: Option<tokio::sync::mpsc::Sender<()>>,
   stream_stop_tx: Option<tokio::sync::mpsc::Sender<()>>,
 }

--- a/services/appflowy-collaborate/src/group/cmd.rs
+++ b/services/appflowy-collaborate/src/group/cmd.rs
@@ -46,7 +46,6 @@ where
 {
   pub group_manager: Arc<GroupManager<S, AC>>,
   pub msg_router_by_user: Arc<DashMap<RealtimeUser, ClientMessageRouter>>,
-  pub access_control: Arc<AC>,
   pub recv: Option<GroupCommandReceiver>,
 }
 

--- a/services/appflowy-collaborate/src/rt_server.rs
+++ b/services/appflowy-collaborate/src/rt_server.rs
@@ -32,7 +32,6 @@ pub struct CollaborationServer<S, AC> {
   group_manager: Arc<GroupManager<S, AC>>,
   connect_state: ConnectState,
   group_sender_by_object_id: Arc<DashMap<String, GroupCommandSender>>,
-  access_control: Arc<AC>,
   storage: Arc<S>,
   #[allow(dead_code)]
   metrics: Arc<CollabRealtimeMetrics>,
@@ -82,7 +81,6 @@ where
       group_manager,
       connect_state,
       group_sender_by_object_id,
-      access_control,
       metrics,
       metrics_calculate,
     })
@@ -168,7 +166,6 @@ where
     let group_sender_by_object_id = self.group_sender_by_object_id.clone();
     let client_msg_router_by_user = self.connect_state.client_message_routers.clone();
     let group_manager = self.group_manager.clone();
-    let access_control = self.access_control.clone();
 
     Box::pin(async move {
       for (object_id, collab_messages) in message_by_oid {
@@ -186,7 +183,6 @@ where
               let runner = GroupCommandRunner {
                 group_manager: group_manager.clone(),
                 msg_router_by_user: client_msg_router_by_user.clone(),
-                access_control: access_control.clone(),
                 recv: Some(recv),
               };
 


### PR DESCRIPTION
This PR fixed the errors reported by Clippy, which includes:
- unused struct fields
- reference that is immediately dereferenced by the compiler