### PR TITLE
feat: dockerfile for collab service

### DIFF
--- a/services/appflowy-collaborate/Dockerfile
+++ b/services/appflowy-collaborate/Dockerfile
@@ -1,0 +1,39 @@
+# Using cargo-chef to manage Rust build cache effectively
+FROM lukemathwalker/cargo-chef:latest-rust-1.77 as chef
+
+WORKDIR /app
+RUN apt update && apt install lld clang -y
+
+FROM chef as planner
+COPY . .
+# Compute a lock-like file for our project
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef as builder
+
+# Update package lists and install protobuf-compiler along with other build dependencies
+RUN apt update && apt install -y protobuf-compiler lld clang
+
+COPY --from=planner /app/recipe.json recipe.json
+# Build our project dependencies
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+
+WORKDIR /app/services/appflowy-collaborate
+RUN cargo build --release --bin appflowy_collaborate
+
+FROM debian:bookworm-slim AS runtime
+WORKDIR /app
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && update-ca-certificates \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/appflowy_collaborate /usr/local/bin/appflowy_collaborate
+ENV APP_ENVIRONMENT production
+ENV RUST_BACKTRACE 1
+CMD ["appflowy_collaborate"]


### PR DESCRIPTION
Add dockerfile for collab service. This is meant for testing locally at the moment, the pipeline should be updated to release this image at a later stage when the independent collab service is production ready.