### PR TITLE
Remove dependency on anon and authenticated role, disable row level security

### DIFF
--- a/migrations/20230312043024_user.sql
+++ b/migrations/20230312043024_user.sql
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION update_updated_at_column_func() RETURNS TRIGGER AS $$
 RETURN NEW;
 END;
 $$ language 'plpgsql';
-CREATE TRIGGER update_af_user_modtime BEFORE
+CREATE OR REPLACE TRIGGER update_af_user_modtime BEFORE
 UPDATE ON af_user FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column_func();
 CREATE OR REPLACE FUNCTION prevent_reset_encryption_sign_func() RETURNS TRIGGER AS $$ BEGIN IF OLD.encryption_sign IS NOT NULL
     AND NEW.encryption_sign IS DISTINCT
@@ -27,20 +27,5 @@ END IF;
 RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
-CREATE TRIGGER trigger_prevent_reset_encryption_sign BEFORE
+CREATE OR REPLACE TRIGGER trigger_prevent_reset_encryption_sign BEFORE
 UPDATE ON af_user FOR EACH ROW EXECUTE FUNCTION prevent_reset_encryption_sign_func();
-
--- Enable RLS on the af_user table
--- Policy for INSERT
-ALTER TABLE af_user ENABLE ROW LEVEL SECURITY;
-CREATE POLICY af_user_insert_policy ON public.af_user FOR
-INSERT TO anon,
-    authenticated WITH CHECK (true);
--- Policy for UPDATE
-CREATE POLICY af_user_update_policy ON public.af_user FOR
-UPDATE USING (true) WITH CHECK (true);
--- Policy for SELECT
-CREATE POLICY af_user_select_policy ON public.af_user FOR
-SELECT TO anon,
-    authenticated USING (true);
-ALTER TABLE af_user FORCE ROW LEVEL SECURITY;

--- a/migrations/20230906102652_collab.sql
+++ b/migrations/20230906102652_collab.sql
@@ -11,20 +11,20 @@ CREATE TABLE IF NOT EXISTS af_collab (
     workspace_id UUID NOT NULL REFERENCES af_workspace(workspace_id) ON DELETE CASCADE,
     PRIMARY KEY (oid, partition_key)
 ) PARTITION BY LIST (partition_key);
-CREATE TABLE af_collab_document PARTITION OF af_collab FOR
+CREATE TABLE IF NOT EXISTS af_collab_document PARTITION OF af_collab FOR
 VALUES IN (0);
-CREATE TABLE af_collab_database PARTITION OF af_collab FOR
+CREATE TABLE IF NOT EXISTS af_collab_database PARTITION OF af_collab FOR
 VALUES IN (1);
-CREATE TABLE af_collab_w_database PARTITION OF af_collab FOR
+CREATE TABLE IF NOT EXISTS af_collab_w_database PARTITION OF af_collab FOR
 VALUES IN (2);
-CREATE TABLE af_collab_folder PARTITION OF af_collab FOR
+CREATE TABLE IF NOT EXISTS af_collab_folder PARTITION OF af_collab FOR
 VALUES IN (3);
-CREATE TABLE af_collab_database_row PARTITION OF af_collab FOR
+CREATE TABLE IF NOT EXISTS af_collab_database_row PARTITION OF af_collab FOR
 VALUES IN (4);
-CREATE TABLE af_collab_user_awareness PARTITION OF af_collab FOR
+CREATE TABLE IF NOT EXISTS af_collab_user_awareness PARTITION OF af_collab FOR
 VALUES IN (5);
 
-CREATE TABLE af_collab_member (
+CREATE TABLE IF NOT EXISTS af_collab_member (
     uid BIGINT REFERENCES af_user(uid) ON DELETE CASCADE,
     oid TEXT NOT NULL,
     permission_id INTEGER REFERENCES af_permissions(id) NOT NULL,
@@ -32,8 +32,6 @@ CREATE TABLE af_collab_member (
 );
 
 -- Listener
-DROP TRIGGER IF EXISTS af_collab_member_change_trigger ON af_collab_member;
-
 CREATE OR REPLACE FUNCTION notify_af_collab_member_change() RETURNS trigger AS $$
 DECLARE
 payload TEXT;
@@ -54,7 +52,7 @@ END IF;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER af_collab_member_change_trigger
+CREATE OR REPLACE TRIGGER af_collab_member_change_trigger
     AFTER INSERT OR UPDATE OR DELETE ON af_collab_member
     FOR EACH ROW EXECUTE FUNCTION notify_af_collab_member_change();
 
@@ -69,9 +67,4 @@ CREATE TABLE IF NOT EXISTS af_collab_snapshot (
     workspace_id UUID NOT NULL REFERENCES af_workspace(workspace_id) ON DELETE CASCADE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
-CREATE INDEX idx_af_collab_snapshot_oid ON af_collab_snapshot(oid);
--- Enable RLS on the af_collab table
-ALTER TABLE af_collab ENABLE ROW LEVEL SECURITY;
-CREATE POLICY af_collab_policy ON af_collab FOR ALL TO anon,
-    authenticated USING (true);
-ALTER TABLE af_collab FORCE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS idx_af_collab_snapshot_oid ON af_collab_snapshot(oid);


### PR DESCRIPTION
`authenticated` and `anon` role was needed in the past due to dependency on supabase. Now that we are no longer using supabase, there's no reason why authenticated and anon roles should exists, nor do we need row level security.

For existing users, the script will not make any changes: the roles will still exists, so is row level security. New users, however, will be able to install appflowy cloud without using these extra roles, or forced to used a postgres super user for appflowy cloud.