### PR TITLE
feat: use different shared state redis key prefix for independent collab service

### DIFF
--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -58,9 +58,11 @@ where
     snapshot_control: SnapshotControl,
     rt_cmd_sender: CLCommandSender,
     redis_conn_manager: RedisConnectionManager,
+    shared_state_redis_key_prefix: &str,
     metrics: Arc<CollabMetrics>,
   ) -> Self {
-    let shared_state = RealtimeSharedState::new(redis_conn_manager.clone());
+    let shared_state =
+      RealtimeSharedState::new(redis_conn_manager.clone(), shared_state_redis_key_prefix);
     let queue = Arc::new(StorageQueue::new_with_metrics(
       cache.clone(),
       redis_conn_manager,

--- a/services/appflowy-collaborate/src/shared_state.rs
+++ b/services/appflowy-collaborate/src/shared_state.rs
@@ -5,15 +5,19 @@ use redis::{pipe, AsyncCommands, AsyncIter};
 #[derive(Clone)]
 pub struct RealtimeSharedState {
   redis_conn_manager: redis::aio::ConnectionManager,
+  redis_key_prefix: String,
 }
 
 impl RealtimeSharedState {
-  pub fn new(redis_conn_manager: redis::aio::ConnectionManager) -> Self {
-    Self { redis_conn_manager }
+  pub fn new(redis_conn_manager: redis::aio::ConnectionManager, redis_key_prefix: &str) -> Self {
+    Self {
+      redis_conn_manager,
+      redis_key_prefix: redis_key_prefix.to_string(),
+    }
   }
   pub async fn add_connected_user(&self, uid: i64, device_id: &str) -> Result<(), RealtimeError> {
     let mut conn = self.redis_conn_manager.clone();
-    let key = realtime_shared_state_cache_key(&uid, device_id);
+    let key = self.realtime_shared_state_cache_key(&uid, device_id);
     conn
       .set_ex(key, "1", 60 * 60 * 3)
       .await
@@ -27,7 +31,7 @@ impl RealtimeSharedState {
     device_id: &str,
   ) -> Result<(), RealtimeError> {
     let mut conn = self.redis_conn_manager.clone();
-    let key = realtime_shared_state_cache_key(&uid, device_id);
+    let key = self.realtime_shared_state_cache_key(&uid, device_id);
     conn
       .del(key)
       .await
@@ -37,7 +41,7 @@ impl RealtimeSharedState {
 
   pub async fn is_user_connected(&self, uid: &i64, device_id: &str) -> Result<bool, RealtimeError> {
     let mut conn = self.redis_conn_manager.clone();
-    let key = realtime_shared_state_cache_key(uid, device_id);
+    let key = self.realtime_shared_state_cache_key(uid, device_id);
     let result: Option<String> = conn
       .get(key)
       .await
@@ -48,7 +52,7 @@ impl RealtimeSharedState {
   pub async fn remove_all_connected_users(&self) -> Result<(), RealtimeError> {
     let mut conn = self.redis_conn_manager.clone();
     let iter: AsyncIter<String> = conn
-      .scan_match(format!("{}:*", REALTIME_SHARE_STATE_PREFIX))
+      .scan_match(format!("{}:*", self.redis_key_prefix))
       .await
       .map_err(|err| RealtimeError::Internal(err.into()))?;
     let keys_to_delete: Vec<_> = iter.collect().await;
@@ -64,11 +68,11 @@ impl RealtimeSharedState {
     }
     Ok(())
   }
+
+  pub fn realtime_shared_state_cache_key(&self, uid: &i64, device_id: &str) -> String {
+    format!("{}:{}:{}", self.redis_key_prefix, uid, device_id)
+  }
 }
 
-pub(crate) const REALTIME_SHARE_STATE_PREFIX: &str = "realtime_shared_state_v0";
-
-#[inline]
-pub(crate) fn realtime_shared_state_cache_key(uid: &i64, device_id: &str) -> String {
-  format!("{}:{}:{}", REALTIME_SHARE_STATE_PREFIX, uid, device_id)
-}
+pub const REALTIME_SHARE_STATE_V0_PREFIX: &str = "realtime_shared_state_v0";
+pub const REALTIME_SHARE_STATE_V1_PREFIX: &str = "realtime_shared_state_v1";

--- a/services/appflowy-collaborate/tests/shared_state_test.rs
+++ b/services/appflowy-collaborate/tests/shared_state_test.rs
@@ -11,7 +11,10 @@ async fn redis_client() -> redis::Client {
 #[tokio::test]
 async fn connected_user_test() {
   let redis_client = redis_client().await;
-  let shared_state = RealtimeSharedState::new(redis_client.get_connection_manager().await.unwrap());
+  let shared_state = RealtimeSharedState::new(
+    redis_client.get_connection_manager().await.unwrap(),
+    "shared_state_prefix",
+  );
 
   let device_id = uuid::Uuid::new_v4().to_string();
   let is_connected = shared_state
@@ -46,7 +49,10 @@ async fn connected_user_test() {
 #[tokio::test]
 async fn remove_all_connected_user_test() {
   let redis_client = redis_client().await;
-  let shared_state = RealtimeSharedState::new(redis_client.get_connection_manager().await.unwrap());
+  let shared_state = RealtimeSharedState::new(
+    redis_client.get_connection_manager().await.unwrap(),
+    "shared_state_prefix",
+  );
 
   let device_id = uuid::Uuid::new_v4().to_string();
   shared_state


### PR DESCRIPTION
Currently, the independent collab service is competing with the appflowy cloud service for the shared state redis key. During start up, both service will attempt to remove all redis key with the prefix.

After this PR, the new collab service will use a different prefix for the shared state.