### PR TITLE
chore: enable setting up periodic sync step 1 sends from sync plugin

### DIFF
--- a/libs/client-api-test/src/test_client.rs
+++ b/libs/client-api-test/src/test_client.rs
@@ -600,7 +600,7 @@ impl TestClient {
         stream,
         Some(handler),
         ws_connect_state,
-        Some(Duration::from_secs(1)),
+        Some(Duration::from_secs(10)),
       );
       let lock = collab.read().await;
       let collab = (*lock).borrow();
@@ -673,7 +673,7 @@ impl TestClient {
         stream,
         Some(handler),
         ws_connect_state,
-        Some(Duration::from_secs(1)),
+        Some(Duration::from_secs(10)),
       );
 
       let lock = collab.read().await;

--- a/libs/client-api-test/src/test_client.rs
+++ b/libs/client-api-test/src/test_client.rs
@@ -600,6 +600,7 @@ impl TestClient {
         stream,
         Some(handler),
         ws_connect_state,
+        Some(Duration::from_secs(1)),
       );
       let lock = collab.read().await;
       let collab = (*lock).borrow();
@@ -672,6 +673,7 @@ impl TestClient {
         stream,
         Some(handler),
         ws_connect_state,
+        Some(Duration::from_secs(1)),
       );
 
       let lock = collab.read().await;

--- a/libs/client-api/src/collab_sync/plugin.rs
+++ b/libs/client-api/src/collab_sync/plugin.rs
@@ -64,6 +64,7 @@ where
     stream: Stream,
     channel: Option<Arc<Channel>>,
     mut ws_connect_state: WSConnectStateReceiver,
+    periodic_sync: Option<Duration>,
   ) -> Self {
     let sync_queue = SyncControl::new(
       object.clone(),
@@ -72,6 +73,7 @@ where
       sink_config,
       stream,
       collab.clone(),
+      periodic_sync,
     );
 
     let mut sync_state_stream = sync_queue.subscribe_sync_state();

--- a/libs/client-api/src/collab_sync/sync_control.rs
+++ b/libs/client-api/src/collab_sync/sync_control.rs
@@ -60,6 +60,7 @@ where
     sink_config: SinkConfig,
     stream: Stream,
     collab: CollabRef,
+    periodic_sync: Option<Duration>,
   ) -> Self {
     let protocol = ClientSyncProtocol;
     let (notifier, notifier_rx) = watch::channel(SinkSignal::Proceed);
@@ -86,6 +87,7 @@ where
       stream,
       collab.clone(),
       Arc::downgrade(&sink),
+      periodic_sync,
     );
 
     Self {

--- a/services/appflowy-collaborate/src/group/protocol.rs
+++ b/services/appflowy-collaborate/src/group/protocol.rs
@@ -31,6 +31,10 @@ impl CollabSyncProtocol for ServerSyncProtocol {
     // Retrieve the latest document state from the client after they return online from offline editing.
     let mut encoder = EncoderV1::new();
     Message::Sync(SyncMessage::SyncStep2(client_step2_update)).encode(&mut encoder);
+
+    //FIXME: this should never happen as response to sync step 1 from the client, but rather be
+    //  send when a connection is established
+    Message::Sync(SyncMessage::SyncStep1(txn.state_vector())).encode(&mut encoder);
     Ok(Some(encoder.to_vec()))
   }
 

--- a/services/appflowy-collaborate/src/group/protocol.rs
+++ b/services/appflowy-collaborate/src/group/protocol.rs
@@ -1,12 +1,11 @@
 use collab::core::awareness::Awareness;
 use collab::core::collab::{TransactionExt, TransactionMutExt};
 use collab::core::origin::CollabOrigin;
+use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
+use yrs::{ReadTxn, StateVector, Transact, Update};
 
 use collab_rt_protocol::CollabSyncProtocol;
 use collab_rt_protocol::{CustomMessage, Message, RTProtocolError, SyncMessage};
-
-use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
-use yrs::{ReadTxn, StateVector, Transact, Update};
 
 #[derive(Clone)]
 pub struct ServerSyncProtocol;
@@ -30,11 +29,8 @@ impl CollabSyncProtocol for ServerSyncProtocol {
     })?;
 
     // Retrieve the latest document state from the client after they return online from offline editing.
-    let server_step1_update = txn.state_vector();
-
     let mut encoder = EncoderV1::new();
     Message::Sync(SyncMessage::SyncStep2(client_step2_update)).encode(&mut encoder);
-    Message::Sync(SyncMessage::SyncStep1(server_step1_update)).encode(&mut encoder);
     Ok(Some(encoder.to_vec()))
   }
 


### PR DESCRIPTION
This PR extends SyncPlugin with optional parameter, that will periodically send `SyncStep1` to the server. This way we can get notified about missing updates from other clients.

Example scenario that it solves:
1. Client 1 (C1) syncs an update to the Server
2. For whatever reason Client 2 (C2) didn't got C1 update.
3. Until C1 will send another update or C2 will restart the connection, C2 will  never get that missing update.

With this PR we can occasionally ask server to about all missing updates given our own state vector.