### PR TITLE
Endpoint for server info

### DIFF
--- a/libs/shared-entity/Cargo.toml
+++ b/libs/shared-entity/Cargo.toml
@@ -20,11 +20,18 @@ database-entity.workspace = true
 collab-entity = { workspace = true }
 app-error = { workspace = true }
 chrono = "0.4.31"
-appflowy-ai-client = { workspace = true, default-features = false, features = ["dto"] }
+appflowy-ai-client = { workspace = true, default-features = false, features = [
+    "dto",
+] }
 pin-project = "1.1.5"
 
-actix-web = { version = "4.4.1", default-features = false, features = ["http2"], optional = true }
-validator = { version = "0.16", features = ["validator_derive", "derive"], optional = true }
+actix-web = { version = "4.4.1", default-features = false, features = [
+    "http2",
+], optional = true }
+validator = { version = "0.16", features = [
+    "validator_derive",
+    "derive",
+], optional = true }
 futures = "0.3.30"
 bytes = "1.6.0"
 log = "0.4.21"

--- a/libs/shared-entity/src/dto/mod.rs
+++ b/libs/shared-entity/src/dto/mod.rs
@@ -4,4 +4,5 @@ pub mod billing_dto;
 pub mod history_dto;
 pub mod publish_dto;
 pub mod search_dto;
+pub mod server_info_dto;
 pub mod workspace_dto;

--- a/libs/shared-entity/src/dto/server_info_dto.rs
+++ b/libs/shared-entity/src/dto/server_info_dto.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum SupportedClientFeatures {
+  // Supports Collab Params serialization using Protobuf
+  CollabParamsProtobuf,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ServerInfoResponseItem {
-  pub version: String,
+  pub supported_client_features: Vec<SupportedClientFeatures>,
+  pub minimum_supported_client_version: Option<String>,
 }

--- a/libs/shared-entity/src/dto/server_info_dto.rs
+++ b/libs/shared-entity/src/dto/server_info_dto.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ServerInfoResponseItem {
+  pub version: String,
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ pub mod file_storage;
 pub mod history;
 pub mod metrics;
 pub mod search;
+pub mod server_info;
 pub mod template;
 pub mod user;
 pub mod util;

--- a/src/api/server_info.rs
+++ b/src/api/server_info.rs
@@ -10,7 +10,8 @@ async fn server_info_handler() -> actix_web::Result<JsonAppResponse<ServerInfoRe
   Ok(
     AppResponse::Ok()
       .with_data(ServerInfoResponseItem {
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        supported_client_features: vec![],
+        minimum_supported_client_version: None,
       })
       .into(),
   )

--- a/src/api/server_info.rs
+++ b/src/api/server_info.rs
@@ -1,0 +1,17 @@
+use actix_web::{web, Scope};
+use shared_entity::dto::server_info_dto::ServerInfoResponseItem;
+use shared_entity::response::{AppResponse, JsonAppResponse};
+
+pub fn server_info_scope() -> Scope {
+  web::scope("/api/server").service(web::resource("").route(web::get().to(server_info_handler)))
+}
+
+async fn server_info_handler() -> actix_web::Result<JsonAppResponse<ServerInfoResponseItem>> {
+  Ok(
+    AppResponse::Ok()
+      .with_data(ServerInfoResponseItem {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+      })
+      .into(),
+  )
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -48,6 +48,7 @@ use crate::api::file_storage::file_storage_scope;
 use crate::api::history::history_scope;
 use crate::api::metrics::metrics_scope;
 use crate::api::search::search_scope;
+use crate::api::server_info::server_info_scope;
 use crate::api::template::template_scope;
 use crate::api::user::user_scope;
 use crate::api::workspace::{collab_scope, workspace_scope};
@@ -158,6 +159,7 @@ pub async fn run_actix_server(
       // .wrap(DecryptPayloadMiddleware)
       .wrap(access_control.clone())
       .wrap(RequestIdMiddleware)
+      .service(server_info_scope())
       .service(user_scope())
       .service(workspace_scope())
       .service(collab_scope())

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -4,6 +4,7 @@ mod collab_history;
 mod file_test;
 mod gotrue;
 mod search;
+mod server_info;
 mod sql_test;
 mod user;
 mod websocket;

--- a/tests/server_info/info.rs
+++ b/tests/server_info/info.rs
@@ -1,0 +1,9 @@
+use client_api_test::generate_unique_registered_user_client;
+
+#[tokio::test]
+async fn test_get_server_info() {
+  let (c, _) = generate_unique_registered_user_client().await;
+  c.get_server_info()
+    .await
+    .expect("Failed to get server info");
+}

--- a/tests/server_info/mod.rs
+++ b/tests/server_info/mod.rs
@@ -1,0 +1,1 @@
+mod info;


### PR DESCRIPTION
There are a few scenarios which it will be helpful for a client to be aware of the functionality currently supported by AppFlowy Cloud:

1. A user is using self hosting an older version of AppFlowy Cloud, which does not support some of the newer functionality introduced by the newer client. Having a server info endpoint will allow the client to either provide a fallback, or provide appropriate error message to the user.

2. A user is using an older version of AppFlowy client, which relies on functionality that is already deprecated by AppFlowy Cloud. By checking the features supported by the server, the client can prompt the user to upgrade the client version.