### PR TITLE
chore: write collab to disk after first sync step2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=6f98f054a8306a8791b65bf1825091ab3fe60166#6f98f054a8306a8791b65bf1825091ab3fe60166"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=6f98f054a8306a8791b65bf1825091ab3fe60166#6f98f054a8306a8791b65bf1825091ab3fe60166"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=6f98f054a8306a8791b65bf1825091ab3fe60166#6f98f054a8306a8791b65bf1825091ab3fe60166"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=6f98f054a8306a8791b65bf1825091ab3fe60166#6f98f054a8306a8791b65bf1825091ab3fe60166"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=6f98f054a8306a8791b65bf1825091ab3fe60166#6f98f054a8306a8791b65bf1825091ab3fe60166"
 dependencies = [
  "anyhow",
  "collab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c4777db#c4777db5d32ee418ee8c6782bf851fdcf2a2eb60"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c4777db#c4777db5d32ee418ee8c6782bf851fdcf2a2eb60"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c4777db#c4777db5d32ee418ee8c6782bf851fdcf2a2eb60"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c4777db#c4777db5d32ee418ee8c6782bf851fdcf2a2eb60"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c4777db#c4777db5d32ee418ee8c6782bf851fdcf2a2eb60"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=97163517303bb0ed468992a4511aac6eb8775a4d#97163517303bb0ed468992a4511aac6eb8775a4d"
 dependencies = [
  "anyhow",
  "collab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,11 +282,11 @@ debug = true
 [patch.crates-io]
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c4777db" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c4777db" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c4777db" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c4777db" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c4777db" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
 
 [features]
 history = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,11 +282,11 @@ debug = true
 [patch.crates-io]
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "97163517303bb0ed468992a4511aac6eb8775a4d" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "6f98f054a8306a8791b65bf1825091ab3fe60166" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "6f98f054a8306a8791b65bf1825091ab3fe60166" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "6f98f054a8306a8791b65bf1825091ab3fe60166" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "6f98f054a8306a8791b65bf1825091ab3fe60166" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "6f98f054a8306a8791b65bf1825091ab3fe60166" }
 
 [features]
 history = []

--- a/libs/client-api/src/collab_sync/sync_control.rs
+++ b/libs/client-api/src/collab_sync/sync_control.rs
@@ -8,7 +8,7 @@ use collab::core::origin::CollabOrigin;
 use collab::preclude::Collab;
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::{broadcast, watch};
-use tracing::{instrument, trace};
+use tracing::{error, instrument, trace};
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
 use yrs::{ReadTxn, StateVector};
@@ -189,8 +189,7 @@ where
   }
 
   if let Err(err) = sync_object.collab_type.validate_require_data(collab) {
-    #[cfg(feature = "sync_verbose_log")]
-    trace!("{} error: {}", sync_object.object_id, err);
+    error!("start init sync :{}:{}", sync_object.object_id, err);
     return Err(SyncError::Internal(err));
   }
 

--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -162,6 +162,11 @@ where
     params: CollabParams,
     priority: WritePriority,
   ) -> Result<(), AppError> {
+    trace!(
+      "Queue insert collab:{}:{}",
+      params.object_id,
+      params.collab_type
+    );
     if let Err(err) = params.check_encode_collab().await {
       return Err(AppError::NoRequiredData(format!(
         "Invalid collab doc state detected for workspace_id: {}, uid: {}, object_id: {} collab_type:{}. Error details: {}",

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::fmt::Display;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -196,7 +197,7 @@ impl CollabGroup {
         modified_at.elapsed().as_secs(),
         self.subscribers.len()
       );
-      modified_at.elapsed().as_secs() > 120
+      modified_at.elapsed().as_secs() > 60 * 60
     } else {
       let elapsed_secs = modified_at.elapsed().as_secs();
       if elapsed_secs > self.timeout_secs() {
@@ -260,7 +261,26 @@ pub(crate) struct EditState {
 
   max_edit_count: u32,
   max_secs: i64,
+  /// Indicate the collab object is just created in the client and not exist in server database.
   is_new: AtomicBool,
+  /// Indicate the collab is ready to save to disk.
+  /// If is_ready_to_save is true, which means the collab contains the requirement data and ready to save to disk.
+  is_ready_to_save: AtomicBool,
+}
+
+impl Display for EditState {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+        f,
+        "EditState {{ edit_counter: {}, prev_edit_count: {},  max_edit_count: {}, max_secs: {}, is_new: {}, is_ready_to_save: {}",
+        self.edit_counter.load(Ordering::SeqCst),
+        self.prev_edit_count.load(Ordering::SeqCst),
+        self.max_edit_count,
+        self.max_secs,
+        self.is_new.load(Ordering::SeqCst),
+        self.is_ready_to_save.load(Ordering::SeqCst),
+        )
+  }
 }
 
 impl EditState {
@@ -272,6 +292,7 @@ impl EditState {
       max_edit_count,
       max_secs,
       is_new: AtomicBool::new(is_new),
+      is_ready_to_save: AtomicBool::new(false),
     }
   }
 
@@ -311,7 +332,19 @@ impl EditState {
     self.is_new.store(is_new, Ordering::SeqCst);
   }
 
+  pub(crate) fn set_ready_to_save(&self) {
+    self.is_ready_to_save.store(true, Ordering::Relaxed);
+  }
+
   pub(crate) fn should_save_to_disk(&self) -> bool {
+    if !self.is_ready_to_save.load(Ordering::Relaxed) {
+      return false;
+    }
+
+    if self.is_new.load(Ordering::Relaxed) {
+      return true;
+    }
+
     let current_edit_count = self.edit_counter.load(Ordering::SeqCst);
     let prev_edit_count = self.prev_edit_count.load(Ordering::SeqCst);
 

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -455,6 +455,7 @@ mod tests {
   #[test]
   fn edit_state_test() {
     let edit_state = EditState::new(10, 10, false);
+    edit_state.set_ready_to_save();
     edit_state.increment_edit_count();
 
     for _ in 0..10 {

--- a/services/appflowy-collaborate/src/group/manager.rs
+++ b/services/appflowy-collaborate/src/group/manager.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use collab::core::collab::DataSource;
 use collab::core::origin::CollabOrigin;
 use collab::entity::EncodedCollab;
-use collab::preclude::{Collab, CollabPlugin};
+use collab::preclude::Collab;
 use collab_entity::CollabType;
 use tokio::sync::{Mutex, RwLock};
 use tracing::{error, instrument, trace};
@@ -22,7 +22,7 @@ use database_entity::dto::QueryCollabParams;
 use crate::client::client_msg_router::ClientMessageRouter;
 use crate::error::{CreateGroupFailedReason, RealtimeError};
 use crate::group::group_init::CollabGroup;
-use crate::group::plugin::HistoryPlugin;
+
 use crate::group::state::GroupManagementState;
 use crate::indexer::IndexerProvider;
 use crate::metrics::CollabMetricsCalculate;
@@ -195,19 +195,9 @@ where
       };
 
       let collab = Arc::new(RwLock::new(collab));
-      let plugins: Vec<Box<dyn CollabPlugin>> = vec![Box::new(HistoryPlugin::new(
-        workspace_id.to_string(),
-        object_id.to_string(),
-        collab_type.clone(),
-        Arc::downgrade(&collab),
-        self.storage.clone(),
-        is_new_collab,
-      ))];
-
       {
         // initialize
         let mut collab = collab.write().await;
-        collab.add_plugins(plugins);
         collab.initialize();
       }
       (collab, encode_collab)

--- a/services/appflowy-collaborate/src/group/persistence.rs
+++ b/services/appflowy-collaborate/src/group/persistence.rs
@@ -6,7 +6,7 @@ use collab::preclude::Collab;
 use collab_entity::{validate_data_for_folder, CollabType};
 use tokio::sync::{mpsc, RwLock};
 use tokio::time::interval;
-use tracing::{trace, warn};
+use tracing::{info, instrument, trace, warn};
 
 use app_error::AppError;
 use database::collab::CollabStorage;
@@ -59,6 +59,9 @@ where
   pub async fn run(self, mut destroy_group_rx: mpsc::Receiver<Arc<RwLock<Collab>>>) {
     let mut interval = interval(self.persistence_interval);
     loop {
+      // delay 30 seconds before the first save. We don't want to save immediately after the collab is created
+      tokio::time::sleep(Duration::from_secs(30)).await;
+
       tokio::select! {
         _ = interval.tick() => {
           if self.attempt_save().await.is_err() {
@@ -91,14 +94,13 @@ where
 
   /// return true if the collab has been dropped. Otherwise, return false
   async fn attempt_save(&self) -> Result<(), AppError> {
-    if self.edit_state.is_new() && self.save(true).await.is_ok() {
-      self.edit_state.set_is_new(false);
-      return Ok(());
-    }
+    trace!("collab:{} edit state: {}", self.object_id, self.edit_state);
 
     // Check if conditions for saving to disk are not met
     if self.edit_state.should_save_to_disk() {
-      self.save(false).await?;
+      if let Err(err) = self.save(self.edit_state.is_new()).await {
+        warn!("fail to write: {}:{}", self.object_id, err);
+      }
     }
     Ok(())
   }
@@ -117,10 +119,12 @@ where
       get_encode_collab(&workspace_id, &object_id, &lock, &collab_type)?
     };
     if let Some(indexer) = &self.indexer {
-      let embeddings = indexer
+      if let Ok(embeddings) = indexer
         .index(&object_id, params.encoded_collab_v1.clone())
-        .await?;
-      params.embeddings = embeddings;
+        .await
+      {
+        params.embeddings = embeddings;
+      }
     }
 
     self

--- a/services/appflowy-collaborate/src/group/persistence.rs
+++ b/services/appflowy-collaborate/src/group/persistence.rs
@@ -6,7 +6,7 @@ use collab::preclude::Collab;
 use collab_entity::{validate_data_for_folder, CollabType};
 use tokio::sync::{mpsc, RwLock};
 use tokio::time::interval;
-use tracing::{info, instrument, trace, warn};
+use tracing::{trace, warn};
 
 use app_error::AppError;
 use database::collab::CollabStorage;

--- a/services/appflowy-collaborate/src/group/plugin/history_plugin.rs
+++ b/services/appflowy-collaborate/src/group/plugin/history_plugin.rs
@@ -27,6 +27,7 @@ impl<S> HistoryPlugin<S>
 where
   S: CollabStorage,
 {
+  #[allow(dead_code)]
   pub fn new(
     workspace_id: String,
     object_id: String,

--- a/services/appflowy-collaborate/src/group/plugin/mod.rs
+++ b/services/appflowy-collaborate/src/group/plugin/mod.rs
@@ -1,3 +1,1 @@
 mod history_plugin;
-
-pub use history_plugin::*;

--- a/services/appflowy-collaborate/src/snapshot/snapshot_control.rs
+++ b/services/appflowy-collaborate/src/snapshot/snapshot_control.rs
@@ -15,7 +15,7 @@ use futures_util::StreamExt;
 use chrono::{DateTime, Utc};
 
 use collab_rt_protocol::validate_encode_collab;
-use sqlx::{Acquire, PgPool};
+use sqlx::PgPool;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -35,6 +35,7 @@ pub enum SnapshotCommand {
 }
 
 #[derive(Clone)]
+// #[deprecated(note = "snapshot is implemented in the appflowy-history")]
 pub struct SnapshotControl {
   cache: SnapshotCache,
   command_sender: SnapshotCommandSender,
@@ -180,9 +181,7 @@ impl SnapshotControl {
   }
 
   async fn latest_snapshot_time(&self, oid: &str) -> Result<Option<DateTime<Utc>>, AppError> {
-    let mut pool_conn = self.pg_pool.acquire().await?;
-    let conn = pool_conn.acquire().await?;
-    let time = latest_snapshot_time(oid, conn).await?;
+    let time = latest_snapshot_time(oid, &self.pg_pool).await?;
     Ok(time)
   }
 }


### PR DESCRIPTION
1. Do not trigger write before server receive sync step2 from client.
2. Upgrade appflowy collab that remove undo redo in `Document` by default
3. Deprecated history plugin