### PR TITLE
feat: Support Railway Deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,10 @@ RUN apt-get update -y \
 COPY --from=builder /app/target/release/appflowy_cloud /usr/local/bin/appflowy_cloud
 ENV APP_ENVIRONMENT production
 ENV RUST_BACKTRACE 1
+
+ARG APPFLOWY_APPLICATION_PORT
+ARG PORT
+ENV PORT=${APPFLOWY_APPLICATION_PORT:-${PORT:-8000}}
+EXPOSE $PORT
+
 CMD ["appflowy_cloud"]

--- a/admin_frontend/Dockerfile
+++ b/admin_frontend/Dockerfile
@@ -40,4 +40,10 @@ COPY --from=builder /app/target/release/admin_frontend /usr/local/bin/admin_fron
 COPY --from=builder /app/admin_frontend/assets /app/assets
 ENV RUST_BACKTRACE 1
 ENV RUST_LOG info
+
+ARG ADMIN_FRONTEND_PORT
+ARG PORT
+ENV PORT=${ADMIN_FRONTEND_PORT:-${PORT:-3000}}
+EXPOSE $PORT
+
 CMD ["admin_frontend"]

--- a/admin_frontend/src/config.rs
+++ b/admin_frontend/src/config.rs
@@ -2,21 +2,26 @@ use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub struct Config {
+  pub host: String,
+  pub port: u16,
   pub redis_url: String,
   pub gotrue_url: String,
   pub appflowy_cloud_url: String,
 }
 
 impl Config {
-  pub fn from_env() -> Self {
-    Config {
+  pub fn from_env() ->  Result<Config, anyhow::Error> {
+    let cfg = Config {
+      host: get_or_default("ADMIN_FRONTEND_HOST", "0.0.0.0"),
+      port: get_or_default("ADMIN_FRONTEND_PORT", "3000").parse()?,
       redis_url: get_or_default("ADMIN_FRONTEND_REDIS_URL", "redis://localhost:6379"),
       gotrue_url: get_or_default("ADMIN_FRONTEND_GOTRUE_URL", "http://localhost:9999"),
       appflowy_cloud_url: get_or_default(
         "ADMIN_FRONTEND_APPFLOWY_CLOUD_URL",
         "http://localhost:8000",
       ),
-    }
+    };
+    Ok(cfg)
   }
 }
 

--- a/admin_frontend/src/main.rs
+++ b/admin_frontend/src/main.rs
@@ -27,7 +27,7 @@ async fn main() {
     .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
     .init();
 
-  let config = Config::from_env();
+  let config = Config::from_env().unwrap();
   info!("config loaded: {:?}", &config);
 
   let gotrue_client = gotrue::api::Client::new(reqwest::Client::new(), &config.gotrue_url);
@@ -65,7 +65,8 @@ async fn main() {
     .nest_service("/web-api", web_api_router)
     .nest_service("/assets", ServeDir::new("assets"));
 
-  let listener = TcpListener::bind("0.0.0.0:3000")
+  let address = format!("{}:{}", config.host, config.port);
+  let listener = TcpListener::bind(address)
     .await
     .expect("failed to bind to port");
   info!("listening on: {:?}", listener);


### PR DESCRIPTION
This PR makes some minor changes to support deploying on railway: 
- allows setting the host and port for the admin service via an environment variable. This allows using ipv6 (this was already done for af-cloud)
- exposes container ports for af-cloud and admin via environment variables

Testing: 
- Tested on my own deployments on railway