### PR TITLE
fix: use two column as unique constraint

### DIFF
--- a/migrations/20240627525836_publish_collab_5.sql
+++ b/migrations/20240627525836_publish_collab_5.sql
@@ -2,6 +2,6 @@
 ALTER TABLE public.af_published_collab
 DROP CONSTRAINT unique_publish_name;
 
--- Add a new unique constraint for the combination of publish_name and view_id
+-- Add a new unique constraint for the combination of publish_name and workspace_id
 ALTER TABLE public.af_published_collab
 ADD CONSTRAINT unique_workspace_id_publish_name UNIQUE (workspace_id, publish_name);

--- a/migrations/20240627525836_publish_collab_5.sql
+++ b/migrations/20240627525836_publish_collab_5.sql
@@ -1,0 +1,7 @@
+-- Drop the existing unique constraint on publish_name
+ALTER TABLE public.af_published_collab
+DROP CONSTRAINT unique_publish_name;
+
+-- Add a new unique constraint for the combination of publish_name and view_id
+ALTER TABLE public.af_published_collab
+ADD CONSTRAINT unique_workspace_id_publish_name UNIQUE (workspace_id, publish_name);


### PR DESCRIPTION
- remove existing publish name as unqiue constraint as it's possible that 2 doc have the same name different workspace with different publish_namespace.
- added unique constraint on (workspace_id, publish_name) as it is not possible(must not) that workspace contains 2 published doc having same publish_name