### PR TITLE
chore: add missing foreign key

### DIFF
--- a/migrations/20240630010030_workspace_member_foreign_key.sql
+++ b/migrations/20240630010030_workspace_member_foreign_key.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.af_workspace_member
+ADD CONSTRAINT af_workspace_member_uid_fkey
+FOREIGN KEY (uid) REFERENCES af_user(uid) ON DELETE CASCADE;


### PR DESCRIPTION
This is needed so that when a user is deleted, it is not in the workspace member table