### PR TITLE
Draft:feat: experimental nginx and docker compose config to test independent collab service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,25 @@ services:
       - APPFLOWY_HISTORY_ENVIRONMENT=production
       - APPFLOWY_HISTORY_DATABASE_URL=${APPFLOWY_HISTORY_DATABASE_URL}
 
+# Uncomment for experimental support for independent collaboration service
+#  appflowy_collaborate:
+#    restart: on-failure
+#    environment:
+#      - RUST_LOG=${RUST_LOG:-info}
+#      - APPFLOWY_ENVIRONMENT=production
+#      - APPFLOWY_DATABASE_URL=${APPFLOWY_DATABASE_URL}
+#      - APPFLOWY_REDIS_URI=redis://redis:6379
+#      - APPFLOWY_GOTRUE_JWT_SECRET=${GOTRUE_JWT_SECRET}
+#      - APPFLOWY_DATABASE_MAX_CONNECTIONS=${APPFLOWY_DATABASE_MAX_CONNECTIONS}
+#      - APPFLOWY_COLLAB_GROUP_PERSISTENCE_INTERVAL=${APPFLOWY_COLLAB_GROUP_PERSISTENCE_INTERVAL:-60}
+#      - APPFLOWY_COLLAB_EDIT_STATE_MAX_COUNT=${APPFLOWY_COLLAB_EDIT_STATE_MAX_COUNT:-100}
+#      - APPFLOWY_COLLAB_EDIT_STATE_MAX_SECS=${APPFLOWY_COLLAB_EDIT_STATE_MAX_SECS:-60}
+#      - APPFLOWY_AI_SERVER_HOST=ai
+#      - APPFLOWY_AI_SERVER_PORT=5001
+#    build:
+#      context: .
+#      dockerfile: ./services/appflowy-collaborate/Dockerfile
+
 volumes:
   postgres_data:
   minio_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -49,8 +49,10 @@ http {
 
         # WebSocket
         location /ws {
-            set $appflowy_cloud appflowy_cloud;
-            proxy_pass http://$appflowy_cloud:8000;
+            set $appflowy_collaborate appflowy_cloud:8000;
+            # Experimental: Independent collaborate service
+            # set $appflowy_collaborate appflowy_collaborate:8001;
+            proxy_pass http://$appflowy_collaborate;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -105,6 +107,12 @@ http {
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH' always;
             add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version' always;
             add_header 'Access-Control-Max-Age' 3600 always;
+
+            # Experimental: Independent collaborate service
+            # location ~* ^/api/realtime/post/stream$ {
+            #     set $appflowy_collaborate appflowy_collaborate:8001;
+            #     proxy_pass http://$appflowy_collaborate;
+            # }
 
             location ~* ^/api/workspace/([a-zA-Z0-9_-]+)/publish$ {
                 set $appflowy_cloud appflowy_cloud;


### PR DESCRIPTION
This PR allows developer to test the independent collaborate service via docker compose. As the new collab service is not fully tested nor production ready, the corresponding configuration is commented out.