### PR TITLE
feat: add additional fields to FolderView and support different root id

### DIFF
--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -139,6 +139,9 @@ pub enum AppError {
 
   #[error("{0}")]
   InvalidPublishedOutline(String),
+
+  #[error("{0}")]
+  InvalidFolderView(String),
 }
 
 impl AppError {
@@ -204,6 +207,7 @@ impl AppError {
       AppError::StringLengthLimitReached(_) => ErrorCode::StringLengthLimitReached,
       AppError::InvalidContentType(_) => ErrorCode::InvalidContentType,
       AppError::InvalidPublishedOutline(_) => ErrorCode::InvalidPublishedOutline,
+      AppError::InvalidFolderView(_) => ErrorCode::InvalidFolderView,
     }
   }
 }
@@ -323,6 +327,7 @@ pub enum ErrorCode {
   SingleUploadLimitExceeded = 1037,
   AppleRevokeTokenError = 1038,
   InvalidPublishedOutline = 1039,
+  InvalidFolderView = 1040,
 }
 
 impl ErrorCode {

--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -687,12 +687,16 @@ impl Client {
     &self,
     workspace_id: &str,
     depth: Option<u32>,
+    root_view_id: Option<String>,
   ) -> Result<FolderView, AppResponseError> {
     let url = format!("{}/api/workspace/{}/folder", self.base_url, workspace_id);
     let resp = self
       .http_client_with_auth(Method::GET, &url)
       .await?
-      .query(&QueryWorkspaceFolder { depth })
+      .query(&QueryWorkspaceFolder {
+        depth,
+        root_view_id,
+      })
       .send()
       .await?;
     log_request_id(&resp);

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -135,6 +135,10 @@ pub struct FolderView {
   pub icon: Option<ViewIcon>,
   pub is_space: bool,
   pub is_private: bool,
+  pub is_published: bool,
+  pub layout: ViewLayout,
+  pub created_at: DateTime<Utc>,
+  pub last_edited_time: DateTime<Utc>,
   /// contains fields like `is_space`, and font information
   pub extra: Option<serde_json::Value>,
   pub children: Vec<FolderView>,
@@ -178,6 +182,7 @@ pub struct QueryWorkspaceParam {
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct QueryWorkspaceFolder {
   pub depth: Option<u32>,
+  pub root_view_id: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1382,17 +1382,25 @@ async fn get_workspace_usage_handler(
 
 async fn get_workspace_folder_handler(
   user_uuid: UserUuid,
-  workspace_id: web::Path<String>,
+  workspace_id: web::Path<Uuid>,
   state: Data<AppState>,
   query: web::Query<QueryWorkspaceFolder>,
 ) -> Result<Json<AppResponse<FolderView>>> {
   let depth = query.depth.unwrap_or(1);
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  let workspace_id = workspace_id.into_inner();
+  let root_view_id = if let Some(root_view_id) = query.root_view_id.as_ref() {
+    root_view_id.to_string()
+  } else {
+    workspace_id.to_string()
+  };
   let folder_view = biz::collab::ops::get_user_workspace_structure(
     state.collab_access_control_storage.clone(),
+    &state.pg_pool,
     uid,
-    workspace_id.into_inner(),
+    workspace_id,
     depth,
+    &root_view_id,
   )
   .await?;
   Ok(Json(AppResponse::Ok().with_data(folder_view)))

--- a/tests/workspace/publish.rs
+++ b/tests/workspace/publish.rs
@@ -740,7 +740,7 @@ async fn duplicate_to_workspace_references() {
     let workspace_id_2 = client_2.workspace_id().await;
     let fv = client_2
       .api_client
-      .get_workspace_folder(&workspace_id_2, Some(5))
+      .get_workspace_folder(&workspace_id_2, Some(5), None)
       .await
       .unwrap();
 
@@ -765,7 +765,7 @@ async fn duplicate_to_workspace_references() {
 
     let fv = client_2
       .api_client
-      .get_workspace_folder(&workspace_id_2, Some(5))
+      .get_workspace_folder(&workspace_id_2, Some(5), None)
       .await
       .unwrap();
 
@@ -847,7 +847,7 @@ async fn duplicate_to_workspace_doc_inline_database() {
 
     let fv = client_2
       .api_client
-      .get_workspace_folder(&workspace_id_2, Some(5))
+      .get_workspace_folder(&workspace_id_2, Some(5), None)
       .await
       .unwrap();
 
@@ -873,7 +873,7 @@ async fn duplicate_to_workspace_doc_inline_database() {
     {
       let fv = client_2
         .api_client
-        .get_workspace_folder(&workspace_id_2, Some(5))
+        .get_workspace_folder(&workspace_id_2, Some(5), None)
         .await
         .unwrap();
       let doc_3_fv = fv
@@ -913,7 +913,8 @@ async fn duplicate_to_workspace_doc_inline_database() {
     )
     .unwrap();
 
-    let folder_view = collab_folder_to_folder_view(&folder, 5);
+    let folder_view =
+      collab_folder_to_folder_view(&workspace_id_2, &folder, 5, &HashSet::default()).unwrap();
     let doc_3_fv = folder_view
       .children
       .into_iter()
@@ -1040,7 +1041,7 @@ async fn duplicate_to_workspace_db_embedded_in_doc() {
 
     let fv = client_2
       .api_client
-      .get_workspace_folder(&workspace_id_2, Some(5))
+      .get_workspace_folder(&workspace_id_2, Some(5), None)
       .await
       .unwrap();
 
@@ -1064,7 +1065,7 @@ async fn duplicate_to_workspace_db_embedded_in_doc() {
     {
       let fv = client_2
         .api_client
-        .get_workspace_folder(&workspace_id_2, Some(5))
+        .get_workspace_folder(&workspace_id_2, Some(5), None)
         .await
         .unwrap();
       let doc_with_embedded_db = fv
@@ -1151,7 +1152,7 @@ async fn duplicate_to_workspace_db_with_relation() {
 
     let fv = client_2
       .api_client
-      .get_workspace_folder(&workspace_id_2, Some(5))
+      .get_workspace_folder(&workspace_id_2, Some(5), None)
       .await
       .unwrap();
 
@@ -1178,7 +1179,7 @@ async fn duplicate_to_workspace_db_with_relation() {
     {
       let fv = client_2
         .api_client
-        .get_workspace_folder(&workspace_id_2, Some(5))
+        .get_workspace_folder(&workspace_id_2, Some(5), None)
         .await
         .unwrap();
       let db_with_rel_col = fv

--- a/tests/workspace/workspace_folder.rs
+++ b/tests/workspace/workspace_folder.rs
@@ -7,8 +7,27 @@ async fn get_workpace_folder() {
   assert_eq!(workspaces.len(), 1);
   let workspace_id = workspaces[0].workspace_id.to_string();
 
-  let folder_view = c.get_workspace_folder(&workspace_id, None).await.unwrap();
+  let folder_view = c
+    .get_workspace_folder(&workspace_id, None, None)
+    .await
+    .unwrap();
   assert_eq!(folder_view.name, "Workspace");
   assert_eq!(folder_view.children[0].name, "General");
   assert_eq!(folder_view.children[0].children.len(), 0);
+  let folder_view = c
+    .get_workspace_folder(&workspace_id, Some(2), None)
+    .await
+    .unwrap();
+  assert_eq!(folder_view.name, "Workspace");
+  assert_eq!(folder_view.children[0].name, "General");
+  assert_eq!(folder_view.children[0].children.len(), 2);
+  let folder_view = c
+    .get_workspace_folder(
+      &workspace_id,
+      Some(1),
+      Some(folder_view.children[0].view_id.clone()),
+    )
+    .await
+    .unwrap();
+  assert_eq!(folder_view.children.len(), 2);
 }


### PR DESCRIPTION
Fixes:
- Originally, the default folder view is return if a view cannot be retrieved by id from the Folder struct. The appflowy web frontend might display the wrong result. This PR filter out such views from the output tree instead.
- There are child views which their parent view id attribute does not match the parent view's id. Such case is due to malformed encoded collab and should have been filtered out.

New features:
- A new query parameter named root_view_id, that allows the caller to iterate the folder view from any view, not just the root workspace id. Will be used in the future by the appflowy web frontend.
- Add is_published and layout fields to the FolderView.
- Return error if no valid nodes are found in the folder view tree