### PR TITLE
chore: update create collab list api endpoint

### DIFF
--- a/services/appflowy-collaborate/src/group/persistence.rs
+++ b/services/appflowy-collaborate/src/group/persistence.rs
@@ -55,9 +55,6 @@ where
 
   pub async fn run(self, mut destroy_group_rx: mpsc::Receiver<MutexCollab>) {
     let mut interval = interval(self.persistence_interval);
-    // TODO(nathan): remove this sleep when creating a new collab, applying all the updates
-    // workarounds for the issue that the collab doesn't contain the required data when first created
-    sleep(Duration::from_secs(5)).await;
     loop {
       tokio::select! {
         _ = interval.tick() => {

--- a/services/appflowy-collaborate/src/group/persistence.rs
+++ b/services/appflowy-collaborate/src/group/persistence.rs
@@ -12,7 +12,7 @@ use collab::core::collab::{MutexCollab, WeakMutexCollab};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::{interval, sleep};
+use tokio::time::interval;
 use tracing::{error, trace, warn};
 
 pub(crate) struct GroupPersistence<S> {

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -666,14 +666,25 @@ async fn create_collab_list_handler(
   if valid_items.is_empty() {
     return Err(AppError::InvalidRequest("Empty collab params list".to_string()).into());
   }
+  let mut transaction = state
+    .pg_pool
+    .begin()
+    .await
+    .context("acquire transaction to upsert collab")
+    .map_err(AppError::from)?;
 
   for params in valid_items {
     let _object_id = params.object_id.clone();
     state
       .collab_access_control_storage
-      .insert_new_collab(&workspace_id, &uid, params)
+      .insert_new_collab_with_transaction(&workspace_id, &uid, params, &mut transaction)
       .await?;
   }
+
+  transaction
+    .commit()
+    .await
+    .context("fail to commit the transaction to upsert collab")?;
 
   Ok(Json(AppResponse::Ok()))
 }


### PR DESCRIPTION
1. Using transaction when inserting list of collabs. 
2. Remove necessary sleep when trying to save data to disk since `attempt_save` will determine to save data to disk or not