### PR TITLE
fix: add doc note for mandatory smtps

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -33,6 +33,7 @@ GOTRUE_RATE_LIMIT_EMAIL_SENT=100
 # If you intend to use mail confirmation, you need to set the SMTP configuration below
 # You would then need to set GOTRUE_MAILER_AUTOCONFIRM=false
 # Check for logs in gotrue service if there are any issues with email confirmation
+# Note that smtps will be used for port 465, otherwise plain smtp with optional STARTTLS
 GOTRUE_SMTP_HOST=smtp.gmail.com
 GOTRUE_SMTP_PORT=465
 GOTRUE_SMTP_USER=email_sender@some_company.com
@@ -87,6 +88,7 @@ APPFLOWY_S3_BUCKET=appflowy
 #APPFLOWY_S3_REGION=us-east-1
 
 # AppFlowy Cloud Mailer
+# Note that smtps (TLS) is always required, even for ports other than 465
 APPFLOWY_MAILER_SMTP_HOST=smtp.gmail.com
 APPFLOWY_MAILER_SMTP_PORT=465
 APPFLOWY_MAILER_SMTP_USERNAME=email_sender@some_company.com

--- a/dev.env
+++ b/dev.env
@@ -21,6 +21,7 @@ GOTRUE_MAILER_AUTOCONFIRM=false
 GOTRUE_RATE_LIMIT_EMAIL_SENT=1000
 
 # if you enable mail confirmation, you need to set the SMTP configuration below
+# Note that smtps will be used for port 465, otherwise plain smtp with optional STARTTLS
 GOTRUE_SMTP_HOST=smtp.gmail.com
 GOTRUE_SMTP_PORT=465
 GOTRUE_SMTP_USER=email_sender@some_company.com
@@ -78,6 +79,7 @@ APPFLOWY_S3_BUCKET=appflowy
 #APPFLOWY_S3_REGION=us-east-1
 
 # AppFlowy Cloud Mailer
+# Note that smtps (TLS) is always required, even for ports other than 465
 APPFLOWY_MAILER_SMTP_HOST=smtp.gmail.com
 APPFLOWY_MAILER_SMTP_USERNAME=notify@appflowy.io
 APPFLOWY_MAILER_SMTP_PASSWORD=email_sender_password


### PR DESCRIPTION
This documents the findings from #537 in both .env templates: smtps (TLS) is mandatory for `APPFLOWY_MAILER_SMTP`.
