### PR TITLE
feat: impose character limits on comment

### DIFF
--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -122,6 +122,9 @@ pub enum AppError {
 
   #[error("{0}")]
   AIServiceUnavailable(String),
+
+  #[error("{0}")]
+  StringLengthLimitReached(String),
 }
 
 impl AppError {
@@ -182,6 +185,7 @@ impl AppError {
       AppError::Utf8Error(_) => ErrorCode::Internal,
       AppError::PublishNamespaceAlreadyTaken(_) => ErrorCode::PublishNamespaceAlreadyTaken,
       AppError::AIServiceUnavailable(_) => ErrorCode::AIServiceUnavailable,
+      AppError::StringLengthLimitReached(_) => ErrorCode::StringLengthLimitReached,
     }
   }
 }
@@ -294,6 +298,7 @@ pub enum ErrorCode {
   PublishNamespaceAlreadyTaken = 1031,
   AIServiceUnavailable = 1032,
   AIResponseLimitExceeded = 1033,
+  StringLengthLimitReached = 1034,
 }
 
 impl ErrorCode {

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -35,6 +35,8 @@ use crate::biz::user::user_init::initialize_workspace_for_user;
 use crate::mailer::{Mailer, WorkspaceInviteMailerParam};
 use crate::state::GoTrueAdmin;
 
+const MAX_COMMENT_LENGTH: usize = 5000;
+
 pub async fn delete_workspace_for_user(
   pg_pool: &PgPool,
   workspace_id: &Uuid,
@@ -186,6 +188,11 @@ pub async fn create_comment_on_published_view(
   content: &str,
   user_uuid: &Uuid,
 ) -> Result<(), AppError> {
+  if content.len() > MAX_COMMENT_LENGTH {
+    return Err(AppError::StringLengthLimitReached(
+      "comment content exceed limit".to_string(),
+    ));
+  }
   insert_comment_to_published_view(pg_pool, view_id, user_uuid, content, reply_comment_id).await?;
   Ok(())
 }


### PR DESCRIPTION
Currently, there is no limits on the size of the comment that a user can create. This can lead to potential denial of service attack from the user, by creating excessively long comment.

To protect against such scenario, the length of the comment string is limit to 5000. The size of the string is used as opposed to the number of characters of the string, because counting the characters is an O(n) operation.