### PR TITLE
feat: add can be deleted field to GlobalComment

### DIFF
--- a/.sqlx/query-e9e22adc5a6f6daf354dc122cadab41b7cc13e0d956b3204d22f26a47ad594e3.json
+++ b/.sqlx/query-e9e22adc5a6f6daf354dc122cadab41b7cc13e0d956b3204d22f26a47ad594e3.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT\n      af.uuid\n      FROM af_published_collab apc\n      JOIN af_user af ON af.uid = apc.published_by\n      WHERE view_id = $1\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uuid",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e9e22adc5a6f6daf354dc122cadab41b7cc13e0d956b3204d22f26a47ad594e3"
+}

--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -844,6 +844,16 @@ impl Client {
   }
 
   #[instrument(level = "debug", skip_all, err)]
+  pub async fn http_client_without_auth(
+    &self,
+    method: Method,
+    url: &str,
+  ) -> Result<RequestBuilder, AppResponseError> {
+    trace!("start request: {}, method: {}", url, method,);
+    Ok(self.cloud_client.request(method, url))
+  }
+
+  #[instrument(level = "debug", skip_all, err)]
   pub async fn http_client_with_auth(
     &self,
     method: Method,

--- a/libs/client-api/src/http_publish.rs
+++ b/libs/client-api/src/http_publish.rs
@@ -153,6 +153,29 @@ impl Client {
   }
 }
 
+// Optional login
+impl Client {
+  pub async fn get_published_view_comments(
+    &self,
+    view_id: &uuid::Uuid,
+  ) -> Result<GlobalComments, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/published-info/{}/comment",
+      self.base_url, view_id
+    );
+    let client = if let Ok(client) = self.http_client_with_auth(Method::GET, &url).await {
+      client
+    } else {
+      self.http_client_without_auth(Method::GET, &url).await?
+    };
+
+    let resp = client.send().await?;
+    AppResponse::<GlobalComments>::from_response(resp)
+      .await?
+      .into_data()
+  }
+}
+
 // Guest API (no login required)
 impl Client {
   #[instrument(level = "debug", skip_all)]
@@ -234,20 +257,6 @@ impl Client {
     }
 
     Ok(bytes)
-  }
-
-  pub async fn get_published_view_comments(
-    &self,
-    view_id: &uuid::Uuid,
-  ) -> Result<GlobalComments, AppResponseError> {
-    let url = format!(
-      "{}/api/workspace/published-info/{}/comment",
-      self.base_url, view_id
-    );
-    let resp = self.cloud_client.get(&url).send().await?;
-    AppResponse::<GlobalComments>::from_response(resp)
-      .await?
-      .into_data()
   }
 
   pub async fn get_published_view_reactions(

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -865,6 +865,7 @@ pub struct GlobalComment {
   pub reply_comment_id: Option<Uuid>,
   pub comment_id: Uuid,
   pub is_deleted: bool,
+  pub can_be_deleted: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -25,7 +25,7 @@ use access_control::collab::CollabAccessControl;
 use app_error::AppError;
 use appflowy_collaborate::actix_ws::entities::ClientStreamMessage;
 use appflowy_collaborate::indexer::IndexerProvider;
-use authentication::jwt::UserUuid;
+use authentication::jwt::{OptionalUserUuid, UserUuid};
 use collab_rt_entity::realtime_proto::HttpRealtimeMessage;
 use collab_rt_entity::RealtimeMessage;
 use collab_rt_protocol::validate_encode_collab;
@@ -1097,10 +1097,12 @@ async fn get_published_collab_info_handler(
 
 async fn get_published_collab_comment_handler(
   view_id: web::Path<Uuid>,
+  optional_user_uuid: OptionalUserUuid,
   state: Data<AppState>,
 ) -> Result<JsonAppResponse<GlobalComments>> {
   let view_id = view_id.into_inner();
-  let comments = get_comments_on_published_view(&state.pg_pool, &view_id).await?;
+  let comments =
+    get_comments_on_published_view(&state.pg_pool, &view_id, &optional_user_uuid).await?;
   let resp = GlobalComments { comments };
   Ok(Json(AppResponse::Ok().with_data(resp)))
 }

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -1,3 +1,4 @@
+use authentication::jwt::OptionalUserUuid;
 use database_entity::dto::{AFWorkspaceSettingsChange, PublishCollabItem};
 use std::collections::HashMap;
 
@@ -165,8 +166,16 @@ pub async fn get_published_collab_info(
 pub async fn get_comments_on_published_view(
   pg_pool: &PgPool,
   view_id: &Uuid,
+  optional_user_uuid: &OptionalUserUuid,
 ) -> Result<Vec<GlobalComment>, AppError> {
-  let comments = select_comments_for_published_view_orderd_by_recency(pg_pool, view_id).await?;
+  let page_owner_uuid = select_owner_of_published_collab(pg_pool, view_id).await?;
+  let comments = select_comments_for_published_view_ordered_by_recency(
+    pg_pool,
+    view_id,
+    &optional_user_uuid.as_uuid(),
+    &page_owner_uuid,
+  )
+  .await?;
   Ok(comments)
 }
 

--- a/tests/workspace/publish.rs
+++ b/tests/workspace/publish.rs
@@ -267,26 +267,35 @@ async fn test_publish_comments() {
   assert!(result.is_err());
   assert_eq!(result.unwrap_err().code, ErrorCode::NotLoggedIn);
 
-  // Test if only all users, authenticated or not, can view all the comments
+  // Test if only all users, authenticated or not, can view all the comments,
+  // and whether the `can_be_deleted` field is correctly set
   let published_view_comments: Vec<GlobalComment> = page_owner_client
     .get_published_view_comments(&view_id)
     .await
     .unwrap()
     .comments;
   assert_eq!(published_view_comments.len(), 2);
+  assert!(published_view_comments.iter().all(|c| c.can_be_deleted));
   let published_view_comments: Vec<GlobalComment> = first_user_client
     .get_published_view_comments(&view_id)
     .await
     .unwrap()
     .comments;
   assert_eq!(published_view_comments.len(), 2);
+  assert_eq!(
+    published_view_comments
+      .iter()
+      .map(|c| c.can_be_deleted)
+      .collect_vec(),
+    vec![true, false]
+  );
   let published_view_comments: Vec<GlobalComment> = guest_client
     .get_published_view_comments(&view_id)
     .await
     .unwrap()
     .comments;
   assert_eq!(published_view_comments.len(), 2);
-  assert!(published_view_comments.iter().all(|c| !c.is_deleted));
+  assert!(published_view_comments.iter().all(|c| !c.can_be_deleted));
 
   // Test if the comments are correctly sorted
   let comment_creators = published_view_comments
@@ -401,6 +410,7 @@ async fn test_publish_comments() {
     .comments;
   assert_eq!(published_view_comments.len(), 3);
   assert!(published_view_comments.iter().all(|c| c.is_deleted));
+  assert!(published_view_comments.iter().all(|c| !c.can_be_deleted));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Handle the logic on whether a comment can be deleted by the user who request to see all the comments. This allows the frontend to enable or disable deletion action.