### PR TITLE
chore: using copy to improve write speed of batch collab api endpoint

### DIFF
--- a/libs/database/src/collab/cache.rs
+++ b/libs/database/src/collab/cache.rs
@@ -179,7 +179,7 @@ impl CollabCache {
     Ok(encode_collab)
   }
 
-  pub async fn insert_encode_collab_in_disk(
+  pub async fn insert_encode_collab_to_disk(
     &self,
     workspace_id: &str,
     uid: &i64,
@@ -193,11 +193,7 @@ impl CollabCache {
     Ok(())
   }
 
-  /// Insert the encoded collab data into the memory cache.
-  pub async fn insert_encode_collab_data_in_mem(
-    &self,
-    params: &CollabParams,
-  ) -> Result<(), AppError> {
+  pub async fn insert_encode_collab_to_mem(&self, params: CollabParams) -> Result<(), AppError> {
     let timestamp = chrono::Utc::now().timestamp();
     self
       .mem_cache

--- a/libs/database/src/collab/cache.rs
+++ b/libs/database/src/collab/cache.rs
@@ -193,7 +193,7 @@ impl CollabCache {
     Ok(())
   }
 
-  pub async fn insert_encode_collab_to_mem(&self, params: CollabParams) -> Result<(), AppError> {
+  pub async fn insert_encode_collab_to_mem(&self, params: &CollabParams) -> Result<(), AppError> {
     let timestamp = chrono::Utc::now().timestamp();
     self
       .mem_cache

--- a/libs/database/src/collab/collab_storage.rs
+++ b/libs/database/src/collab/collab_storage.rs
@@ -76,7 +76,7 @@ pub trait CollabStorage: Send + Sync + 'static {
   /// if write_immediately is true, the data will be written to disk immediately. Otherwise, the data will
   /// be scheduled to be written to disk later.
   ///
-  async fn insert_or_update_collab(
+  async fn queue_insert_or_update_collab(
     &self,
     workspace_id: &str,
     uid: &i64,
@@ -84,11 +84,11 @@ pub trait CollabStorage: Send + Sync + 'static {
     write_immediately: bool,
   ) -> AppResult<()>;
 
-  async fn insert_new_collab(
+  async fn batch_insert_new_collab(
     &self,
     workspace_id: &str,
     uid: &i64,
-    params: CollabParams,
+    params: Vec<CollabParams>,
   ) -> AppResult<()>;
 
   /// Insert a new collaboration in the storage.
@@ -185,7 +185,7 @@ where
     self.as_ref().encode_collab_redis_query_state()
   }
 
-  async fn insert_or_update_collab(
+  async fn queue_insert_or_update_collab(
     &self,
     workspace_id: &str,
     uid: &i64,
@@ -194,19 +194,19 @@ where
   ) -> AppResult<()> {
     self
       .as_ref()
-      .insert_or_update_collab(workspace_id, uid, params, write_immediately)
+      .queue_insert_or_update_collab(workspace_id, uid, params, write_immediately)
       .await
   }
 
-  async fn insert_new_collab(
+  async fn batch_insert_new_collab(
     &self,
     workspace_id: &str,
     uid: &i64,
-    params: CollabParams,
+    params: Vec<CollabParams>,
   ) -> AppResult<()> {
     self
       .as_ref()
-      .insert_new_collab(workspace_id, uid, params)
+      .batch_insert_new_collab(workspace_id, uid, params)
       .await
   }
 

--- a/services/appflowy-collaborate/src/collab/queue.rs
+++ b/services/appflowy-collaborate/src/collab/queue.rs
@@ -103,7 +103,7 @@ impl StorageQueue {
     trace!("queuing {} object to pending write queue", params.object_id,);
     self
       .collab_cache
-      .insert_encode_collab_data_in_mem(params)
+      .insert_encode_collab_to_mem(params)
       .await?;
 
     let seq = self
@@ -456,7 +456,7 @@ async fn write_pending_to_disk(
       .execute(transaction.deref_mut())
       .await?;
     if let Err(_err) = collab_cache
-      .insert_encode_collab_in_disk(&record.workspace_id, &record.uid, params, &mut transaction)
+      .insert_encode_collab_to_disk(&record.workspace_id, &record.uid, params, &mut transaction)
       .await
     {
       sqlx::query(&format!("ROLLBACK TO SAVEPOINT {}", savepoint_name))

--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -234,7 +234,7 @@ where
     let cache = self.cache.clone();
     tokio::spawn(async move {
       for params in params_list {
-        let _ = cache.insert_encode_collab_to_mem(params).await;
+        let _ = cache.insert_encode_collab_to_mem(&params).await;
       }
     });
     Ok(())

--- a/services/appflowy-collaborate/src/collab/validator.rs
+++ b/services/appflowy-collaborate/src/collab/validator.rs
@@ -1,6 +1,6 @@
 use app_error::AppError;
 use async_trait::async_trait;
-use collab_rt_protocol::validate_encode_collab;
+use collab_rt_protocol::spawn_blocking_validate_encode_collab;
 use database_entity::dto::CollabParams;
 
 #[async_trait]
@@ -11,8 +11,12 @@ pub trait CollabValidator {
 #[async_trait]
 impl CollabValidator for CollabParams {
   async fn check_encode_collab(&self) -> Result<(), AppError> {
-    validate_encode_collab(&self.object_id, &self.encoded_collab_v1, &self.collab_type)
-      .await
-      .map_err(|err| AppError::NoRequiredData(err.to_string()))
+    spawn_blocking_validate_encode_collab(
+      &self.object_id,
+      &self.encoded_collab_v1,
+      &self.collab_type,
+    )
+    .await
+    .map_err(|err| AppError::NoRequiredData(err.to_string()))
   }
 }

--- a/services/appflowy-collaborate/src/group/persistence.rs
+++ b/services/appflowy-collaborate/src/group/persistence.rs
@@ -162,7 +162,7 @@ where
 
     self
       .storage
-      .insert_or_update_collab(&self.workspace_id, &self.uid, params, write_immediately)
+      .queue_insert_or_update_collab(&self.workspace_id, &self.uid, params, write_immediately)
       .await?;
     // Update the edit state on successful save
     self.edit_state.tick();

--- a/services/appflowy-collaborate/src/snapshot/snapshot_control.rs
+++ b/services/appflowy-collaborate/src/snapshot/snapshot_control.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, trace, warn};
 use validator::Validate;
 
 use app_error::AppError;
-use collab_rt_protocol::validate_encode_collab;
+use collab_rt_protocol::spawn_blocking_validate_encode_collab;
 use database::collab::{
   create_snapshot_and_maintain_limit, get_all_collab_snapshot_meta, latest_snapshot_time,
   select_snapshot, AppResult, COLLAB_SNAPSHOT_LIMIT, SNAPSHOT_PER_HOUR,
@@ -271,7 +271,7 @@ impl SnapshotCommandRunner {
     };
 
     // Validate collab data before processing
-    let result = validate_encode_collab(
+    let result = spawn_blocking_validate_encode_collab(
       &next_item.object_id,
       &encoded_collab_v1,
       &next_item.collab_type,

--- a/src/api/util.rs
+++ b/src/api/util.rs
@@ -7,7 +7,7 @@ use actix_web::HttpRequest;
 use appflowy_ai_client::dto::AIModel;
 use async_trait::async_trait;
 use byteorder::{ByteOrder, LittleEndian};
-use collab_rt_protocol::validate_encode_collab;
+use collab_rt_protocol::spawn_blocking_validate_encode_collab;
 use database_entity::dto::CollabParams;
 use std::str::FromStr;
 use tokio_stream::StreamExt;
@@ -74,9 +74,13 @@ pub trait CollabValidator {
 #[async_trait]
 impl CollabValidator for CollabParams {
   async fn check_encode_collab(&self) -> Result<(), AppError> {
-    validate_encode_collab(&self.object_id, &self.encoded_collab_v1, &self.collab_type)
-      .await
-      .map_err(|err| AppError::NoRequiredData(err.to_string()))
+    spawn_blocking_validate_encode_collab(
+      &self.object_id,
+      &self.encoded_collab_v1,
+      &self.collab_type,
+    )
+    .await
+    .map_err(|err| AppError::NoRequiredData(err.to_string()))
   }
 }
 

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -10,14 +10,14 @@ use futures_util::future::try_join_all;
 use prost::Message as ProstMessage;
 use rayon::prelude::*;
 use sqlx::types::uuid;
+use std::time::Instant;
 
 use tokio_stream::StreamExt;
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{error, event, info, instrument, trace};
+use tracing::{error, event, instrument, trace};
 use uuid::Uuid;
 use validator::Validate;
 
-use access_control::collab::CollabAccessControl;
 use app_error::AppError;
 use appflowy_collaborate::actix_ws::entities::ClientStreamMessage;
 use appflowy_collaborate::indexer::IndexerProvider;
@@ -619,7 +619,7 @@ async fn batch_create_collab_handler(
   let mut payload_buffer = Vec::new();
   let mut offset_len_list = Vec::new();
   let mut current_offset = 0;
-
+  let start = Instant::now();
   while let Some(item) = payload.next().await {
     if let Ok(bytes) = item {
       payload_buffer.extend_from_slice(&bytes);
@@ -644,39 +644,51 @@ async fn batch_create_collab_handler(
     }
   }
   // Perform decompression and processing in a Rayon thread pool
-  let mut collab_params_list = tokio::task::spawn_blocking(move || {
-    match compress_type {
-      CompressionType::Brotli { buffer_size } => {
-        let list = offset_len_list
-            .par_iter() // Use Rayon parallel iterator
-            .filter_map(|(offset, len)| {
-              let compressed_data = &payload_buffer[*offset..*offset + *len];
-              match decompress(compressed_data.to_vec(), buffer_size) {
-                Ok(decompressed_data) => {
-                  if let Ok(params) = CollabParams::from_bytes(&decompressed_data) {
-                    if params.validate().is_ok() {
-                      return Some(params);
-                    }
-                  }
-                },
-                Err(err) => {
-                  error!("Failed to decompress data: {:?}", err);
-                },
+  let mut collab_params_list = tokio::task::spawn_blocking(move || match compress_type {
+    CompressionType::Brotli { buffer_size } => offset_len_list
+      .into_par_iter()
+      .filter_map(|(offset, len)| {
+        let compressed_data = &payload_buffer[offset..offset + len];
+        match decompress(compressed_data.to_vec(), buffer_size) {
+          Ok(decompressed_data) => {
+            let params = CollabParams::from_bytes(&decompressed_data).ok()?;
+            if params.validate().is_ok() {
+              match validate_encode_collab(
+                &params.object_id,
+                &params.encoded_collab_v1,
+                &params.collab_type,
+              ) {
+                Ok(_) => Some(params),
+                Err(_) => None,
               }
+            } else {
               None
-            })
-            .collect::<Vec<_>>();
-        Ok::<_, AppError>(list)
-      },
-    }
+            }
+          },
+          Err(err) => {
+            error!("Failed to decompress data: {:?}", err);
+            None
+          },
+        }
+      })
+      .collect::<Vec<_>>(),
   })
   .await
-  .map_err(|_| AppError::InvalidRequest("Failed to decompress data".to_string()))??;
+  .map_err(|_| AppError::InvalidRequest("Failed to decompress data".to_string()))?;
 
-  info!("batch create {} collab objects", collab_params_list.len());
   if collab_params_list.is_empty() {
     return Err(AppError::InvalidRequest("Empty collab params list".to_string()).into());
   }
+
+  let total_size = collab_params_list
+    .iter()
+    .fold(0, |acc, x| acc + x.encoded_collab_v1.len());
+  event!(
+    tracing::Level::INFO,
+    "decompressed {} collab objects in {:?}",
+    collab_params_list.len(),
+    start.elapsed()
+  );
 
   if state
     .indexer_provider
@@ -692,28 +704,18 @@ async fn batch_create_collab_handler(
     }
   }
 
-  // Process each collab params
-  for params in collab_params_list {
-    let object_id = params.object_id.clone();
-    if validate_encode_collab(
-      &params.object_id,
-      &params.encoded_collab_v1,
-      &params.collab_type,
-    )
-    .await
-    .is_ok()
-    {
-      state
-        .collab_access_control_storage
-        .insert_new_collab(&workspace_id, &uid, params)
-        .await?;
+  let start = Instant::now();
+  state
+    .collab_access_control_storage
+    .batch_insert_new_collab(&workspace_id, &uid, collab_params_list)
+    .await?;
 
-      state
-        .collab_access_control
-        .update_access_level_policy(&uid, &object_id, AFAccessLevel::FullAccess)
-        .await?;
-    }
-  }
+  event!(
+    tracing::Level::INFO,
+    "inserted collab objects to disk in {:?}, total size:{}",
+    start.elapsed(),
+    total_size
+  );
 
   Ok(Json(AppResponse::Ok()))
 }
@@ -934,7 +936,7 @@ async fn update_collab_handler(
 
   state
     .collab_access_control_storage
-    .insert_or_update_collab(&workspace_id, &uid, params, false)
+    .queue_insert_or_update_collab(&workspace_id, &uid, params, false)
     .await?;
   Ok(AppResponse::Ok().into())
 }

--- a/tests/collab/collab_curd_test.rs
+++ b/tests/collab/collab_curd_test.rs
@@ -114,8 +114,8 @@ async fn batch_insert_collab_success_test() {
       QueryCollabResult::Success { encode_collab_v1 } => {
         assert_eq!(encode_collab_v1, &params.encoded_collab_v1)
       },
-      QueryCollabResult::Failed { .. } => {
-        panic!("Failed to get collab");
+      QueryCollabResult::Failed { error } => {
+        panic!("Failed to get collab: {:?}", error);
       },
     }
   }

--- a/tests/workspace/import_test.rs
+++ b/tests/workspace/import_test.rs
@@ -154,7 +154,7 @@ async fn import_zip(name: &str) -> (TestClient, String) {
   );
 
   // after the import task is completed, the new workspace should be visible
-  let mut workspaces = client.api_client.get_workspaces().await.unwrap();
+  let workspaces = client.api_client.get_workspaces().await.unwrap();
   assert_eq!(workspaces.len(), 2);
 
   let imported_workspace = workspaces


### PR DESCRIPTION
1. use rayon to do decompression and data validation
2. using copy instead of insert one by one to postgres in the background queue