### PR TITLE
feat: Support s3 as published collab storage

### DIFF
--- a/.sqlx/query-2dda0bc4d9486a49c0af00d8ee4408c970a2ba3533217c130281e7db5a4e3d6b.json
+++ b/.sqlx/query-2dda0bc4d9486a49c0af00d8ee4408c970a2ba3533217c130281e7db5a4e3d6b.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT workspace_id, metadata\n      FROM af_published_collab\n      WHERE view_id = $1\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "workspace_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "2dda0bc4d9486a49c0af00d8ee4408c970a2ba3533217c130281e7db5a4e3d6b"
+}

--- a/.sqlx/query-d205df7e6a71335bc457f560fa5a941c738cd1f8e7c3369b0b24bb34fbb1c6eb.json
+++ b/.sqlx/query-d205df7e6a71335bc457f560fa5a941c738cd1f8e7c3369b0b24bb34fbb1c6eb.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT workspace_id, view_id\n      FROM af_published_collab\n      WHERE workspace_id = (SELECT workspace_id FROM af_workspace WHERE publish_namespace = $1)\n      AND publish_name = $2\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "workspace_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "view_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "d205df7e6a71335bc457f560fa5a941c738cd1f8e7c3369b0b24bb34fbb1c6eb"
+}

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -952,6 +952,12 @@ pub struct PublishCollabMetadata<Metadata> {
   pub metadata: Metadata,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PublishCollabKey {
+  pub workspace_id: uuid::Uuid,
+  pub view_id: uuid::Uuid,
+}
+
 #[derive(Debug)]
 pub struct PublishCollabItem<Meta, Data> {
   pub meta: PublishCollabMetadata<Meta>,

--- a/libs/database/src/file/file_storage.rs
+++ b/libs/database/src/file/file_storage.rs
@@ -32,6 +32,8 @@ pub trait BucketClient {
 
   async fn delete_blob(&self, object_key: &str) -> Result<Self::ResponseData, AppError>;
 
+  async fn delete_blobs(&self, object_key: Vec<String>) -> Result<Self::ResponseData, AppError>;
+
   async fn get_blob(&self, object_key: &str) -> Result<Self::ResponseData, AppError>;
 
   async fn create_upload(

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -1,6 +1,5 @@
 use authentication::jwt::OptionalUserUuid;
 use database_entity::dto::AFWorkspaceSettingsChange;
-use database_entity::dto::PublishCollabItem;
 use database_entity::dto::PublishInfo;
 use std::collections::HashMap;
 
@@ -127,20 +126,6 @@ pub async fn get_workspace_publish_namespace(
   workspace_id: &Uuid,
 ) -> Result<String, AppError> {
   select_workspace_publish_namespace(pg_pool, workspace_id).await
-}
-
-pub async fn publish_collabs(
-  pg_pool: &PgPool,
-  workspace_id: &Uuid,
-  publisher_uuid: &Uuid,
-  publish_items: &[PublishCollabItem<serde_json::Value, Vec<u8>>],
-) -> Result<(), AppError> {
-  for publish_item in publish_items {
-    check_collab_publish_name(publish_item.meta.publish_name.as_str())?;
-  }
-  insert_or_replace_publish_collab_metas(pg_pool, workspace_id, publisher_uuid, publish_items)
-    .await?;
-  Ok(())
 }
 
 pub async fn get_published_collab(
@@ -714,25 +699,5 @@ async fn check_if_user_is_allowed_to_delete_comment(
       "User is not allowed to delete this comment".to_string(),
     ));
   }
-  Ok(())
-}
-
-fn check_collab_publish_name(publish_name: &str) -> Result<(), AppError> {
-  // Check len
-  if publish_name.len() > 128 {
-    return Err(AppError::InvalidRequest(
-      "Publish name must be at most 128 characters long".to_string(),
-    ));
-  }
-
-  // Only contain alphanumeric characters and hyphens
-  for c in publish_name.chars() {
-    if !c.is_alphanumeric() && c != '-' {
-      return Err(AppError::InvalidRequest(
-        "Publish name must only contain alphanumeric characters and hyphens".to_string(),
-      ));
-    }
-  }
-
   Ok(())
 }

--- a/src/biz/workspace/publish.rs
+++ b/src/biz/workspace/publish.rs
@@ -1,67 +1,29 @@
+use std::sync::Arc;
+
 use app_error::AppError;
+use async_trait::async_trait;
 use database_entity::dto::{PublishCollabItem, PublishInfo};
+use shared_entity::dto::publish_dto::PublishViewMetaData;
 use sqlx::PgPool;
+use tracing::debug;
 use uuid::Uuid;
 
 use database::{
+  file::{s3_client_impl::AwsS3BucketClientImpl, BucketClient, ResponseBlob},
   publish::{
     delete_published_collabs, insert_or_replace_publish_collabs, select_publish_collab_meta,
     select_published_collab_blob, select_published_collab_info,
-    select_user_is_collab_publisher_for_all_views, select_workspace_publish_namespace,
-    select_workspace_publish_namespace_exists, update_workspace_publish_namespace,
+    select_published_collab_workspace_view_id, select_published_data_for_view_id,
+    select_published_metadata_for_view_id, select_user_is_collab_publisher_for_all_views,
+    select_workspace_publish_namespace, select_workspace_publish_namespace_exists,
+    update_workspace_publish_namespace,
   },
   workspace::select_user_is_workspace_owner,
 };
 
+use crate::api::metrics::PublishedCollabMetrics;
+
 use super::ops::check_workspace_owner;
-
-pub async fn publish_collabs(
-  pg_pool: &PgPool,
-  workspace_id: &Uuid,
-  publisher_uuid: &Uuid,
-  publish_items: Vec<PublishCollabItem<serde_json::Value, Vec<u8>>>,
-) -> Result<(), AppError> {
-  for publish_item in &publish_items {
-    check_collab_publish_name(publish_item.meta.publish_name.as_str())?;
-  }
-  insert_or_replace_publish_collabs(pg_pool, workspace_id, publisher_uuid, publish_items).await?;
-  Ok(())
-}
-
-pub async fn get_published_collab(
-  pg_pool: &PgPool,
-  publish_namespace: &str,
-  publish_name: &str,
-) -> Result<serde_json::Value, AppError> {
-  let metadata = select_publish_collab_meta(pg_pool, publish_namespace, publish_name).await?;
-  Ok(metadata)
-}
-
-pub async fn get_published_collab_blob(
-  pg_pool: &PgPool,
-  publish_namespace: &str,
-  publish_name: &str,
-) -> Result<Vec<u8>, AppError> {
-  select_published_collab_blob(pg_pool, publish_namespace, publish_name).await
-}
-
-pub async fn get_published_collab_info(
-  pg_pool: &PgPool,
-  view_id: &Uuid,
-) -> Result<PublishInfo, AppError> {
-  select_published_collab_info(pg_pool, view_id).await
-}
-
-pub async fn delete_published_workspace_collab(
-  pg_pool: &PgPool,
-  workspace_id: &Uuid,
-  view_ids: &[Uuid],
-  user_uuid: &Uuid,
-) -> Result<(), AppError> {
-  check_workspace_owner_or_publisher(pg_pool, user_uuid, workspace_id, view_ids).await?;
-  delete_published_collabs(pg_pool, workspace_id, view_ids).await?;
-  Ok(())
-}
 
 async fn check_workspace_owner_or_publisher(
   pg_pool: &PgPool,
@@ -101,6 +63,10 @@ fn check_collab_publish_name(publish_name: &str) -> Result<(), AppError> {
   }
 
   Ok(())
+}
+
+fn get_collab_s3_key(workspace_id: &Uuid, view_id: &Uuid) -> String {
+  format!("published-collab/{}/{}", workspace_id, view_id)
 }
 
 pub async fn set_workspace_namespace(
@@ -153,4 +119,303 @@ async fn check_workspace_namespace(new_namespace: &str) -> Result<(), AppError> 
   // TODO: add more checks for reserved words
 
   Ok(())
+}
+
+#[async_trait]
+pub trait PublishedCollabStore: Sync + Send + 'static {
+  async fn publish_collabs(
+    &self,
+    published_items: Vec<PublishCollabItem<serde_json::Value, Vec<u8>>>,
+    workspace_id: &Uuid,
+    user_uuid: &Uuid,
+  ) -> Result<(), AppError>;
+
+  async fn get_collab_with_view_metadata_by_view_id(
+    &self,
+    view_id: &Uuid,
+  ) -> Result<Option<(PublishViewMetaData, Vec<u8>)>, AppError>;
+
+  async fn get_collab_metadata(
+    &self,
+    publish_namespace: &str,
+    publish_name: &str,
+  ) -> Result<serde_json::Value, AppError>;
+
+  async fn get_collab_publish_info(&self, view_id: &Uuid) -> Result<PublishInfo, AppError>;
+
+  async fn get_collab_blob_by_publish_namespace(
+    &self,
+    publish_namespace: &str,
+    publish_name: &str,
+  ) -> Result<Vec<u8>, AppError>;
+
+  async fn delete_collab(
+    &self,
+    workspace_id: &Uuid,
+    view_ids: &[Uuid],
+    user_uuid: &Uuid,
+  ) -> Result<(), AppError>;
+}
+
+pub struct PublishedCollabPostgresStore {
+  metrics: Arc<PublishedCollabMetrics>,
+  pg_pool: PgPool,
+}
+
+impl PublishedCollabPostgresStore {
+  pub fn new(metrics: Arc<PublishedCollabMetrics>, pg_pool: PgPool) -> Self {
+    Self { metrics, pg_pool }
+  }
+}
+
+#[async_trait]
+impl PublishedCollabStore for PublishedCollabPostgresStore {
+  async fn publish_collabs(
+    &self,
+    publish_items: Vec<PublishCollabItem<serde_json::Value, Vec<u8>>>,
+    workspace_id: &Uuid,
+    user_uuid: &Uuid,
+  ) -> Result<(), AppError> {
+    for publish_item in &publish_items {
+      check_collab_publish_name(publish_item.meta.publish_name.as_str())?;
+    }
+    let publish_items_batch_size = publish_items.len() as i64;
+    let result =
+      insert_or_replace_publish_collabs(&self.pg_pool, workspace_id, user_uuid, publish_items)
+        .await;
+    if result.is_err() {
+      self
+        .metrics
+        .incr_failure_write_count(publish_items_batch_size);
+    } else {
+      self
+        .metrics
+        .incr_success_write_count(publish_items_batch_size);
+    }
+    result
+  }
+
+  async fn get_collab_metadata(
+    &self,
+    publish_namespace: &str,
+    publish_name: &str,
+  ) -> Result<serde_json::Value, AppError> {
+    let metadata =
+      select_publish_collab_meta(&self.pg_pool, publish_namespace, publish_name).await?;
+    Ok(metadata)
+  }
+
+  async fn get_collab_with_view_metadata_by_view_id(
+    &self,
+    view_id: &Uuid,
+  ) -> Result<Option<(PublishViewMetaData, Vec<u8>)>, AppError> {
+    let result = match select_published_data_for_view_id(&self.pg_pool, view_id).await? {
+      Some((js_val, blob)) => {
+        let metadata = serde_json::from_value(js_val)?;
+        Ok(Some((metadata, blob)))
+      },
+      None => Ok(None),
+    };
+    if result.is_err() {
+      self.metrics.incr_failure_read_count(1);
+    } else {
+      self.metrics.incr_success_read_count(1);
+    }
+    result
+  }
+
+  async fn get_collab_publish_info(&self, view_id: &Uuid) -> Result<PublishInfo, AppError> {
+    select_published_collab_info(&self.pg_pool, view_id).await
+  }
+
+  async fn get_collab_blob_by_publish_namespace(
+    &self,
+    publish_namespace: &str,
+    publish_name: &str,
+  ) -> Result<Vec<u8>, AppError> {
+    let result = select_published_collab_blob(&self.pg_pool, publish_namespace, publish_name).await;
+    if result.is_err() {
+      self.metrics.incr_failure_read_count(1);
+    } else {
+      self.metrics.incr_success_read_count(1);
+    }
+    result
+  }
+
+  async fn delete_collab(
+    &self,
+    workspace_id: &Uuid,
+    view_ids: &[Uuid],
+    user_uuid: &Uuid,
+  ) -> Result<(), AppError> {
+    check_workspace_owner_or_publisher(&self.pg_pool, user_uuid, workspace_id, view_ids).await?;
+    delete_published_collabs(&self.pg_pool, workspace_id, view_ids).await?;
+    Ok(())
+  }
+}
+
+pub struct PublishedCollabS3StoreWithPostgresFallback {
+  metrics: Arc<PublishedCollabMetrics>,
+  pg_pool: PgPool,
+  bucket_client: AwsS3BucketClientImpl,
+}
+
+impl PublishedCollabS3StoreWithPostgresFallback {
+  pub fn new(
+    metrics: Arc<PublishedCollabMetrics>,
+    pg_pool: PgPool,
+    bucket_client: AwsS3BucketClientImpl,
+  ) -> Self {
+    Self {
+      metrics,
+      pg_pool,
+      bucket_client,
+    }
+  }
+}
+
+#[async_trait]
+impl PublishedCollabStore for PublishedCollabS3StoreWithPostgresFallback {
+  async fn publish_collabs(
+    &self,
+    publish_items: Vec<PublishCollabItem<serde_json::Value, Vec<u8>>>,
+    workspace_id: &Uuid,
+    user_uuid: &Uuid,
+  ) -> Result<(), AppError> {
+    let publish_items_batch_size = publish_items.len() as i64;
+    let mut handles: Vec<tokio::task::JoinHandle<()>> = vec![];
+    for publish_item in &publish_items {
+      check_collab_publish_name(publish_item.meta.publish_name.as_str())?;
+      let object_key = get_collab_s3_key(workspace_id, &publish_item.meta.view_id);
+      let data = publish_item.data.clone();
+      let bucket_client = self.bucket_client.clone();
+      let metrics = self.metrics.clone();
+      let handle = tokio::spawn(async move {
+        let result = bucket_client.put_blob(&object_key, &data).await;
+        if let Err(err) = result {
+          debug!("Failed to publish collab to S3: {}", err);
+        } else {
+          metrics.incr_success_write_count(1);
+        }
+      });
+      handles.push(handle);
+    }
+    for handle in handles {
+      handle.await?;
+    }
+
+    let result =
+      insert_or_replace_publish_collabs(&self.pg_pool, workspace_id, user_uuid, publish_items)
+        .await;
+    if result.is_err() {
+      self
+        .metrics
+        .incr_failure_write_count(publish_items_batch_size);
+    } else {
+      self
+        .metrics
+        .incr_fallback_write_count(publish_items_batch_size);
+    }
+    result
+  }
+
+  async fn get_collab_metadata(
+    &self,
+    publish_namespace: &str,
+    publish_name: &str,
+  ) -> Result<serde_json::Value, AppError> {
+    let metadata =
+      select_publish_collab_meta(&self.pg_pool, publish_namespace, publish_name).await?;
+    Ok(metadata)
+  }
+
+  async fn get_collab_with_view_metadata_by_view_id(
+    &self,
+    view_id: &Uuid,
+  ) -> Result<Option<(PublishViewMetaData, Vec<u8>)>, AppError> {
+    let result = select_published_metadata_for_view_id(&self.pg_pool, view_id).await?;
+    match result {
+      Some((workspace_id, js_val)) => {
+        let metadata = serde_json::from_value(js_val)?;
+        let object_key = get_collab_s3_key(&workspace_id, view_id);
+        match self.bucket_client.get_blob(&object_key).await {
+          Ok(resp) => {
+            self.metrics.incr_success_read_count(1);
+            Ok(Some((metadata, resp.to_blob())))
+          },
+          Err(_) => {
+            let result = match select_published_data_for_view_id(&self.pg_pool, view_id).await? {
+              Some((js_val, blob)) => {
+                let metadata = serde_json::from_value(js_val)?;
+                Ok(Some((metadata, blob)))
+              },
+              None => Ok(None),
+            };
+            if result.is_err() {
+              self.metrics.incr_failure_read_count(1);
+            } else {
+              self.metrics.incr_fallback_read_count(1);
+            }
+            result
+          },
+        }
+      },
+      None => {
+        self.metrics.incr_success_read_count(1);
+        Ok(None)
+      },
+    }
+  }
+
+  async fn get_collab_publish_info(&self, view_id: &Uuid) -> Result<PublishInfo, AppError> {
+    select_published_collab_info(&self.pg_pool, view_id).await
+  }
+
+  async fn get_collab_blob_by_publish_namespace(
+    &self,
+    publish_namespace: &str,
+    publish_name: &str,
+  ) -> Result<Vec<u8>, AppError> {
+    let collab_key =
+      select_published_collab_workspace_view_id(&self.pg_pool, publish_namespace, publish_name)
+        .await?;
+    let object_key = get_collab_s3_key(&collab_key.workspace_id, &collab_key.view_id);
+    let resp = self.bucket_client.get_blob(&object_key).await;
+    match resp {
+      Ok(resp) => {
+        self.metrics.incr_success_read_count(1);
+        Ok(resp.to_blob())
+      },
+      Err(err) => {
+        debug!(
+          "Failed to get published collab blob {} from S3 due to {}",
+          object_key, err
+        );
+        let result =
+          select_published_collab_blob(&self.pg_pool, publish_namespace, publish_name).await;
+        if result.is_err() {
+          self.metrics.incr_failure_read_count(1);
+        } else {
+          self.metrics.incr_fallback_read_count(1);
+        }
+        result
+      },
+    }
+  }
+
+  async fn delete_collab(
+    &self,
+    workspace_id: &Uuid,
+    view_ids: &[Uuid],
+    user_uuid: &Uuid,
+  ) -> Result<(), AppError> {
+    check_workspace_owner_or_publisher(&self.pg_pool, user_uuid, workspace_id, view_ids).await?;
+    let object_keys = view_ids
+      .iter()
+      .map(|view_id| get_collab_s3_key(workspace_id, view_id))
+      .collect::<Vec<String>>();
+    self.bucket_client.delete_blobs(object_keys).await?;
+    delete_published_collabs(&self.pg_pool, workspace_id, view_ids).await?;
+    Ok(())
+  }
 }

--- a/src/biz/workspace/publish_dup.rs
+++ b/src/biz/workspace/publish_dup.rs
@@ -17,7 +17,11 @@ use collab_rt_entity::{ClientCollabMessage, UpdateSync};
 use collab_rt_protocol::{Message, SyncMessage};
 use database::collab::GetCollabOrigin;
 use database::collab::{select_workspace_database_oid, CollabStorage};
+use database::file::s3_client_impl::AwsS3BucketClientImpl;
+use database::file::BucketClient;
+use database::file::ResponseBlob;
 use database::publish::select_published_data_for_view_id;
+use database::publish::select_published_metadata_for_view_id;
 use database_entity::dto::CollabParams;
 use shared_entity::dto::publish_dto::{PublishDatabaseData, PublishViewInfo, PublishViewMetaData};
 use shared_entity::dto::workspace_dto;
@@ -38,6 +42,7 @@ use crate::biz::collab::ops::get_latest_collab_encoded;
 #[allow(clippy::too_many_arguments)]
 pub async fn duplicate_published_collab_to_workspace(
   pg_pool: &PgPool,
+  bucket_client: AwsS3BucketClientImpl,
   collab_storage: Arc<CollabAccessControlStorage>,
   dest_uid: i64,
   publish_view_id: String,
@@ -46,6 +51,7 @@ pub async fn duplicate_published_collab_to_workspace(
 ) -> Result<(), AppError> {
   let copier = PublishCollabDuplicator::new(
     pg_pool.clone(),
+    bucket_client,
     collab_storage.clone(),
     dest_uid,
     dest_workspace_id,
@@ -87,6 +93,8 @@ pub struct PublishCollabDuplicator {
   /// for fetching published data
   /// and writing them to dest workspace
   pg_pool: PgPool,
+  /// for fetching published data from s3
+  bucket_client: AwsS3BucketClientImpl,
   /// user initiating the duplication
   duplicator_uid: i64,
   /// workspace to duplicate into
@@ -98,6 +106,7 @@ pub struct PublishCollabDuplicator {
 impl PublishCollabDuplicator {
   pub fn new(
     pg_pool: PgPool,
+    bucket_client: AwsS3BucketClientImpl,
     collab_storage: Arc<CollabAccessControlStorage>,
     dest_uid: i64,
     dest_workspace_id: String,
@@ -113,8 +122,8 @@ impl PublishCollabDuplicator {
       duplicated_db_main_view: HashMap::new(),
       duplicated_db_view: HashMap::new(),
       duplicated_db_row: HashMap::new(),
-
       pg_pool,
+      bucket_client,
       collab_storage,
       duplicator_uid: dest_uid,
       dest_workspace_id,
@@ -147,6 +156,7 @@ impl PublishCollabDuplicator {
       collabs_to_insert,
       ts_now: _,
       pg_pool,
+      bucket_client: _,
       duplicator_uid,
       dest_workspace_id,
       dest_view_id,
@@ -1098,10 +1108,21 @@ impl PublishCollabDuplicator {
     &self,
     view_id: &uuid::Uuid,
   ) -> Result<Option<(PublishViewMetaData, Vec<u8>)>, AppError> {
-    match select_published_data_for_view_id(&self.pg_pool, view_id).await? {
-      Some((js_val, blob)) => {
+    let result = select_published_metadata_for_view_id(&self.pg_pool, view_id).await?;
+    match result {
+      Some((workspace_id, js_val)) => {
         let metadata = serde_json::from_value(js_val)?;
-        Ok(Some((metadata, blob)))
+        let object_key = format!("published-collab/{}/{}", workspace_id, view_id);
+        match self.bucket_client.get_blob(&object_key).await {
+          Ok(resp) => Ok(Some((metadata, resp.to_blob()))),
+          Err(_) => match select_published_data_for_view_id(&self.pg_pool, view_id).await? {
+            Some((js_val, blob)) => {
+              let metadata = serde_json::from_value(js_val)?;
+              Ok(Some((metadata, blob)))
+            },
+            None => Ok(None),
+          },
+        }
       },
       None => Ok(None),
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,8 +26,9 @@ use snowflake::Snowflake;
 use tonic_proto::history::history_client::HistoryClient;
 use workspace_access::WorkspaceAccessControlImpl;
 
-use crate::api::metrics::RequestMetrics;
+use crate::api::metrics::{PublishedCollabMetrics, RequestMetrics};
 use crate::biz::pg_listener::PgListeners;
+use crate::biz::workspace::publish::PublishedCollabStore;
 use crate::config::config::Config;
 use crate::mailer::Mailer;
 
@@ -45,6 +46,7 @@ pub struct AppState {
   pub collab_access_control: CollabAccessControlImpl,
   pub workspace_access_control: WorkspaceAccessControlImpl,
   pub bucket_storage: Arc<S3BucketStorage>,
+  pub published_collab_store: Arc<dyn PublishedCollabStore>,
   pub bucket_client: AwsS3BucketClientImpl,
   pub pg_listeners: Arc<PgListeners>,
   pub access_control: AccessControl,
@@ -123,6 +125,7 @@ pub struct AppMetrics {
   pub realtime_metrics: Arc<CollabRealtimeMetrics>,
   pub access_control_metrics: Arc<AccessControlMetrics>,
   pub collab_metrics: Arc<CollabMetrics>,
+  pub published_collab_metrics: Arc<PublishedCollabMetrics>,
 }
 
 impl Default for AppMetrics {
@@ -138,12 +141,14 @@ impl AppMetrics {
     let realtime_metrics = Arc::new(CollabRealtimeMetrics::register(&mut registry));
     let access_control_metrics = Arc::new(AccessControlMetrics::register(&mut registry));
     let collab_metrics = Arc::new(CollabMetrics::register(&mut registry));
+    let published_collab_metrics = Arc::new(PublishedCollabMetrics::register(&mut registry));
     Self {
       registry: Arc::new(registry),
       request_metrics,
       realtime_metrics,
       access_control_metrics,
       collab_metrics,
+      published_collab_metrics,
     }
   }
 }


### PR DESCRIPTION
This PR will introduce a new trait, PublishedCollabStore, which will handle the different operations for publish collabs. Two different implementation has been introduced: one write and read exclusively from postgres as per status quo, the other will write to both s3 and postgres, and read from s3 with postgres as fallback. 