### PR TITLE
chore: fix misleading metric description and method name for access control metrics

### DIFF
--- a/libs/access-control/src/casbin/adapter.rs
+++ b/libs/access-control/src/casbin/adapter.rs
@@ -136,7 +136,7 @@ impl Adapter for PgAdapter {
 
     self
       .access_control_metrics
-      .record_load_all_policies_in_secs(start.elapsed().as_millis() as u64);
+      .record_load_all_policies_in_ms(start.elapsed().as_millis() as u64);
 
     Ok(())
   }

--- a/libs/access-control/src/metrics.rs
+++ b/libs/access-control/src/metrics.rs
@@ -29,7 +29,7 @@ impl AccessControlMetrics {
     let realtime_registry = registry.sub_registry_with_prefix("ac");
     realtime_registry.register(
       "load_all_polices",
-      "load all polices when server start duration in seconds",
+      "load all polices when server start duration in milliseconds",
       metrics.load_all_policies.clone(),
     );
 
@@ -48,7 +48,7 @@ impl AccessControlMetrics {
     metrics
   }
 
-  pub fn record_load_all_policies_in_secs(&self, millis: u64) {
+  pub fn record_load_all_policies_in_ms(&self, millis: u64) {
     self.load_all_policies.set(millis as i64);
   }
 


### PR DESCRIPTION
The metric for measuring access control time was described as using seconds as the measurement unit, even though the actual implementation uses milliseconds.