### PR TITLE
chore: reconnect realtime metrics

### DIFF
--- a/services/appflowy-collaborate/src/group/broadcast.rs
+++ b/services/appflowy-collaborate/src/group/broadcast.rs
@@ -185,7 +185,7 @@ impl CollabBroadcast {
     mut sink: Sink,
     mut stream: Stream,
     collab: Weak<RwLock<Collab>>,
-    metrics_calculate: CollabRealtimeMetrics,
+    metrics_calculate: Arc<CollabRealtimeMetrics>,
   ) -> Subscription
   where
     Sink: SinkExt<CollabMessage> + Clone + Send + Sync + Unpin + 'static,

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -44,7 +44,7 @@ pub struct CollabGroup {
   /// A list of subscribers to this group. Each subscriber will receive updates from the
   /// broadcast.
   subscribers: DashMap<RealtimeUser, Subscription>,
-  metrics_calculate: CollabRealtimeMetrics,
+  metrics_calculate: Arc<CollabRealtimeMetrics>,
   destroy_group_tx: mpsc::Sender<Arc<RwLock<Collab>>>,
 }
 
@@ -62,7 +62,7 @@ impl CollabGroup {
     object_id: String,
     collab_type: CollabType,
     collab: Arc<RwLock<Collab>>,
-    metrics_calculate: CollabRealtimeMetrics,
+    metrics_calculate: Arc<CollabRealtimeMetrics>,
     storage: Arc<S>,
     is_new_collab: bool,
     collab_redis_stream: Arc<CollabRedisStream>,

--- a/services/appflowy-collaborate/src/group/manager.rs
+++ b/services/appflowy-collaborate/src/group/manager.rs
@@ -30,7 +30,7 @@ pub struct GroupManager<S, AC> {
   state: GroupManagementState,
   storage: Arc<S>,
   access_control: Arc<AC>,
-  metrics_calculate: CollabRealtimeMetrics,
+  metrics_calculate: Arc<CollabRealtimeMetrics>,
   collab_redis_stream: Arc<CollabRedisStream>,
   control_event_stream: Arc<Mutex<StreamGroup>>,
   persistence_interval: Duration,
@@ -48,7 +48,7 @@ where
   pub async fn new(
     storage: Arc<S>,
     access_control: Arc<AC>,
-    metrics_calculate: CollabRealtimeMetrics,
+    metrics_calculate: Arc<CollabRealtimeMetrics>,
     collab_stream: CollabRedisStream,
     persistence_interval: Duration,
     edit_state_max_count: u32,

--- a/services/appflowy-collaborate/src/group/state.rs
+++ b/services/appflowy-collaborate/src/group/state.rs
@@ -19,11 +19,11 @@ pub(crate) struct GroupManagementState {
   group_by_object_id: Arc<DashMap<String, Arc<CollabGroup>>>,
   /// Keep track of all [Collab] objects that a user is subscribed to.
   editing_by_user: Arc<DashMap<RealtimeUser, HashSet<Editing>>>,
-  metrics_calculate: CollabRealtimeMetrics,
+  metrics_calculate: Arc<CollabRealtimeMetrics>,
 }
 
 impl GroupManagementState {
-  pub(crate) fn new(metrics_calculate: CollabRealtimeMetrics) -> Self {
+  pub(crate) fn new(metrics_calculate: Arc<CollabRealtimeMetrics>) -> Self {
     Self {
       group_by_object_id: Arc::new(DashMap::new()),
       editing_by_user: Arc::new(DashMap::new()),


### PR DESCRIPTION
Reconnect realtime collab metrics, that were detached from the registry in #770