### PR TITLE
chore: disabling indexing on workspace prunes collab embeddings

### DIFF
--- a/.sqlx/query-e5d51236e5c96ac91c70cd1d1b603f63e80e4f05a45a0790dd0bde892429ef14.json
+++ b/.sqlx/query-e5d51236e5c96ac91c70cd1d1b603f63e80e4f05a45a0790dd0bde892429ef14.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM af_collab_embeddings e WHERE e.oid in (\n        SELECT c.oid\n        FROM af_collab c\n        WHERE c.partition_key = e.partition_key\n          AND c.oid = e.oid\n          AND c.workspace_id = $1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e5d51236e5c96ac91c70cd1d1b603f63e80e4f05a45a0790dd0bde892429ef14"
+}

--- a/libs/database/src/workspace.rs
+++ b/libs/database/src/workspace.rs
@@ -814,6 +814,20 @@ pub async fn upsert_workspace_settings(
   .execute(tx.deref_mut())
   .await?;
 
+  if settings.disable_search_indexing {
+    sqlx::query!(
+      r#"DELETE FROM af_collab_embeddings e WHERE e.oid in (
+        SELECT c.oid
+        FROM af_collab c
+        WHERE c.partition_key = e.partition_key
+          AND c.oid = e.oid
+          AND c.workspace_id = $1)"#,
+      workspace_id
+    )
+    .execute(tx.deref_mut())
+    .await?;
+  }
+
   Ok(())
 }
 


### PR DESCRIPTION
1. turning off `workspace.settings.disable_search_indexing` should prune `af_collab_embeddings` for that workspace: otherwise they will be outdated (as are no longer indexed) but will still appear in search results.
2. should turning on `workspace.settings.disable_search_indexing` cause all of the collabs in that workspace to be reindexed? (question to @appflowy). IMO this could be an issue: if user starts flipping the disable indexing switch, they may overburden server with redundant requests and our AI billing will grow very easily.