### PR TITLE
feat: parameterize the postgres password

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -1,11 +1,14 @@
 # This file is a template for docker compose deployment
 # Copy this file to .env and change the values as needed
 
+# PostgreSQL default user password
+POSTGRES_PASSWORD="changepassword"
+
 # AppFlowy Cloud
 ## URL that connects to the gotrue docker container
 APPFLOWY_GOTRUE_BASE_URL=http://gotrue:9999
 ## URL that connects to the postgres docker container
-APPFLOWY_DATABASE_URL=postgres://postgres:password@postgres:5432/postgres
+APPFLOWY_DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
 APPFLOWY_ACCESS_CONTROL=true
 APPFLOWY_WEBSOCKET_MAILBOX_SIZE=6000
 APPFLOWY_DATABASE_MAX_CONNECTIONS=40
@@ -127,17 +130,17 @@ NGINX_TLS_PORT=443
 APPFLOWY_AI_OPENAI_API_KEY=
 APPFLOWY_AI_SERVER_PORT=5001
 APPFLOWY_AI_SERVER_HOST=ai
-APPFLOWY_AI_DATABASE_URL=postgresql+psycopg://postgres:password@postgres:5432/postgres
+APPFLOWY_AI_DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
 APPFLOWY_LOCAL_AI_TEST_ENABLED=false
 
 # AppFlowy History
 APPFLOWY_GRPC_HISTORY_ADDRS=http://localhost:50051
 APPFLOWY_HISTORY_REDIS_URL=redis://redis:6379
-APPFLOWY_HISTORY_DATABASE_URL=postgres://postgres:password@postgres:5432/postgres
+APPFLOWY_HISTORY_DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
 
 # AppFlowy Indexer
 APPFLOWY_INDEXER_ENABLED=true
-APPFLOWY_INDEXER_DATABASE_URL=postgres://postgres:password@postgres:5432/postgres
+APPFLOWY_INDEXER_DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
 APPFLOWY_INDEXER_REDIS_URL=redis://redis:6379
 
 # AppFlowy Collaborate
@@ -146,7 +149,7 @@ APPFLOWY_COLLABORATE_REMOVE_BATCH_SIZE=100
 
 # AppFlowy Worker
 APPFLOWY_WORKER_REDIS_URL=redis://redis:6379
-APPFLOWY_WORKER_DATABASE_URL=postgres://postgres:password@postgres:5432/postgres
+APPFLOWY_WORKER_DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres
 
 # AppFlowy Web
 APPFLOWY_WEB_URL=http://localhost:3000


### PR DESCRIPTION
Set the password for Postgres separately and ensure that all connection strings related to Postgres share this variable setting.

check service environment variable
```bash
docker compose config {service_name}
```

example: `docker compose config appflowy_cloud`
env setting postgres password to changepassword
```.env
POSTGRES_PASSWORD="changepassword"
...
```
`docker compose config appflowy_cloud` will return
```yaml
name: appflowy-cloud
services:
  appflowy_cloud:
    build:
      context: /Users/thanatosdi/Dev/AppFlowy-Cloud
      dockerfile: Dockerfile
      args:
        FEATURES: ""
    environment:
      APPFLOWY_ACCESS_CONTROL: "true"
      APPFLOWY_AI_SERVER_HOST: ai
      APPFLOWY_AI_SERVER_PORT: "5001"
      APPFLOWY_DATABASE_MAX_CONNECTIONS: "40"
      APPFLOWY_DATABASE_URL: postgres://postgres:changepassword@postgres:5432/postgres
      APPFLOWY_ENVIRONMENT: production
      APPFLOWY_GOTRUE_ADMIN_EMAIL: admin@example.com
      APPFLOWY_GOTRUE_ADMIN_PASSWORD: password
      APPFLOWY_GOTRUE_BASE_URL: http://gotrue:9999
      APPFLOWY_GOTRUE_EXT_URL: http://your-host
      APPFLOWY_GOTRUE_JWT_EXP: "7200"
      APPFLOWY_GOTRUE_JWT_SECRET: hello456
      APPFLOWY_MAILER_SMTP_HOST: smtp.gmail.com
      APPFLOWY_MAILER_SMTP_PASSWORD: email_sender_password
      APPFLOWY_MAILER_SMTP_PORT: "465"
      APPFLOWY_MAILER_SMTP_USERNAME: email_sender@some_company.com
      APPFLOWY_REDIS_URI: redis://redis:6379
      APPFLOWY_S3_ACCESS_KEY: minioadmin
      APPFLOWY_S3_BUCKET: appflowy
      APPFLOWY_S3_CREATE_BUCKET: "true"
      APPFLOWY_S3_MINIO_URL: http://minio:9000
      APPFLOWY_S3_REGION: ""
      APPFLOWY_S3_SECRET_KEY: minioadmin
      APPFLOWY_S3_USE_MINIO: "true"
      RUST_LOG: info
    image: appflowyinc/appflowy_cloud:latest
    networks:
      default: null
    restart: on-failure
networks:
  default:
    name: appflowy-cloud_default

```