### PR TITLE
chore: access control interface to return error instead of boolean

### DIFF
--- a/libs/access-control/src/casbin/access.rs
+++ b/libs/access-control/src/casbin/access.rs
@@ -99,7 +99,7 @@ impl AccessControl {
     uid: &i64,
     obj: ObjectType<'_>,
     act: ActionVariant<'_>,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     self
       .enforcer
       .enforce_policy(workspace_id, uid, obj, act)

--- a/libs/access-control/src/casbin/collab.rs
+++ b/libs/access-control/src/casbin/collab.rs
@@ -30,7 +30,7 @@ impl CollabAccessControl for CollabAccessControlImpl {
     uid: &i64,
     oid: &str,
     action: Action,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     self
       .access_control
       .enforce(
@@ -48,7 +48,7 @@ impl CollabAccessControl for CollabAccessControlImpl {
     uid: &i64,
     oid: &str,
     access_level: AFAccessLevel,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     self
       .access_control
       .enforce(
@@ -120,7 +120,7 @@ impl RealtimeCollabAccessControlImpl {
     oid: &str,
     required_action: Action,
   ) -> Result<bool, AppError> {
-    let is_permitted = self
+    self
       .access_control
       .enforce(
         workspace_id,
@@ -130,7 +130,7 @@ impl RealtimeCollabAccessControlImpl {
       )
       .await?;
 
-    Ok(is_permitted)
+    Ok(true)
   }
 }
 

--- a/libs/access-control/src/casbin/workspace.rs
+++ b/libs/access-control/src/casbin/workspace.rs
@@ -27,7 +27,7 @@ impl WorkspaceAccessControl for WorkspaceAccessControlImpl {
     uid: &i64,
     workspace_id: &str,
     role: AFRole,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     self
       .access_control
       .enforce(
@@ -44,7 +44,7 @@ impl WorkspaceAccessControl for WorkspaceAccessControlImpl {
     uid: &i64,
     workspace_id: &str,
     action: Action,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     self
       .access_control
       .enforce(

--- a/libs/access-control/src/collab.rs
+++ b/libs/access-control/src/collab.rs
@@ -5,21 +5,25 @@ use database_entity::dto::AFAccessLevel;
 
 #[async_trait]
 pub trait CollabAccessControl: Sync + Send + 'static {
+  /// Check if the user can perform the action on the collab.
+  /// Returns AppError::NotEnoughPermission if the user does not have the permission.
   async fn enforce_action(
     &self,
     workspace_id: &str,
     uid: &i64,
     oid: &str,
     action: Action,
-  ) -> Result<bool, AppError>;
+  ) -> Result<(), AppError>;
 
+  /// Check if the user has the access level in the collab.
+  /// Returns AppError::NotEnoughPermission if the user does not have the access level.
   async fn enforce_access_level(
     &self,
     workspace_id: &str,
     uid: &i64,
     oid: &str,
     access_level: AFAccessLevel,
-  ) -> Result<bool, AppError>;
+  ) -> Result<(), AppError>;
 
   /// Return the access level of the user in the collab
   async fn update_access_level_policy(

--- a/libs/access-control/src/noops/collab.rs
+++ b/libs/access-control/src/noops/collab.rs
@@ -30,8 +30,8 @@ impl CollabAccessControl for CollabAccessControlImpl {
     _uid: &i64,
     _oid: &str,
     _action: Action,
-  ) -> Result<bool, AppError> {
-    Ok(true)
+  ) -> Result<(), AppError> {
+    Ok(())
   }
 
   async fn enforce_access_level(
@@ -40,8 +40,8 @@ impl CollabAccessControl for CollabAccessControlImpl {
     _uid: &i64,
     _oid: &str,
     _access_level: AFAccessLevel,
-  ) -> Result<bool, AppError> {
-    Ok(true)
+  ) -> Result<(), AppError> {
+    Ok(())
   }
 
   async fn update_access_level_policy(

--- a/libs/access-control/src/noops/workspace.rs
+++ b/libs/access-control/src/noops/workspace.rs
@@ -28,8 +28,8 @@ impl WorkspaceAccessControl for WorkspaceAccessControlImpl {
     _uid: &i64,
     _workspace_id: &str,
     _role: AFRole,
-  ) -> Result<bool, AppError> {
-    Ok(true)
+  ) -> Result<(), AppError> {
+    Ok(())
   }
 
   async fn enforce_action(
@@ -37,8 +37,8 @@ impl WorkspaceAccessControl for WorkspaceAccessControlImpl {
     _uid: &i64,
     _workspace_id: &str,
     _action: Action,
-  ) -> Result<bool, AppError> {
-    Ok(true)
+  ) -> Result<(), AppError> {
+    Ok(())
   }
 
   async fn insert_role(

--- a/libs/access-control/src/workspace.rs
+++ b/libs/access-control/src/workspace.rs
@@ -6,19 +6,19 @@ use sqlx::types::Uuid;
 
 #[async_trait]
 pub trait WorkspaceAccessControl: Send + Sync + 'static {
-  async fn enforce_role(
-    &self,
-    uid: &i64,
-    workspace_id: &str,
-    role: AFRole,
-  ) -> Result<bool, AppError>;
+  /// Check if the user has the role in the workspace.
+  /// Returns AppError::NotEnoughPermission if the user does not have the role.
+  async fn enforce_role(&self, uid: &i64, workspace_id: &str, role: AFRole)
+    -> Result<(), AppError>;
 
+  /// Check if the user can perform action on the workspace.
+  /// Returns AppError::NotEnoughPermission if the user does not have the role.
   async fn enforce_action(
     &self,
     uid: &i64,
     workspace_id: &str,
     action: Action,
-  ) -> Result<bool, AppError>;
+  ) -> Result<(), AppError>;
 
   async fn insert_role(&self, uid: &i64, workspace_id: &Uuid, role: AFRole)
     -> Result<(), AppError>;

--- a/libs/database/src/collab/collab_storage.rs
+++ b/libs/database/src/collab/collab_storage.rs
@@ -32,7 +32,7 @@ pub trait CollabStorageAccessControl: Send + Sync + 'static {
     workspace_id: &str,
     uid: &i64,
     oid: &str,
-  ) -> Result<bool, AppError>;
+  ) -> Result<(), AppError>;
 
   /// Enforce the user's permission to write to the collab object.
   async fn enforce_write_collab(
@@ -40,18 +40,13 @@ pub trait CollabStorageAccessControl: Send + Sync + 'static {
     workspace_id: &str,
     uid: &i64,
     oid: &str,
-  ) -> Result<bool, AppError>;
+  ) -> Result<(), AppError>;
 
   /// Enforce the user's permission to write to the workspace.
-  async fn enforce_write_workspace(&self, uid: &i64, workspace_id: &str) -> Result<bool, AppError>;
+  async fn enforce_write_workspace(&self, uid: &i64, workspace_id: &str) -> Result<(), AppError>;
 
   /// Enforce the user's permission to delete the collab object.
-  async fn enforce_delete(
-    &self,
-    workspace_id: &str,
-    uid: &i64,
-    oid: &str,
-  ) -> Result<bool, AppError>;
+  async fn enforce_delete(&self, workspace_id: &str, uid: &i64, oid: &str) -> Result<(), AppError>;
 }
 
 pub enum GetCollabOrigin {

--- a/services/appflowy-collaborate/src/collab/access_control.rs
+++ b/services/appflowy-collaborate/src/collab/access_control.rs
@@ -35,12 +35,12 @@ impl CollabStorageAccessControl for CollabStorageAccessControlImpl {
     workspace_id: &str,
     uid: &i64,
     oid: &str,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     let collab_exists = self.cache.is_exist(oid).await?;
     if !collab_exists {
       // If the collab does not exist, we should not enforce the access control. We consider the user
       // has the permission to read the collab
-      return Ok(true);
+      return Ok(());
     }
     self
       .collab_access_control
@@ -53,12 +53,12 @@ impl CollabStorageAccessControl for CollabStorageAccessControlImpl {
     workspace_id: &str,
     uid: &i64,
     oid: &str,
-  ) -> Result<bool, AppError> {
+  ) -> Result<(), AppError> {
     let collab_exists = self.cache.is_exist(oid).await?;
     if !collab_exists {
       // If the collab does not exist, we should not enforce the access control. we consider the user
       // has the permission to write the collab
-      return Ok(true);
+      return Ok(());
     }
     self
       .collab_access_control
@@ -66,19 +66,14 @@ impl CollabStorageAccessControl for CollabStorageAccessControlImpl {
       .await
   }
 
-  async fn enforce_write_workspace(&self, uid: &i64, workspace_id: &str) -> Result<bool, AppError> {
+  async fn enforce_write_workspace(&self, uid: &i64, workspace_id: &str) -> Result<(), AppError> {
     self
       .workspace_access_control
       .enforce_action(uid, workspace_id, Action::Write)
       .await
   }
 
-  async fn enforce_delete(
-    &self,
-    workspace_id: &str,
-    uid: &i64,
-    oid: &str,
-  ) -> Result<bool, AppError> {
+  async fn enforce_delete(&self, workspace_id: &str, uid: &i64, oid: &str) -> Result<(), AppError> {
     self
       .collab_access_control
       .enforce_access_level(workspace_id, uid, oid, AFAccessLevel::FullAccess)

--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -86,14 +86,10 @@ where
   ) -> Result<(), AppError> {
     // If the collab doesn't exist, check if the user has enough permissions to create collab.
     // If the user is the owner or member of the workspace, the user can create collab.
-    let can_write_workspace = self
+    self
       .access_control
       .enforce_write_workspace(uid, workspace_id)
       .await?;
-
-    if !can_write_workspace {
-      return Err(AppError::NotEnoughPermissions);
-    }
     Ok(())
   }
 
@@ -104,14 +100,10 @@ where
     object_id: &str,
   ) -> Result<(), AppError> {
     // If the collab already exists, check if the user has enough permissions to update collab
-    let can_write = self
+    self
       .access_control
       .enforce_write_collab(workspace_id, uid, object_id)
       .await?;
-
-    if !can_write {
-      return Err(AppError::NotEnoughPermissions);
-    }
     Ok(())
   }
 
@@ -363,14 +355,10 @@ where
     match origin {
       GetCollabOrigin::User { uid } => {
         // Check if the user has enough permissions to access the collab
-        let can_read = self
+        self
           .access_control
           .enforce_read_collab(&params.workspace_id, &uid, &params.object_id)
           .await?;
-
-        if !can_read {
-          return Err(AppError::NotEnoughPermissions);
-        }
       },
       GetCollabOrigin::Server => {},
     }
@@ -456,13 +444,10 @@ where
   }
 
   async fn delete_collab(&self, workspace_id: &str, uid: &i64, object_id: &str) -> AppResult<()> {
-    if !self
+    self
       .access_control
       .enforce_delete(workspace_id, uid, object_id)
-      .await?
-    {
-      return Err(AppError::NotEnoughPermissions);
-    }
+      .await?;
     self.cache.delete_collab(object_id).await?;
     Ok(())
   }

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -286,13 +286,10 @@ async fn delete_workspace_handler(
   state: Data<AppState>,
 ) -> Result<Json<AppResponse<()>>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_role(&uid, &workspace_id.to_string(), AFRole::Owner)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
   workspace::ops::delete_workspace_for_user(
     state.pg_pool.clone(),
     *workspace_id,
@@ -326,13 +323,10 @@ async fn post_workspace_invite_handler(
   state: Data<AppState>,
 ) -> Result<JsonAppResponse<()>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_role(&uid, &workspace_id.to_string(), AFRole::Owner)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
 
   let invited_members = payload.into_inner();
   workspace::ops::invite_workspace_members(
@@ -402,13 +396,10 @@ async fn get_workspace_settings_handler(
   workspace_id: web::Path<Uuid>,
 ) -> Result<JsonAppResponse<AFWorkspaceSettings>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_action(&uid, &workspace_id.to_string(), Action::Read)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
   let settings = workspace::ops::get_workspace_settings(&state.pg_pool, &workspace_id).await?;
   Ok(AppResponse::Ok().with_data(settings).into())
 }
@@ -423,13 +414,10 @@ async fn post_workspace_settings_handler(
   let data = data.into_inner();
   trace!("workspace settings: {:?}", data);
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_action(&uid, &workspace_id.to_string(), Action::Write)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
   let settings =
     workspace::ops::update_workspace_settings(&state.pg_pool, &workspace_id, data).await?;
   Ok(AppResponse::Ok().with_data(settings).into())
@@ -442,13 +430,10 @@ async fn get_workspace_members_handler(
   workspace_id: web::Path<Uuid>,
 ) -> Result<JsonAppResponse<Vec<AFWorkspaceMember>>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_action(&uid, &workspace_id.to_string(), Action::Read)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
   let members = workspace::ops::get_workspace_members(&state.pg_pool, &workspace_id)
     .await?
     .into_iter()
@@ -471,13 +456,10 @@ async fn remove_workspace_member_handler(
   workspace_id: web::Path<Uuid>,
 ) -> Result<JsonAppResponse<()>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_role(&uid, &workspace_id.to_string(), AFRole::Owner)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
 
   let member_emails = payload
     .into_inner()
@@ -504,13 +486,10 @@ async fn get_workspace_member_handler(
 ) -> Result<JsonAppResponse<AFWorkspaceMember>> {
   let (workspace_id, user_uuid_to_retrieved) = path.into_inner();
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_action(&uid, &workspace_id.to_string(), Action::Read)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
   let member_row =
     workspace::ops::get_workspace_member(&user_uuid_to_retrieved, &state.pg_pool, &workspace_id)
       .await?;
@@ -561,13 +540,10 @@ async fn update_workspace_member_handler(
 ) -> Result<JsonAppResponse<()>> {
   let workspace_id = workspace_id.into_inner();
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_role(&uid, &workspace_id.to_string(), AFRole::Owner)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
 
   let changeset = payload.into_inner();
 
@@ -894,13 +870,10 @@ async fn get_page_view_handler(
     .get_user_uid(&user_uuid)
     .await
     .map_err(AppResponseError::from)?;
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_action(&uid, &workspace_uuid.to_string(), Action::Read)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
 
   let page_collab = get_page_view_collab(
     &state.pg_pool,
@@ -1533,13 +1506,10 @@ async fn get_workspace_folder_handler(
   let depth = query.depth.unwrap_or(1);
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let workspace_id = workspace_id.into_inner();
-  let has_access = state
+  state
     .workspace_access_control
     .enforce_action(&uid, &workspace_id.to_string(), Action::Read)
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions.into());
-  }
   let root_view_id = if let Some(root_view_id) = query.root_view_id.as_ref() {
     root_view_id.to_string()
   } else {

--- a/src/biz/access_request/ops.rs
+++ b/src/biz/access_request/ops.rs
@@ -125,16 +125,13 @@ pub async fn approve_or_reject_access_request(
   is_approved: bool,
 ) -> Result<(), AppError> {
   let access_request = select_access_request_by_request_id(pg_pool, request_id).await?;
-  let has_access = workspace_access_control
+  workspace_access_control
     .enforce_role(
       &uid,
       &access_request.workspace.workspace_id.to_string(),
       AFRole::Owner,
     )
     .await?;
-  if !has_access {
-    return Err(AppError::NotEnoughPermissions);
-  }
 
   let mut txn = pg_pool.begin().await.context("approving request")?;
   let role = AFRole::Member;

--- a/src/biz/collab/access_control.rs
+++ b/src/biz/collab/access_control.rs
@@ -101,25 +101,19 @@ impl MiddlewareAccessControl for CollabMiddlewareAccessControl {
     }
 
     let access_level = self.require_access_level(&method, path);
-    let result = match access_level {
+    match access_level {
       None => {
         self
           .access_control
           .enforce_action(workspace_id, uid, oid, Action::from(&method))
-          .await?
+          .await
       },
       Some(access_level) => {
         self
           .access_control
           .enforce_access_level(workspace_id, uid, oid, access_level)
-          .await?
+          .await
       },
-    };
-
-    if result {
-      Ok(())
-    } else {
-      Err(AppError::NotEnoughPermissions)
     }
   }
 }

--- a/src/biz/workspace/access_control.rs
+++ b/src/biz/workspace/access_control.rs
@@ -122,7 +122,7 @@ impl MiddlewareAccessControl for WorkspaceMiddlewareAccessControl {
     // For example, Both AFRole::Owner and AFRole::Member have the write permission to the workspace,
     // but only the Owner can manage the workspace members.
     let require_role = self.require_role(&method, path);
-    let result = match require_role {
+    match require_role {
       Some(role) => {
         self
           .access_control
@@ -137,12 +137,6 @@ impl MiddlewareAccessControl for WorkspaceMiddlewareAccessControl {
           .enforce_action(uid, resource_id, action)
           .await
       },
-    }?;
-
-    if result {
-      Ok(())
-    } else {
-      Err(AppError::NotEnoughPermissions)
     }
   }
 }


### PR DESCRIPTION
Currently, the access control trait will return true if the subject has access to the object, and false otherwise. This makes it possible to enforce the behavior of the implementation: it is very clear that the app error means unexpected behaviour, and the boolean return value indicate whether the user has access or not.

However, on the caller's end - it became impossible to enforce the error type to return if the user does not have the access. It is very possible for the caller to accidentally return a different error code, which will result in inconsistency. There's also additional handling required for every call, to return permission error if the result is false.

It is possible to enforce the returned error code by having a middleware that will be used by every single endpoints that requires access control. However, our long term plan is to stop relying on middleware, and expect the endpoints to use the access control interface directly. This is due to three reasons:
1. middleware on the global level introduce a layer of abstraction which the developer can accidentally missed
2. Some endpoints requires additional context to enforce access control, which might not be available on the middleware layer.
3. Some endpoints might provide a fallback response in the event when the user does not have sufficient permission.

Therefore, the alternative is to return NotEnoughPermission error in the event where the user does not have access, which will simplify the usage of the access control trait.

The downside, is that it is possible for an implementation to return a different error type than expected when a user does not have access. However, since it is not expected for us to have many implementations, aside from casbin and noops, this should be manageable by documenting the trait properly.