### PR TITLE
chore: reuse group collab for indexing

### DIFF
--- a/libs/collab-rt-entity/src/realtime_proto.rs
+++ b/libs/collab-rt-entity/src/realtime_proto.rs
@@ -2,8 +2,8 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpRealtimeMessage {
-  #[prost(string, tag = "1")]
-  pub device_id: ::prost::alloc::string::String,
-  #[prost(bytes = "vec", tag = "2")]
-  pub payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag = "1")]
+    pub device_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
 }

--- a/libs/collab-rt-entity/src/realtime_proto.rs
+++ b/libs/collab-rt-entity/src/realtime_proto.rs
@@ -2,8 +2,8 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpRealtimeMessage {
-    #[prost(string, tag = "1")]
-    pub device_id: ::prost::alloc::string::String,
-    #[prost(bytes = "vec", tag = "2")]
-    pub payload: ::prost::alloc::vec::Vec<u8>,
+  #[prost(string, tag = "1")]
+  pub device_id: ::prost::alloc::string::String,
+  #[prost(bytes = "vec", tag = "2")]
+  pub payload: ::prost::alloc::vec::Vec<u8>,
 }

--- a/services/appflowy-collaborate/src/group/persistence.rs
+++ b/services/appflowy-collaborate/src/group/persistence.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use collab::preclude::Collab;
-use collab_entity::{CollabType, validate_data_for_folder};
+use collab_entity::{validate_data_for_folder, CollabType};
 use tokio::sync::{mpsc, RwLock};
 use tokio::time::interval;
 use tracing::{trace, warn};

--- a/services/appflowy-collaborate/src/indexer/provider.rs
+++ b/services/appflowy-collaborate/src/indexer/provider.rs
@@ -140,7 +140,7 @@ impl IndexerProvider {
 
   async fn index_collab(&self, unindexed: UnindexedCollab) -> Result<(), AppError> {
     if let Some(indexer) = self.indexer_cache.get(&unindexed.collab_type) {
-      let workspace_id = unindexed.workspace_id.clone();
+      let workspace_id = unindexed.workspace_id;
       let embeddings = indexer
         .index(&unindexed.object_id, unindexed.collab)
         .await?;

--- a/services/appflowy-collaborate/src/indexer/provider.rs
+++ b/services/appflowy-collaborate/src/indexer/provider.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use actix::dev::Stream;
 use async_stream::try_stream;
 use async_trait::async_trait;
+use collab::core::collab::DataSource;
+use collab::core::origin::CollabOrigin;
 use collab::entity::EncodedCollab;
+use collab::preclude::Collab;
 use collab_entity::CollabType;
 use sqlx::PgPool;
 use tokio_stream::StreamExt;
@@ -16,17 +19,35 @@ use appflowy_ai_client::client::AppFlowyAIClient;
 use database::collab::select_blob_from_af_collab;
 use database::index::{get_collabs_without_embeddings, upsert_collab_embeddings};
 use database::workspace::select_workspace_settings;
-use database_entity::dto::{AFCollabEmbeddings, CollabParams};
+use database_entity::dto::{AFCollabEmbeddingParams, AFCollabEmbeddings, CollabParams};
 
 use crate::indexer::DocumentIndexer;
 
 #[async_trait]
 pub trait Indexer: Send + Sync {
+  fn embedding_params(&self, collab: &Collab) -> Result<Vec<AFCollabEmbeddingParams>, AppError>;
+
+  async fn embeddings(
+    &self,
+    params: Vec<AFCollabEmbeddingParams>,
+  ) -> Result<Option<AFCollabEmbeddings>, AppError>;
+
   async fn index(
     &self,
     object_id: &str,
-    doc_state: Vec<u8>,
-  ) -> Result<Option<AFCollabEmbeddings>, AppError>;
+    encoded_collab: EncodedCollab,
+  ) -> Result<Option<AFCollabEmbeddings>, AppError> {
+    let collab = Collab::new_with_source(
+      CollabOrigin::Empty,
+      object_id,
+      DataSource::DocStateV1(encoded_collab.doc_state.into()),
+      vec![],
+      false,
+    )
+    .map_err(|err| AppError::Internal(err.into()))?;
+    let embedding_params = self.embedding_params(&collab)?;
+    self.embeddings(embedding_params).await
+  }
 }
 
 /// A structure responsible for resolving different [Indexer] types for different [CollabType]s,
@@ -119,14 +140,15 @@ impl IndexerProvider {
 
   async fn index_collab(&self, unindexed: UnindexedCollab) -> Result<(), AppError> {
     if let Some(indexer) = self.indexer_cache.get(&unindexed.collab_type) {
-      if let Some(embeddings) = indexer
-        .index(&unindexed.object_id, unindexed.collab.doc_state.into())
-        .await?
-      {
+      let workspace_id = unindexed.workspace_id.clone();
+      let embeddings = indexer
+        .index(&unindexed.object_id, unindexed.collab)
+        .await?;
+      if let Some(embeddings) = embeddings {
         let mut tx = self.db.begin().await?;
         upsert_collab_embeddings(
           &mut tx,
-          &unindexed.workspace_id,
+          &workspace_id,
           embeddings.tokens_consumed,
           &embeddings.params,
         )
@@ -142,9 +164,8 @@ impl IndexerProvider {
     params: &CollabParams,
   ) -> Result<Option<AFCollabEmbeddings>, AppError> {
     if let Some(indexer) = self.indexer_for(params.collab_type.clone()) {
-      let embeddings = indexer
-        .index(&params.object_id, params.encoded_collab_v1.clone())
-        .await?;
+      let encoded_collab = EncodedCollab::decode_from_bytes(&params.encoded_collab_v1)?;
+      let embeddings = indexer.index(&params.object_id, encoded_collab).await?;
       Ok(embeddings)
     } else {
       Ok(None)

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1,7 +1,7 @@
-use actix_web::{Scope, web};
-use actix_web::{HttpRequest, Result};
 use actix_web::web::{Bytes, Payload};
 use actix_web::web::{Data, Json, PayloadConfig};
+use actix_web::{web, Scope};
+use actix_web::{HttpRequest, Result};
 use anyhow::{anyhow, Context};
 use bytes::BytesMut;
 use collab::entity::EncodedCollab;
@@ -28,11 +28,11 @@ use database::collab::CollabStorage;
 use database::user::select_uid_from_email;
 use database_entity::dto::*;
 use shared_entity::dto::workspace_dto::*;
-use shared_entity::response::{AppResponse, JsonAppResponse};
 use shared_entity::response::AppResponseError;
+use shared_entity::response::{AppResponse, JsonAppResponse};
 
-use crate::api::util::{CollabValidator, compress_type_from_header_value, device_id_from_headers};
 use crate::api::util::PayloadReader;
+use crate::api::util::{compress_type_from_header_value, device_id_from_headers, CollabValidator};
 use crate::api::ws::RealtimeServerAddr;
 use crate::biz;
 use crate::biz::workspace;
@@ -40,7 +40,7 @@ use crate::biz::workspace::ops::{
   create_comment_on_published_view, create_reaction_on_comment, get_comments_on_published_view,
   get_reactions_on_published_view, remove_comment_on_published_view, remove_reaction_on_comment,
 };
-use crate::domain::compression::{CompressionType, decompress, X_COMPRESSION_TYPE};
+use crate::domain::compression::{decompress, CompressionType, X_COMPRESSION_TYPE};
 use crate::state::AppState;
 
 pub const WORKSPACE_ID_PATH: &str = "workspace_id";


### PR DESCRIPTION
This PR modified document indexer to enable reusing `Arc<RwLock<Collab>>` supplied by persistence group instead of recreating it every time when `save` is being called. This means that we need to hold a lock a little bit longer (because we need to get Document text data), but we don't waste CPU/memory for build a copy of collab aside every time a save is being called.