### PR TITLE
fix: order comments by recency

### DIFF
--- a/.sqlx/query-ba86638be27dfdf52e157e07e3e22ccb5547a7815b8313b241b8b535a83e6ff1.json
+++ b/.sqlx/query-ba86638be27dfdf52e157e07e3e22ccb5547a7815b8313b241b8b535a83e6ff1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n      SELECT\n        avc.comment_id,\n        avc.created_at,\n        avc.updated_at,\n        avc.content,\n        avc.reply_comment_id,\n        avc.is_deleted,\n        au.uuid AS \"user_uuid?\",\n        au.name AS \"user_name?\"\n      FROM af_published_view_comment avc\n      LEFT OUTER JOIN af_user au ON avc.created_by = au.uid\n      WHERE view_id = $1\n    ",
+  "query": "\n      SELECT\n        avc.comment_id,\n        avc.created_at,\n        avc.updated_at,\n        avc.content,\n        avc.reply_comment_id,\n        avc.is_deleted,\n        au.uuid AS \"user_uuid?\",\n        au.name AS \"user_name?\"\n      FROM af_published_view_comment avc\n      LEFT OUTER JOIN af_user au ON avc.created_by = au.uid\n      WHERE view_id = $1\n      ORDER BY avc.created_at DESC\n    ",
   "describe": {
     "columns": [
       {
@@ -60,5 +60,5 @@
       false
     ]
   },
-  "hash": "c2e4e6e5db677977c00654223532cadaec9513b76f79965d591cf5bf5cc68707"
+  "hash": "ba86638be27dfdf52e157e07e3e22ccb5547a7815b8313b241b8b535a83e6ff1"
 }

--- a/libs/database/src/workspace.rs
+++ b/libs/database/src/workspace.rs
@@ -1118,7 +1118,10 @@ pub async fn select_published_collab_info<'a, E: Executor<'a, Database = Postgre
   Ok(res)
 }
 
-pub async fn select_comments_for_published_view<'a, E: Executor<'a, Database = Postgres>>(
+pub async fn select_comments_for_published_view_orderd_by_recency<
+  'a,
+  E: Executor<'a, Database = Postgres>,
+>(
   executor: E,
   view_id: &Uuid,
 ) -> Result<Vec<GlobalComment>, AppError> {
@@ -1136,6 +1139,7 @@ pub async fn select_comments_for_published_view<'a, E: Executor<'a, Database = P
       FROM af_published_view_comment avc
       LEFT OUTER JOIN af_user au ON avc.created_by = au.uid
       WHERE view_id = $1
+      ORDER BY avc.created_at DESC
     "#,
     view_id,
   )

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -22,7 +22,7 @@ use database::workspace::{
   change_workspace_icon, delete_from_workspace, delete_published_collabs, delete_workspace_members,
   get_invitation_by_id, insert_comment_to_published_view, insert_or_replace_publish_collab_metas,
   insert_user_workspace, insert_workspace_invitation, rename_workspace, select_all_user_workspaces,
-  select_comments_for_published_view, select_member_count_for_workspaces,
+  select_comments_for_published_view_orderd_by_recency, select_member_count_for_workspaces,
   select_publish_collab_meta, select_published_collab_blob, select_published_collab_info,
   select_user_is_allowed_to_delete_comment, select_user_is_collab_publisher_for_all_views,
   select_user_is_workspace_owner, select_workspace, select_workspace_invitations_for_user,
@@ -180,7 +180,7 @@ pub async fn get_comments_on_published_view(
   pg_pool: &PgPool,
   view_id: &Uuid,
 ) -> Result<Vec<GlobalComment>, AppError> {
-  let comments = select_comments_for_published_view(pg_pool, view_id).await?;
+  let comments = select_comments_for_published_view_orderd_by_recency(pg_pool, view_id).await?;
   Ok(comments)
 }
 


### PR DESCRIPTION
Order comments from the latest to the oldest, instead of relying on frontend to sort the result.