### PR TITLE
fix: allowed workspace owner only to view access request

### DIFF
--- a/src/api/access_request.rs
+++ b/src/api/access_request.rs
@@ -32,15 +32,18 @@ pub fn access_request_scope() -> Scope {
 }
 
 async fn get_access_request_handler(
-  _uuid: UserUuid,
+  uuid: UserUuid,
   access_request_id: web::Path<Uuid>,
   state: Data<AppState>,
 ) -> Result<JsonAppResponse<AccessRequest>> {
   let access_request_id = access_request_id.into_inner();
+  let uid = state.user_cache.get_user_uid(&uuid).await?;
   let access_request = get_access_request(
     &state.pg_pool,
     state.collab_access_control_storage.clone(),
     access_request_id,
+    *uuid,
+    uid,
   )
   .await?;
   Ok(Json(AppResponse::Ok().with_data(access_request)))

--- a/src/biz/access_request/ops.rs
+++ b/src/biz/access_request/ops.rs
@@ -73,9 +73,17 @@ pub async fn get_access_request(
   pg_pool: &PgPool,
   collab_storage: Arc<CollabAccessControlStorage>,
   access_request_id: Uuid,
+  user_uuid: Uuid,
+  user_uid: i64,
 ) -> Result<AccessRequest, AppError> {
   let access_request_with_view_id =
     select_access_request_by_request_id(pg_pool, access_request_id).await?;
+  if access_request_with_view_id.workspace.owner_uid != user_uid {
+    return Err(AppError::NotEnoughPermissions {
+      user: user_uuid.to_string(),
+      action: "get access request".to_string(),
+    });
+  }
   let folder = get_latest_collab_folder(
     collab_storage,
     GetCollabOrigin::Server,

--- a/tests/workspace/access_request.rs
+++ b/tests/workspace/access_request.rs
@@ -40,6 +40,13 @@ async fn access_request_test() {
     resp.unwrap_err().code,
     ErrorCode::AccessRequestAlreadyExists
   );
+  // Only workspace owner should be allowed to view access requests
+  let resp = requester_client
+    .get_access_request(access_request.request_id)
+    .await;
+  assert!(resp.is_err());
+  assert_eq!(resp.unwrap_err().code, ErrorCode::NotEnoughPermissions);
+
   let access_request_id = access_request.request_id;
   let access_request_to_be_approved = owner_client
     .get_access_request(access_request_id)


### PR DESCRIPTION
Returns NotEnoughPermission error when users other than the workspace owner is trying to view an access request. This is so that the web frontend can decide if a user should be able to access the approval landing page.