### PR TITLE
feat: endpoint for avatar upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-multipart"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5118a26dee7e34e894f7e85aa0ee5080ae4c18bf03c0e30d49a80e418f00a53"
+dependencies = [
+ "actix-multipart-derive",
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "httparse",
+ "local-waker",
+ "log",
+ "memchr",
+ "mime",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "actix-multipart-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11eb847f49a700678ea2fa73daeb3208061afa2b9d1a8527c03390f4c4a1c6b"
+dependencies = [
+ "darling",
+ "parse-size",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "actix-router"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +588,7 @@ dependencies = [
  "actix",
  "actix-http",
  "actix-identity",
+ "actix-multipart",
  "actix-router",
  "actix-rt",
  "actix-service",
@@ -2582,6 +2621,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,6 +3774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,6 +4593,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944553dd59c802559559161f9816429058b869003836120e262e8caec061b7ae"
 
 [[package]]
 name = "password-hash"
@@ -6020,6 +6106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6582,6 +6677,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ actix-service = "2.0.2"
 actix-identity = "0.6.0"
 actix-router = "0.5.2"
 actix-session = { version = "0.8", features = ["redis-rs-tls-session"] }
+actix-multipart = { version = "0.7.2", features = ["derive"] }
 openssl = { version = "0.10.62", features = ["vendored"] }
 
 # serde

--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -133,6 +133,9 @@ pub enum AppError {
 
   #[error("{0}")]
   StringLengthLimitReached(String),
+
+  #[error("{0}")]
+  InvalidContentType(String),
 }
 
 impl AppError {
@@ -196,6 +199,7 @@ impl AppError {
       AppError::PublishNamespaceAlreadyTaken(_) => ErrorCode::PublishNamespaceAlreadyTaken,
       AppError::AIServiceUnavailable(_) => ErrorCode::AIServiceUnavailable,
       AppError::StringLengthLimitReached(_) => ErrorCode::StringLengthLimitReached,
+      AppError::InvalidContentType(_) => ErrorCode::InvalidContentType,
     }
   }
 }
@@ -311,6 +315,7 @@ pub enum ErrorCode {
   StringLengthLimitReached = 1034,
   #[cfg(feature = "sqlx_error")]
   SqlxArgEncodingError = 1035,
+  InvalidContentType = 1036,
 }
 
 impl ErrorCode {

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -1223,6 +1223,11 @@ pub struct TemplateHomePageQueryParams {
   pub per_count: Option<i64>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AvatarImageSource {
+  pub file_id: String,
+}
+
 #[cfg(test)]
 mod test {
   use crate::dto::{CollabParams, CollabParamsV0};

--- a/src/application.rs
+++ b/src/application.rs
@@ -210,7 +210,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     config.s3.bucket.clone(),
   );
   let bucket_storage = Arc::new(S3BucketStorage::from_bucket_impl(
-    s3_client,
+    s3_client.clone(),
     pg_pool.clone(),
   ));
 
@@ -307,6 +307,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     collab_access_control,
     workspace_access_control,
     bucket_storage,
+    bucket_client: s3_client,
     pg_listeners,
     access_control,
     metrics,

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,7 @@ use appflowy_collaborate::indexer::IndexerProvider;
 use appflowy_collaborate::metrics::CollabMetrics;
 use appflowy_collaborate::shared_state::RealtimeSharedState;
 use appflowy_collaborate::CollabRealtimeMetrics;
-use database::file::s3_client_impl::S3BucketStorage;
+use database::file::s3_client_impl::{AwsS3BucketClientImpl, S3BucketStorage};
 
 use database::user::{select_all_uid_uuid, select_uid_from_uuid};
 use gotrue::grant::{Grant, PasswordGrant};
@@ -45,6 +45,7 @@ pub struct AppState {
   pub collab_access_control: CollabAccessControlImpl,
   pub workspace_access_control: WorkspaceAccessControlImpl,
   pub bucket_storage: Arc<S3BucketStorage>,
+  pub bucket_client: AwsS3BucketClientImpl,
   pub pg_listeners: Arc<PgListeners>,
   pub access_control: AccessControl,
   pub metrics: AppMetrics,

--- a/tests/file_test/multiple_part_test.rs
+++ b/tests/file_test/multiple_part_test.rs
@@ -220,7 +220,10 @@ async fn perform_upload_test(
     parent_dir: parent_dir.clone(),
     file_id,
   };
-  let upload = test_bucket.create_upload(key, req).await.unwrap();
+  let upload = test_bucket
+    .create_upload(&key.object_key(), req)
+    .await
+    .unwrap();
 
   let mut chunk_count = (file_size / chunk_size) + 1;
   let mut size_of_last_chunk = file_size % chunk_size;
@@ -253,7 +256,10 @@ async fn perform_upload_test(
       parent_dir: parent_dir.clone(),
       file_id: upload.file_id.clone(),
     };
-    let resp = test_bucket.upload_part(&key, req).await.unwrap();
+    let resp = test_bucket
+      .upload_part(&key.object_key(), req)
+      .await
+      .unwrap();
 
     completed_parts.push(
       CompletedPart::builder()
@@ -282,7 +288,7 @@ async fn perform_upload_test(
     file_id: upload.file_id.clone(),
   };
   test_bucket
-    .complete_upload(&key, complete_req)
+    .complete_upload(&key.object_key(), complete_req)
     .await
     .unwrap();
 


### PR DESCRIPTION
Changes:
1. Add end point for supporting template center avatar upload
2. The bucket client was assuming that the object keys are always inferred from workspace id. As a result, it's hard to use the client for objects which is not associated with a workspace, such as avatar. This has been modified such that the callers of the trait are responsible for constructing the correct object key.
3. Instead of storing the content type via a separate metadata object, the content type was specified while uploading the blob to s3.