### PR TITLE
fix: admin front end image building failure

### DIFF
--- a/admin_frontend/Dockerfile
+++ b/admin_frontend/Dockerfile
@@ -3,7 +3,7 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1.77 as chef
 
 WORKDIR /app
-RUN apt update && apt install lld clang -y
+RUN apt update && apt install lld clang protobuf-compiler -y
 
 # FROM chef as planner
 # COPY . .
@@ -30,11 +30,11 @@ RUN cargo build --release --bin admin_frontend
 FROM debian AS runtime
 WORKDIR /app
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends libc6 libssl-dev \
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends libc6 libssl-dev \
+  # Clean up
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/admin_frontend /usr/local/bin/admin_frontend
 COPY --from=builder /app/admin_frontend/assets /app/assets


### PR DESCRIPTION
There are a few issues that leads to admin frontend image building failures:
1. admin frontend doesn't actually need appflowy collab. However, because the cargo file for admin frontend and the parent cargo toml is in the search path (refer: https://doc.rust-lang.org/cargo/reference/config.html) , the cargo config got merged and admin frontend pulls in AppFlowy Collab as well, even when it is not needed.

2. We recently introduced protobuf dependencies in AppFlowyCollab. In order to prevent compilation failure due to absence of protobuf compiler, we try to catch the panic (https://github.com/AppFlowy-IO/AppFlowy-Collab/blob/main/collab-entity/build.rs#L20) and use vendored protobuf compiler crate as fallback. We are using panic instead of Result, because in the absence of protobuf compiler, prost panics instead of returning a Result.

This works for most case, but catching unwinding error is not guaranteed to work in all scenarios. For example, this does not work in the case of docker build process in admin frontend image.

We will have to either:
1. Install protobuf compiler in admin front end during the building process
2. Use vendored protobuf compiler by default and only use protobuf compiler when PROTOC env is explicitly set. This is so that we don't have to rely on catching unwinding panic in order to use the fallback.
3. Move appflowy cloud into a separate folder, so that appflowy cloud dependencies don't get merged into all other libraries/services.

Option 1 is the most straightforward for now, which is implemented in this PR. After this, we will implement option 2 on AppFlowy Collab. Option 3 will be for long term, due to the large changes involved.
