### PR TITLE
feat: support appflowy web editing for document

### DIFF
--- a/libs/client-api/src/http_collab.rs
+++ b/libs/client-api/src/http_collab.rs
@@ -3,7 +3,7 @@ use crate::{blocking_brotli_compress, Client};
 use app_error::AppError;
 use client_api_entity::{
   BatchQueryCollabParams, BatchQueryCollabResult, CreateCollabParams, DeleteCollabParams,
-  QueryCollab,
+  QueryCollab, UpdateCollabWebParams,
 };
 use reqwest::Method;
 use shared_entity::response::{AppResponse, AppResponseError};
@@ -50,6 +50,26 @@ impl Client {
     );
     let resp = self
       .http_client_with_auth(Method::PUT, &url)
+      .await?
+      .json(&params)
+      .send()
+      .await?;
+    log_request_id(&resp);
+    AppResponse::<()>::from_response(resp).await?.into_error()
+  }
+
+  pub async fn update_web_collab(
+    &self,
+    workspace_id: &str,
+    object_id: &str,
+    params: UpdateCollabWebParams,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/v1/{}/collab/{}/web-update",
+      self.base_url, workspace_id, object_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
       .await?
       .json(&params)
       .send()

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -191,6 +191,12 @@ impl BatchCreateCollabParams {
   }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCollabWebParams {
+  pub doc_state: Vec<u8>,
+  pub collab_type: CollabType,
+}
+
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 pub struct DeleteCollabParams {
   #[validate(custom = "validate_not_empty_str")]

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -47,7 +47,7 @@ use crate::biz::workspace::ops::{
   create_comment_on_published_view, create_reaction_on_comment, get_comments_on_published_view,
   get_reactions_on_published_view, remove_comment_on_published_view, remove_reaction_on_comment,
 };
-use crate::biz::workspace::page_view::get_page_view_collab;
+use crate::biz::workspace::page_view::{get_page_view_collab, update_page_collab_data};
 use crate::domain::compression::{
   blocking_decompress, decompress, CompressionType, X_COMPRESSION_TYPE,
 };
@@ -117,6 +117,10 @@ pub fn workspace_scope() -> Scope {
     .service(
       web::resource("/v1/{workspace_id}/collab/{object_id}")
         .route(web::get().to(v1_get_collab_handler)),
+    )
+    .service(
+      web::resource("/v1/{workspace_id}/collab/{object_id}/web-update")
+        .route(web::post().to(post_web_update_handler)),
     )
     .service(
       web::resource("/{workspace_id}/page-view/{view_id}")
@@ -783,6 +787,32 @@ async fn v1_get_collab_handler(
   };
 
   Ok(Json(AppResponse::Ok().with_data(resp)))
+}
+
+async fn post_web_update_handler(
+  user_uuid: UserUuid,
+  path: web::Path<(Uuid, Uuid)>,
+  payload: Json<UpdateCollabWebParams>,
+  state: Data<AppState>,
+) -> Result<Json<AppResponse<()>>> {
+  let (workspace_id, object_id) = path.into_inner();
+  let collab_type = payload.collab_type.clone();
+  let uid = state
+    .user_cache
+    .get_user_uid(&user_uuid)
+    .await
+    .map_err(AppResponseError::from)?;
+  update_page_collab_data(
+    state.collab_access_control_storage.clone(),
+    state.metrics.appflowy_web_metrics.clone(),
+    uid,
+    workspace_id,
+    object_id,
+    collab_type,
+    &payload.doc_state,
+  )
+  .await?;
+  Ok(Json(AppResponse::Ok()))
 }
 
 async fn get_page_view_handler(

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,7 +26,7 @@ use gotrue::grant::{Grant, PasswordGrant};
 use snowflake::Snowflake;
 use tonic_proto::history::history_client::HistoryClient;
 
-use crate::api::metrics::{PublishedCollabMetrics, RequestMetrics};
+use crate::api::metrics::{AppFlowyWebMetrics, PublishedCollabMetrics, RequestMetrics};
 use crate::biz::pg_listener::PgListeners;
 use crate::biz::workspace::publish::PublishedCollabStore;
 use crate::config::config::Config;
@@ -126,6 +126,7 @@ pub struct AppMetrics {
   pub access_control_metrics: Arc<AccessControlMetrics>,
   pub collab_metrics: Arc<CollabMetrics>,
   pub published_collab_metrics: Arc<PublishedCollabMetrics>,
+  pub appflowy_web_metrics: Arc<AppFlowyWebMetrics>,
 }
 
 impl Default for AppMetrics {
@@ -142,6 +143,7 @@ impl AppMetrics {
     let access_control_metrics = Arc::new(AccessControlMetrics::register(&mut registry));
     let collab_metrics = Arc::new(CollabMetrics::register(&mut registry));
     let published_collab_metrics = Arc::new(PublishedCollabMetrics::register(&mut registry));
+    let appflowy_web_metrics = Arc::new(AppFlowyWebMetrics::register(&mut registry));
     Self {
       registry: Arc::new(registry),
       request_metrics,
@@ -149,6 +151,7 @@ impl AppMetrics {
       access_control_metrics,
       collab_metrics,
       published_collab_metrics,
+      appflowy_web_metrics,
     }
   }
 }

--- a/tests/collab/mod.rs
+++ b/tests/collab/mod.rs
@@ -7,3 +7,4 @@ mod permission_test;
 mod single_device_edit;
 mod storage_test;
 pub mod util;
+mod web_edit;

--- a/tests/collab/web_edit.rs
+++ b/tests/collab/web_edit.rs
@@ -1,0 +1,102 @@
+use client_api::entity::{QueryCollab, QueryCollabParams, UpdateCollabWebParams};
+use client_api_test::{
+  assert_client_collab_within_secs, assert_server_collab, generate_unique_registered_user,
+  TestClient,
+};
+use collab_entity::CollabType;
+use serde_json::json;
+use yrs::{updates::decoder::Decode, Map, ReadTxn, StateVector, Transact};
+
+#[tokio::test]
+async fn web_and_native_app_edit_same_collab_test() {
+  let collab_type = CollabType::Unknown;
+  let registered_user = generate_unique_registered_user().await;
+  let mut app_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let workspace_id = app_client.workspace_id().await;
+  let object_id = app_client
+    .create_and_edit_collab(&workspace_id, collab_type.clone())
+    .await;
+
+  // client 1 edit the collab
+  app_client
+    .insert_into(&object_id, "name", "workspace1")
+    .await;
+  app_client
+    .wait_object_sync_complete(&object_id)
+    .await
+    .unwrap();
+  assert_server_collab(
+    &workspace_id,
+    &mut app_client.api_client,
+    &object_id,
+    &collab_type,
+    30,
+    json!({
+      "name": "workspace1"
+    }),
+  )
+  .await
+  .unwrap();
+  // AppFlowy Web does not actually rely on the Rust client, the below is just to emulate
+  // the behaviour of the web frontend's javascript client.
+  let web_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let collab_doc_state = web_client
+    .api_client
+    .get_collab(QueryCollabParams {
+      workspace_id: workspace_id.clone(),
+      inner: QueryCollab {
+        object_id: object_id.clone(),
+        collab_type: collab_type.clone(),
+      },
+    })
+    .await
+    .unwrap()
+    .encode_collab
+    .doc_state;
+  let web_doc = yrs::Doc::new();
+  let update = yrs::Update::decode_v1(&collab_doc_state).unwrap();
+  web_doc.transact_mut().apply_update(update).unwrap();
+  let doc_data = web_doc.transact().get_map("data").unwrap();
+  {
+    let mut txn = web_doc.transact_mut();
+    doc_data.insert(&mut txn, "paragraph", "content");
+  }
+  web_client
+    .api_client
+    .update_web_collab(
+      &workspace_id,
+      &object_id,
+      UpdateCollabWebParams {
+        doc_state: web_doc
+          .transact()
+          .encode_state_as_update_v1(&StateVector::default()),
+        collab_type: collab_type.clone(),
+      },
+    )
+    .await
+    .unwrap();
+
+  let expected_json = json!({
+    "name": "workspace1",
+    "paragraph": "content",
+  });
+  assert_server_collab(
+    &workspace_id,
+    &mut app_client.api_client,
+    &object_id,
+    &collab_type,
+    30,
+    expected_json.clone(),
+  )
+  .await
+  .unwrap();
+
+  assert_client_collab_within_secs(
+    &mut app_client,
+    &object_id,
+    "paragraph",
+    expected_json.clone(),
+    30,
+  )
+  .await;
+}

--- a/tests/workspace/publish.rs
+++ b/tests/workspace/publish.rs
@@ -1,6 +1,6 @@
 use app_error::ErrorCode;
 use appflowy_cloud::biz::collab::folder_view::collab_folder_to_folder_view;
-use appflowy_cloud::biz::workspace::publish_dup::collab_from_doc_state;
+use appflowy_cloud::biz::workspace::ops::collab_from_doc_state;
 use client_api::entity::{AFRole, GlobalComment, PublishCollabItem, PublishCollabMetadata};
 use client_api_test::TestClient;
 use client_api_test::{generate_unique_registered_user_client, localhost_client};


### PR DESCRIPTION
Add API endpoint to receive updates from AppFlowy Web and apply the changes to the collab stored in-memory / on the database. As of now AppFlowy Web does not need to be updated until the browser is refreshed, hence there is no need to send missing updates back to the web client.