### PR TITLE
chore: remove redundant metrics collector

### DIFF
--- a/services/appflowy-collaborate/src/group/broadcast.rs
+++ b/services/appflowy-collaborate/src/group/broadcast.rs
@@ -1,5 +1,4 @@
 use std::borrow::BorrowMut;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 
 use anyhow::anyhow;
@@ -29,7 +28,7 @@ use collab_rt_protocol::{Message, MessageReader, MSG_SYNC, MSG_SYNC_UPDATE};
 use crate::error::RealtimeError;
 use crate::group::group_init::EditState;
 use crate::group::protocol::ServerSyncProtocol;
-use crate::metrics::CollabMetricsCalculate;
+use crate::metrics::CollabRealtimeMetrics;
 
 pub trait CollabUpdateStreaming: 'static + Send + Sync {
   fn send_update(&self, update: Vec<u8>) -> Result<(), RealtimeError>;
@@ -186,7 +185,7 @@ impl CollabBroadcast {
     mut sink: Sink,
     mut stream: Stream,
     collab: Weak<RwLock<Collab>>,
-    metrics_calculate: CollabMetricsCalculate,
+    metrics_calculate: CollabRealtimeMetrics,
   ) -> Subscription
   where
     Sink: SinkExt<CollabMessage> + Clone + Send + Sync + Unpin + 'static,
@@ -280,7 +279,7 @@ async fn handle_client_messages<Sink>(
   message_map: MessageByObjectId,
   sink: &mut Sink,
   collab: Arc<RwLock<dyn BorrowMut<Collab> + Send + Sync + 'static>>,
-  metrics_calculate: &CollabMetricsCalculate,
+  metrics_calculate: &CollabRealtimeMetrics,
   edit_state: &Arc<EditState>,
 ) where
   Sink: SinkExt<CollabMessage> + Unpin + 'static,
@@ -338,7 +337,7 @@ async fn handle_one_client_message(
   object_id: &str,
   collab_msg: &ClientCollabMessage,
   collab: &Arc<RwLock<dyn BorrowMut<Collab> + Send + Sync + 'static>>,
-  metrics_calculate: &CollabMetricsCalculate,
+  metrics_calculate: &CollabRealtimeMetrics,
   edit_state: &Arc<EditState>,
 ) -> Result<CollabAck, RealtimeError> {
   let msg_id = collab_msg.msg_id();
@@ -383,13 +382,11 @@ async fn handle_one_message_payload(
   msg_id: MsgId,
   payload: &Bytes,
   collab: &Arc<RwLock<dyn BorrowMut<Collab> + Send + Sync + 'static>>,
-  metrics_calculate: &CollabMetricsCalculate,
+  metrics_calculate: &CollabRealtimeMetrics,
   edit_state: &Arc<EditState>,
 ) -> Result<CollabAck, RealtimeError> {
   let payload = payload.clone();
-  metrics_calculate
-    .acquire_collab_lock_count
-    .fetch_add(1, Ordering::Relaxed);
+  metrics_calculate.acquire_collab_lock_count.inc();
 
   // Spawn a blocking task to handle the message
   let result = handle_message(
@@ -419,7 +416,7 @@ async fn handle_message(
   payload: &Bytes,
   message_origin: &CollabOrigin,
   collab: &Arc<RwLock<dyn BorrowMut<Collab> + Send + Sync + 'static>>,
-  metrics_calculate: &CollabMetricsCalculate,
+  metrics_calculate: &CollabRealtimeMetrics,
   object_id: &str,
   msg_id: MsgId,
   edit_state: &Arc<EditState>,
@@ -436,9 +433,7 @@ async fn handle_message(
         match handle_message_follow_protocol(message_origin, &ServerSyncProtocol, collab, msg).await
         {
           Ok(payload) => {
-            metrics_calculate
-              .apply_update_count
-              .fetch_add(1, Ordering::Relaxed);
+            metrics_calculate.apply_update_count.inc();
             // One ClientCollabMessage can have multiple Yrs [Message] in it, but we only need to
             // send one ack back to the client.
             if ack_response.is_none() {
@@ -454,9 +449,7 @@ async fn handle_message(
             }
           },
           Err(err) => {
-            metrics_calculate
-              .apply_update_failed_count
-              .fetch_add(1, Ordering::Relaxed);
+            metrics_calculate.apply_update_failed_count.inc();
             let code = ack_code_from_error(&err);
             let payload = match err {
               RTProtocolError::MissUpdates {

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -30,7 +30,7 @@ use crate::error::RealtimeError;
 use crate::group::broadcast::{CollabBroadcast, CollabUpdateStreaming, Subscription};
 use crate::group::persistence::GroupPersistence;
 use crate::indexer::Indexer;
-use crate::metrics::CollabMetricsCalculate;
+use crate::metrics::CollabRealtimeMetrics;
 
 /// A group used to manage a single [Collab] object
 pub struct CollabGroup {
@@ -44,7 +44,7 @@ pub struct CollabGroup {
   /// A list of subscribers to this group. Each subscriber will receive updates from the
   /// broadcast.
   subscribers: DashMap<RealtimeUser, Subscription>,
-  metrics_calculate: CollabMetricsCalculate,
+  metrics_calculate: CollabRealtimeMetrics,
   destroy_group_tx: mpsc::Sender<Arc<RwLock<Collab>>>,
 }
 
@@ -62,7 +62,7 @@ impl CollabGroup {
     object_id: String,
     collab_type: CollabType,
     collab: Arc<RwLock<Collab>>,
-    metrics_calculate: CollabMetricsCalculate,
+    metrics_calculate: CollabRealtimeMetrics,
     storage: Arc<S>,
     is_new_collab: bool,
     collab_redis_stream: Arc<CollabRedisStream>,

--- a/services/appflowy-collaborate/src/group/manager.rs
+++ b/services/appflowy-collaborate/src/group/manager.rs
@@ -24,13 +24,13 @@ use crate::error::{CreateGroupFailedReason, RealtimeError};
 use crate::group::group_init::CollabGroup;
 use crate::group::state::GroupManagementState;
 use crate::indexer::IndexerProvider;
-use crate::metrics::CollabMetricsCalculate;
+use crate::metrics::CollabRealtimeMetrics;
 
 pub struct GroupManager<S, AC> {
   state: GroupManagementState,
   storage: Arc<S>,
   access_control: Arc<AC>,
-  metrics_calculate: CollabMetricsCalculate,
+  metrics_calculate: CollabRealtimeMetrics,
   collab_redis_stream: Arc<CollabRedisStream>,
   control_event_stream: Arc<Mutex<StreamGroup>>,
   persistence_interval: Duration,
@@ -48,7 +48,7 @@ where
   pub async fn new(
     storage: Arc<S>,
     access_control: Arc<AC>,
-    metrics_calculate: CollabMetricsCalculate,
+    metrics_calculate: CollabRealtimeMetrics,
     collab_stream: CollabRedisStream,
     persistence_interval: Duration,
     edit_state_max_count: u32,


### PR DESCRIPTION
This PR removes `CollabMetricsCalculate` - the same feature is provided by `CollabRealtimeMetrics` which works exactly the same way (`Gauge` internally is equivalent to `AtomcI64`, see the [source code](https://docs.rs/prometheus-client/latest/src/prometheus_client/metrics/gauge.rs.html#45-48)) so we don't need to update it every 2min in a separate task.