### PR TITLE
fix: add default serialization to owner email field

### DIFF
--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -574,6 +574,7 @@ pub struct AFWorkspace {
   pub database_storage_id: Uuid,
   pub owner_uid: i64,
   pub owner_name: String,
+  #[serde(default)]
   pub owner_email: String,
   pub workspace_type: i32,
   pub workspace_name: String,


### PR DESCRIPTION
Add default serialization to owner email field so that an AppFlowy client that use the latest API client won't throw an error when connecting to an older version of appflowy cloud.