### PR TITLE
feat: add retrieve sections endpoints

### DIFF
--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -4,6 +4,7 @@ use client_api_entity::auth_dto::DeleteUserQuery;
 use client_api_entity::workspace_dto::FolderView;
 use client_api_entity::workspace_dto::QueryWorkspaceFolder;
 use client_api_entity::workspace_dto::QueryWorkspaceParam;
+use client_api_entity::workspace_dto::SectionItems;
 use client_api_entity::AuthProvider;
 use client_api_entity::CollabType;
 use gotrue::grant::PasswordGrant;
@@ -715,6 +716,57 @@ impl Client {
       .await?;
     log_request_id(&resp);
     AppResponse::<AFWorkspace>::from_response(resp)
+      .await?
+      .into_data()
+  }
+
+  #[instrument(level = "info", skip_all, err)]
+  pub async fn get_workspace_favorite(
+    &self,
+    workspace_id: &str,
+  ) -> Result<SectionItems, AppResponseError> {
+    let url = format!("{}/api/workspace/{}/favorite", self.base_url, workspace_id);
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    log_request_id(&resp);
+    AppResponse::<SectionItems>::from_response(resp)
+      .await?
+      .into_data()
+  }
+
+  #[instrument(level = "info", skip_all, err)]
+  pub async fn get_workspace_recent(
+    &self,
+    workspace_id: &str,
+  ) -> Result<SectionItems, AppResponseError> {
+    let url = format!("{}/api/workspace/{}/recent", self.base_url, workspace_id);
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    log_request_id(&resp);
+    AppResponse::<SectionItems>::from_response(resp)
+      .await?
+      .into_data()
+  }
+
+  #[instrument(level = "info", skip_all, err)]
+  pub async fn get_workspace_trash(
+    &self,
+    workspace_id: &str,
+  ) -> Result<SectionItems, AppResponseError> {
+    let url = format!("{}/api/workspace/{}/trash", self.base_url, workspace_id);
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    log_request_id(&resp);
+    AppResponse::<SectionItems>::from_response(resp)
       .await?
       .into_data()
   }

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -144,6 +144,11 @@ pub struct FolderView {
   pub children: Vec<FolderView>,
 }
 
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct SectionItems {
+  pub views: Vec<FolderView>,
+}
+
 #[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum IconType {

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -38,6 +38,9 @@ use crate::api::util::PayloadReader;
 use crate::api::util::{compress_type_from_header_value, device_id_from_headers, CollabValidator};
 use crate::api::ws::RealtimeServerAddr;
 use crate::biz;
+use crate::biz::collab::ops::{
+  get_user_favorite_folder_views, get_user_recent_folder_views, get_user_trash_folder_views,
+};
 use crate::biz::workspace;
 use crate::biz::workspace::ops::{
   create_comment_on_published_view, create_reaction_on_comment, get_comments_on_published_view,
@@ -174,6 +177,11 @@ pub fn workspace_scope() -> Scope {
     .service(
       web::resource("/{workspace_id}/folder").route(web::get().to(get_workspace_folder_handler)),
     )
+    .service(web::resource("/{workspace_id}/recent").route(web::get().to(get_recent_views_handler)))
+    .service(
+      web::resource("/{workspace_id}/favorite").route(web::get().to(get_favorite_views_handler)),
+    )
+    .service(web::resource("/{workspace_id}/trash").route(web::get().to(get_trash_views_handler)))
     .service(
       web::resource("/published-outline/{publish_namespace}")
         .route(web::get().to(get_workspace_publish_outline_handler)),
@@ -1320,6 +1328,65 @@ async fn get_workspace_folder_handler(
   )
   .await?;
   Ok(Json(AppResponse::Ok().with_data(folder_view)))
+}
+
+async fn get_recent_views_handler(
+  user_uuid: UserUuid,
+  workspace_id: web::Path<Uuid>,
+  state: Data<AppState>,
+) -> Result<Json<AppResponse<SectionItems>>> {
+  let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  let workspace_id = workspace_id.into_inner();
+  let folder_views = get_user_recent_folder_views(
+    state.collab_access_control_storage.clone(),
+    &state.pg_pool,
+    uid,
+    workspace_id,
+  )
+  .await?;
+  let section_items = SectionItems {
+    views: folder_views,
+  };
+  Ok(Json(AppResponse::Ok().with_data(section_items)))
+}
+
+async fn get_favorite_views_handler(
+  user_uuid: UserUuid,
+  workspace_id: web::Path<Uuid>,
+  state: Data<AppState>,
+) -> Result<Json<AppResponse<SectionItems>>> {
+  let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  let workspace_id = workspace_id.into_inner();
+  let folder_views = get_user_favorite_folder_views(
+    state.collab_access_control_storage.clone(),
+    &state.pg_pool,
+    uid,
+    workspace_id,
+  )
+  .await?;
+  let section_items = SectionItems {
+    views: folder_views,
+  };
+  Ok(Json(AppResponse::Ok().with_data(section_items)))
+}
+
+async fn get_trash_views_handler(
+  user_uuid: UserUuid,
+  workspace_id: web::Path<Uuid>,
+  state: Data<AppState>,
+) -> Result<Json<AppResponse<SectionItems>>> {
+  let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  let workspace_id = workspace_id.into_inner();
+  let folder_views = get_user_trash_folder_views(
+    state.collab_access_control_storage.clone(),
+    uid,
+    workspace_id,
+  )
+  .await?;
+  let section_items = SectionItems {
+    views: folder_views,
+  };
+  Ok(Json(AppResponse::Ok().with_data(section_items)))
 }
 
 async fn get_workspace_publish_outline_handler(

--- a/src/biz/collab/ops.rs
+++ b/src/biz/collab/ops.rs
@@ -4,6 +4,7 @@ use app_error::AppError;
 use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
 use collab_entity::CollabType;
 use collab_entity::EncodedCollab;
+use collab_folder::SectionItem;
 use collab_folder::{CollabOrigin, Folder};
 use database::collab::{CollabStorage, GetCollabOrigin};
 use database::publish::select_published_view_ids_for_workspace;
@@ -27,6 +28,7 @@ use database_entity::dto::{
 };
 
 use super::folder_view::collab_folder_to_folder_view;
+use super::folder_view::section_items_to_folder_view;
 use super::publish_outline::collab_folder_to_published_outline;
 
 /// Create a new collab member
@@ -154,6 +156,93 @@ pub async fn get_collab_member_list(
   params.validate()?;
   let collab_member = database::collab::select_collab_members(&params.object_id, pg_pool).await?;
   Ok(collab_member)
+}
+
+pub async fn get_user_favorite_folder_views(
+  collab_storage: Arc<CollabAccessControlStorage>,
+  pg_pool: &PgPool,
+  uid: i64,
+  workspace_id: Uuid,
+) -> Result<Vec<FolderView>, AppError> {
+  let folder = get_latest_collab_folder(
+    collab_storage,
+    GetCollabOrigin::User { uid },
+    &workspace_id.to_string(),
+  )
+  .await?;
+  let publish_view_ids = select_published_view_ids_for_workspace(pg_pool, workspace_id).await?;
+  let publish_view_ids: HashSet<String> = publish_view_ids
+    .into_iter()
+    .map(|id| id.to_string())
+    .collect();
+  let deleted_section_item_ids: Vec<String> = folder
+    .get_my_trash_sections()
+    .iter()
+    .map(|s| s.id.clone())
+    .collect();
+  let favorite_section_items: Vec<SectionItem> = folder
+    .get_my_favorite_sections()
+    .into_iter()
+    .filter(|s| !deleted_section_item_ids.contains(&s.id))
+    .collect();
+  Ok(section_items_to_folder_view(
+    &favorite_section_items,
+    &folder,
+    &publish_view_ids,
+  ))
+}
+
+pub async fn get_user_recent_folder_views(
+  collab_storage: Arc<CollabAccessControlStorage>,
+  pg_pool: &PgPool,
+  uid: i64,
+  workspace_id: Uuid,
+) -> Result<Vec<FolderView>, AppError> {
+  let folder = get_latest_collab_folder(
+    collab_storage,
+    GetCollabOrigin::User { uid },
+    &workspace_id.to_string(),
+  )
+  .await?;
+  let deleted_section_item_ids: Vec<String> = folder
+    .get_my_trash_sections()
+    .iter()
+    .map(|s| s.id.clone())
+    .collect();
+  let recent_section_items: Vec<SectionItem> = folder
+    .get_my_recent_sections()
+    .into_iter()
+    .filter(|s| !deleted_section_item_ids.contains(&s.id))
+    .collect();
+  let publish_view_ids = select_published_view_ids_for_workspace(pg_pool, workspace_id).await?;
+  let publish_view_ids: HashSet<String> = publish_view_ids
+    .into_iter()
+    .map(|id| id.to_string())
+    .collect();
+  Ok(section_items_to_folder_view(
+    &recent_section_items,
+    &folder,
+    &publish_view_ids,
+  ))
+}
+
+pub async fn get_user_trash_folder_views(
+  collab_storage: Arc<CollabAccessControlStorage>,
+  uid: i64,
+  workspace_id: Uuid,
+) -> Result<Vec<FolderView>, AppError> {
+  let folder = get_latest_collab_folder(
+    collab_storage,
+    GetCollabOrigin::User { uid },
+    &workspace_id.to_string(),
+  )
+  .await?;
+  let section_items = folder.get_my_trash_sections();
+  Ok(section_items_to_folder_view(
+    &section_items,
+    &folder,
+    &HashSet::default(),
+  ))
 }
 
 pub async fn get_user_workspace_structure(

--- a/tests/workspace/workspace_folder.rs
+++ b/tests/workspace/workspace_folder.rs
@@ -1,4 +1,7 @@
+use client_api::entity::{CreateCollabParams, QueryCollabParams};
 use client_api_test::generate_unique_registered_user_client;
+use collab::core::origin::CollabClient;
+use collab_folder::{CollabOrigin, Folder};
 
 #[tokio::test]
 async fn get_workpace_folder() {
@@ -30,4 +33,66 @@ async fn get_workpace_folder() {
     .await
     .unwrap();
   assert_eq!(folder_view.children.len(), 2);
+}
+
+#[tokio::test]
+async fn get_section_items() {
+  let (c, _user) = generate_unique_registered_user_client().await;
+  let user_workspace_info = c.get_user_workspace_info().await.unwrap();
+  let workspaces = c.get_workspaces().await.unwrap();
+  assert_eq!(workspaces.len(), 1);
+  let workspace_id = workspaces[0].workspace_id.to_string();
+  let folder_collab = c
+    .get_collab(QueryCollabParams::new(
+      workspace_id.clone(),
+      collab_entity::CollabType::Folder,
+      workspace_id.clone(),
+    ))
+    .await
+    .unwrap()
+    .encode_collab;
+  let uid = user_workspace_info.user_profile.uid;
+  let mut folder = Folder::from_collab_doc_state(
+    uid,
+    CollabOrigin::Client(CollabClient::new(uid, c.device_id.clone())),
+    folder_collab.into(),
+    &workspace_id,
+    vec![],
+  )
+  .unwrap();
+  let views = folder.get_views_belong_to(&workspace_id);
+  let new_favorite_id = views[0].children[0].id.clone();
+  let to_be_deleted_favorite_id = views[0].children[1].id.clone();
+  folder.add_favorite_view_ids(vec![
+    new_favorite_id.clone(),
+    to_be_deleted_favorite_id.clone(),
+  ]);
+  folder.add_trash_view_ids(vec![to_be_deleted_favorite_id.clone()]);
+  let recent_id = folder.get_views_belong_to(&new_favorite_id)[0].id.clone();
+  folder.add_recent_view_ids(vec![recent_id.clone()]);
+  let collab_type = collab_entity::CollabType::Folder;
+  c.update_collab(CreateCollabParams {
+    workspace_id: workspace_id.clone(),
+    collab_type: collab_type.clone(),
+    object_id: workspace_id.clone(),
+    encoded_collab_v1: folder
+      .encode_collab_v1(|collab| collab_type.validate_require_data(collab))
+      .unwrap()
+      .encode_to_bytes()
+      .unwrap(),
+  })
+  .await
+  .unwrap();
+  let favorite_section_items = c.get_workspace_favorite(&workspace_id).await.unwrap();
+  assert_eq!(favorite_section_items.views.len(), 1);
+  assert_eq!(favorite_section_items.views[0].view_id, new_favorite_id);
+  let trash_section_items = c.get_workspace_trash(&workspace_id).await.unwrap();
+  assert_eq!(trash_section_items.views.len(), 1);
+  assert_eq!(
+    trash_section_items.views[0].view_id,
+    to_be_deleted_favorite_id
+  );
+  let recent_section_items = c.get_workspace_recent(&workspace_id).await.unwrap();
+  assert_eq!(recent_section_items.views.len(), 1);
+  assert_eq!(recent_section_items.views[0].view_id, recent_id);
 }


### PR DESCRIPTION
Add endpoints to retrieve favorite, trash and recent views belonging to a workspace and the user who send the request.