### PR TITLE
chore: update sqlx to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -671,7 +671,7 @@ dependencies = [
  "futures",
  "futures-util",
  "governor",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itertools 0.12.1",
  "lazy_static",
  "md5",
@@ -1683,9 +1683,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"
@@ -1695,9 +1695,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "fca2be1d5c43812bae364ee3f30b3afcb7877cf59f4aeb94c66f313a41d2fac9"
 dependencies = [
  "serde",
 ]
@@ -1781,9 +1781,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1871,18 +1871,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -2199,6 +2199,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2789,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "email_address"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b7a0ac6570e31bfe2c6cf575a576a55af9893d1a6b30b4444e6e90b216bb84"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "encoding_rs"
@@ -2858,9 +2867,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -3255,7 +3269,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3274,7 +3288,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3335,20 +3349,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -3746,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3948,9 +3953,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3998,9 +4003,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4435,6 +4440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4575,14 +4586,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
 ]
 
 [[package]]
 name = "pgvector"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed92bf218dbe236609222dca0345767408ee7d5c93876c7fe09fa9b03f7249f"
+checksum = "e0e8871b6d7ca78348c6cd29b911b94851f3429f0cd403130ca17f26c1fb91a6"
 dependencies = [
  "sqlx",
 ]
@@ -4802,9 +4813,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy 0.6.6",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -4904,7 +4918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -6280,9 +6294,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -6293,11 +6307,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
 dependencies = [
- "ahash 0.8.11",
  "atoi",
  "byteorder",
  "bytes",
@@ -6311,9 +6324,10 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "log",
  "memchr",
  "once_cell",
@@ -6338,26 +6352,26 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -6369,7 +6383,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.72",
  "tempfile",
  "tokio",
  "url",
@@ -6377,12 +6391,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
@@ -6422,12 +6436,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
@@ -6463,9 +6477,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
 dependencies = [
  "atoi",
  "chrono",
@@ -6479,10 +6493,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
 ]
 
@@ -6921,9 +6935,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
@@ -6931,7 +6945,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "toml_datetime",
  "winnow",
 ]
@@ -7875,7 +7889,7 @@ dependencies = [
  "collab-entity",
  "collab-folder",
  "getrandom 0.2.15",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "nanoid",
  "serde",
  "serde_json",
@@ -7964,11 +7978,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ infra = { path = "libs/infra" }
 tracing = { version = "0.1", features = ["log"] }
 gotrue = { path = "libs/gotrue" }
 redis = "0.25.2"
-sqlx = { version = "0.7.4", default-features = false }
+sqlx = { version = "0.8.0", default-features = false }
 dashmap = "5.5.3"
 futures = "0.3.30"
 async-stream = "0.3.5"
@@ -258,7 +258,7 @@ tonic = "0.11"
 prost = "0.12"
 tonic-proto = { path = "libs/tonic-proto" }
 appflowy-ai-client = { path = "libs/appflowy-ai-client", default-features = false }
-pgvector = { version = "0.3", features = ["sqlx"] }
+pgvector = { version = "0.4", features = ["sqlx"] }
 client-api-entity = { path = "libs/client-api-entity" }
 
 # collaboration

--- a/libs/app-error/Cargo.toml
+++ b/libs/app-error/Cargo.toml
@@ -13,7 +13,10 @@ serde_repr = "0.1.18"
 serde.workspace = true
 anyhow = "1.0.79"
 uuid = { version = "1.6.1", features = ["v4"] }
-sqlx = { version = "0.7", default-features = false, features = ["postgres", "json"], optional = true }
+sqlx = { workspace = true, default-features = false, features = [
+  "postgres",
+  "json",
+], optional = true }
 validator = { version = "0.16", optional = true }
 url = { version = "2.5.0" }
 actix-web = { version = "4.4.1", optional = true }

--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -3,6 +3,7 @@ pub mod gotrue;
 
 #[cfg(feature = "gotrue_error")]
 use crate::gotrue::GoTrueError;
+use std::error::Error as StdError;
 use std::string::FromUtf8Error;
 
 #[cfg(feature = "appflowy_ai_error")]
@@ -83,6 +84,13 @@ pub enum AppError {
   #[cfg(feature = "sqlx_error")]
   #[error("{0}")]
   SqlxError(String),
+
+  #[cfg(feature = "sqlx_error")]
+  #[error("{desc}: {err}")]
+  SqlxArgEncodingError {
+    desc: String,
+    err: Box<dyn StdError + 'static + Send + Sync>,
+  },
 
   #[cfg(feature = "validation_error")]
   #[error(transparent)]
@@ -169,6 +177,8 @@ impl AppError {
       AppError::IOError(_) => ErrorCode::IOError,
       #[cfg(feature = "sqlx_error")]
       AppError::SqlxError(_) => ErrorCode::SqlxError,
+      #[cfg(feature = "sqlx_error")]
+      AppError::SqlxArgEncodingError { .. } => ErrorCode::SqlxArgEncodingError,
       #[cfg(feature = "validation_error")]
       AppError::ValidatorError(_) => ErrorCode::InvalidRequest,
       AppError::S3ResponseError(_) => ErrorCode::S3ResponseError,
@@ -299,6 +309,8 @@ pub enum ErrorCode {
   AIServiceUnavailable = 1032,
   AIResponseLimitExceeded = 1033,
   StringLengthLimitReached = 1034,
+  #[cfg(feature = "sqlx_error")]
+  SqlxArgEncodingError = 1035,
 }
 
 impl ErrorCode {

--- a/libs/database/Cargo.toml
+++ b/libs/database/Cargo.toml
@@ -19,7 +19,14 @@ serde.workspace = true
 serde_json.workspace = true
 tonic-proto.workspace = true
 
-sqlx = { version = "0.7", default-features = false, features = ["postgres", "chrono", "uuid", "macros", "runtime-tokio-rustls", "rust_decimal"] }
+sqlx = { workspace = true, default-features = false, features = [
+  "postgres",
+  "chrono",
+  "uuid",
+  "macros",
+  "runtime-tokio-rustls",
+  "rust_decimal",
+] }
 pgvector = { workspace = true, features = ["sqlx"] }
 tracing = { version = "0.1.40" }
 uuid = { version = "1.6.1", features = ["serde", "v4"] }
@@ -27,7 +34,10 @@ chrono = { version = "0.4", features = ["serde"] }
 redis.workspace = true
 futures-util = "0.3.30"
 bytes = "1.5"
-aws-sdk-s3 = { version = "1.36.0", features = ["behavior-version-latest", "rt-tokio"], optional = true }
+aws-sdk-s3 = { version = "1.36.0", features = [
+  "behavior-version-latest",
+  "rt-tokio",
+], optional = true }
 sha2 = "0.10.8"
 base64 = "0.21.7"
 rust_decimal = "1.33.1"

--- a/libs/database/src/chat/chat_ops.rs
+++ b/libs/database/src/chat/chat_ops.rs
@@ -68,19 +68,25 @@ pub async fn update_chat(
 
   if let Some(ref name) = params.name {
     query_parts.push(format!("name = ${}", current_param_pos));
-    args.add(name);
+    args
+      .add(name)
+      .map_err(|err| AppError::SqlxError(err.to_string()))?;
     current_param_pos += 1;
   }
 
   if let Some(ref rag_ids) = params.rag_ids {
     query_parts.push(format!("rag_ids = ${}", current_param_pos));
     let rag_ids_json = json!(rag_ids);
-    args.add(rag_ids_json);
+    args
+      .add(rag_ids_json)
+      .map_err(|err| AppError::SqlxError(err.to_string()))?;
     current_param_pos += 1;
   }
 
   query_parts.push(format!("WHERE chat_id = ${}", current_param_pos));
-  args.add(chat_id);
+  args
+    .add(chat_id)
+    .map_err(|err| AppError::SqlxError(err.to_string()))?;
 
   let query = query_parts.join(", ") + ";";
   let query = sqlx::query_with(&query, args);
@@ -313,7 +319,9 @@ pub async fn select_chat_messages(
   .to_string();
 
   let mut args = PgArguments::default();
-  args.add(&chat_id);
+  args
+    .add(&chat_id)
+    .map_err(|err| AppError::SqlxError(err.to_string()))?;
 
   // Message IDs:   1    2    3    4    5
   // AfterMessageId(3, 5):   [4]  [5]  has_more = false
@@ -322,24 +330,38 @@ pub async fn select_chat_messages(
   match params.cursor {
     MessageCursor::AfterMessageId(after_message_id) => {
       query += " AND message_id > $2";
-      args.add(after_message_id);
+      args
+        .add(after_message_id)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
       query += " ORDER BY message_id DESC LIMIT $3";
-      args.add(params.limit as i64);
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
     },
     MessageCursor::Offset(offset) => {
       query += " ORDER BY message_id ASC LIMIT $2 OFFSET $3";
-      args.add(params.limit as i64);
-      args.add(offset as i64);
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
+      args
+        .add(offset as i64)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
     },
     MessageCursor::BeforeMessageId(before_message_id) => {
       query += " AND message_id < $2";
-      args.add(before_message_id);
+      args
+        .add(before_message_id)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
       query += " ORDER BY message_id DESC LIMIT $3";
-      args.add(params.limit as i64);
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
     },
     MessageCursor::NextBack => {
       query += " ORDER BY message_id DESC LIMIT $2";
-      args.add(params.limit as i64);
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxError(err.to_string()))?;
     },
   }
 

--- a/libs/database/src/user.rs
+++ b/libs/database/src/user.rs
@@ -39,20 +39,26 @@ pub async fn update_user(
   if let Some(n) = name {
     args_num += 1;
     set_clauses.push(format!("name = ${}", args_num));
-    args.add(n);
+    args
+      .add(n)
+      .map_err(|err| AppError::SqlxError(err.to_string()))?;
   }
 
   if let Some(e) = email {
     args_num += 1;
     set_clauses.push(format!("email = ${}", args_num));
-    args.add(e);
+    args
+      .add(e)
+      .map_err(|err| AppError::SqlxError(err.to_string()))?;
   }
 
   if let Some(m) = metadata {
     args_num += 1;
     // Merge existing metadata with new metadata
     set_clauses.push(format!("metadata = metadata || ${}", args_num));
-    args.add(m);
+    args
+      .add(m)
+      .map_err(|err| AppError::SqlxError(err.to_string()))?;
   }
 
   if set_clauses.is_empty() {
@@ -67,7 +73,9 @@ pub async fn update_user(
     set_clauses.join(", "),
     args_num
   );
-  args.add(user_uuid);
+  args
+    .add(user_uuid)
+    .map_err(|err| AppError::SqlxError(err.to_string()))?;
 
   sqlx::query_with(&query, args).execute(pool).await?;
   Ok(())

--- a/libs/database/src/user.rs
+++ b/libs/database/src/user.rs
@@ -39,26 +39,29 @@ pub async fn update_user(
   if let Some(n) = name {
     args_num += 1;
     set_clauses.push(format!("name = ${}", args_num));
-    args
-      .add(n)
-      .map_err(|err| AppError::SqlxError(err.to_string()))?;
+    args.add(n).map_err(|err| AppError::SqlxArgEncodingError {
+      desc: format!("unable to encode user name for user {}", user_uuid),
+      err,
+    })?;
   }
 
   if let Some(e) = email {
     args_num += 1;
     set_clauses.push(format!("email = ${}", args_num));
-    args
-      .add(e)
-      .map_err(|err| AppError::SqlxError(err.to_string()))?;
+    args.add(e).map_err(|err| AppError::SqlxArgEncodingError {
+      desc: format!("unable to encode email for user {}", user_uuid),
+      err,
+    })?;
   }
 
   if let Some(m) = metadata {
     args_num += 1;
     // Merge existing metadata with new metadata
     set_clauses.push(format!("metadata = metadata || ${}", args_num));
-    args
-      .add(m)
-      .map_err(|err| AppError::SqlxError(err.to_string()))?;
+    args.add(m).map_err(|err| AppError::SqlxArgEncodingError {
+      desc: format!("unable to encode metadata for user {}", user_uuid),
+      err,
+    })?;
   }
 
   if set_clauses.is_empty() {
@@ -75,7 +78,10 @@ pub async fn update_user(
   );
   args
     .add(user_uuid)
-    .map_err(|err| AppError::SqlxError(err.to_string()))?;
+    .map_err(|err| AppError::SqlxArgEncodingError {
+      desc: format!("unable to encode user uuid {}", user_uuid),
+      err,
+    })?;
 
   sqlx::query_with(&query, args).execute(pool).await?;
   Ok(())


### PR DESCRIPTION
Update sqlx to 0.8. The new version resolve https://github.com/launchbadge/sqlx/issues/2242 , which allows gives us greater flexibility for SQL type <-> Rust struct conversion.

pgvector is also updated to 0.4 , as 0.3.x does not work for sqlx 0.8.