### PR TITLE
feat: oauth login box

### DIFF
--- a/admin_frontend/assets/login.css
+++ b/admin_frontend/assets/login.css
@@ -28,6 +28,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .oauth-icon {

--- a/admin_frontend/templates/pages/login.html
+++ b/admin_frontend/templates/pages/login.html
@@ -90,19 +90,25 @@
 
     <h3>OAuth Login</h3>
     <div id="oauth-container">
-      {% for provider in oauth_providers %}
-      <div class="oauth-icon">
+      <div style="display: flex; flex-wrap: wrap; align-items: center; justify-content: center">
+        {% for provider in oauth_providers %}
         <a
           href="/gotrue/authorize?provider={{ provider|escape }}&redirect_to=/web/login"
+          style="text-decoration: none"
         >
-          <div
-            hx-get="../assets/{{ provider|escape }}/logo.html"
-            hx-trigger="load"
-            hx-swap="outerHTML"
-          ></div>
+          <div style="display: flex; align-items: center; border: 1px solid; margin: 4px; border-radius: 4px; height: 64px">
+            <div> &nbsp&nbsp{{ provider }} </div>
+            <div class="oauth-icon">
+              <div
+                hx-get="../assets/{{ provider|escape }}/logo.html"
+                hx-trigger="load"
+                hx-swap="outerHTML"
+              ></div>
+            </div>
+          </div>
         </a>
+        {% endfor %}
       </div>
-      {% endfor %}
     </div>
     {% endif %}
 


### PR DESCRIPTION
This PR supports allows other OAuth login in the admin web portal, even if the icon is not available.
When `GOTRUE_EXTERNAL_GITLAB_ENABLED=true` is set in gotrue service, a box will be shown for login.
This is useful for self-hosters who wants to use oauth authentication that gotrue provides in a more friendly manner.

![image](https://github.com/user-attachments/assets/9f674510-680a-4003-8f50-6545a68c1070)