### PR TITLE
chore: replace bincode serialization with protobuf for collab stream

### DIFF
--- a/libs/collab-stream/src/pubsub.rs
+++ b/libs/collab-stream/src/pubsub.rs
@@ -93,8 +93,8 @@ impl ToRedisArgs for PubSubMessage {
   where
     W: ?Sized + RedisWrite,
   {
-    let json = bincode::serialize(self).unwrap();
-    json.write_redis_args(out);
+    let proto = self.to_proto().encode_to_vec();
+    proto.write_redis_args(out);
   }
 }
 


### PR DESCRIPTION
As we already update the decoding method to handle both bincode and protobuf serialization, it is now safe to replace the bincode with protobuf serialization for collab stream.

We will proceed with removing bincode deserialization entirely for collab stream in a future version.