### PR TITLE
chore: try to fix inifinite sync

### DIFF
--- a/libs/client-api/src/collab_sync/sync_control.rs
+++ b/libs/client-api/src/collab_sync/sync_control.rs
@@ -222,7 +222,7 @@ where
       },
       Some(sv) => {
         trace!(
-          "🔥{} start init sync, reason:{}",
+          "🔥{} start init sync with state vector, reason:{}",
           &sync_object.object_id,
           reason
         );

--- a/libs/collab-rt-protocol/src/message.rs
+++ b/libs/collab-rt-protocol/src/message.rs
@@ -258,7 +258,7 @@ pub enum RTProtocolError {
 
   #[error("Missing Updates")]
   MissUpdates {
-    /// - `state_vector_v1`: Contains the last known state vector from the client. If `None`,
+    /// - `state_vector_v1`: Contains the last known state vector from the Collab. If `None`,
     ///   this indicates that the receiver needs to perform a full initialization synchronization starting from sync step 0.
     ///
     /// The receiver uses this information to determine how to recover from the error,

--- a/libs/collab-rt-protocol/src/protocol.rs
+++ b/libs/collab-rt-protocol/src/protocol.rs
@@ -68,9 +68,9 @@ impl CollabSyncProtocol for ClientSyncProtocol {
             update.missing.is_empty()
           );
         }
-        // let state_vector_v1 = update.missing.encode_v1();
+        let state_vector_v1 = txn.state_vector().encode_v1();
         Err(RTProtocolError::MissUpdates {
-          state_vector_v1: None,
+          state_vector_v1: Some(state_vector_v1),
           reason: "client miss updates".to_string(),
         })
       },

--- a/services/appflowy-collaborate/src/group/protocol.rs
+++ b/services/appflowy-collaborate/src/group/protocol.rs
@@ -67,8 +67,9 @@ impl CollabSyncProtocol for ServerSyncProtocol {
         // let state_vector_v1 = update.missing.encode_v1();
         // for the moment, we don't need to send missing updates to the client. passing None
         // instead, which will trigger a sync step 0 on client
+        let state_vector_v1 = txn.state_vector().encode_v1();
         Err(RTProtocolError::MissUpdates {
-          state_vector_v1: None,
+          state_vector_v1: Some(state_vector_v1),
           reason: "server miss updates".to_string(),
         })
       },


### PR DESCRIPTION
1. client initiates a sync process.
2. server responds with sync step 2.
3. client applies the update from sync step 2 but return a "client missing update" error. As a result, the server never receives the updates from the client.

This PR return current `txn` state vector when missing update. Client will calculate missing updates for this state vector