### PR TITLE
feat: enforce access control on workspace level CRUD

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -1,3 +1,4 @@
+use access_control::act::Action;
 use actix_web::web::{Data, Query};
 use actix_web::{web, Scope};
 use uuid::Uuid;
@@ -24,6 +25,10 @@ async fn document_search(
   let request = payload.into_inner();
   let user_uuid = auth.uuid()?;
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  state
+    .workspace_access_control
+    .enforce_action(&uid, &workspace_id.to_string(), Action::Read)
+    .await?;
   let metrics = &*state.metrics.request_metrics;
   let resp = search_document(
     &state.pg_pool,


### PR DESCRIPTION
Enable access control for workspace level CRUD, before deprecating the use of middleware.

Ideally, we should use Uuid for the workspace id argument, as most endpoints that requires access control extracts the workspace id from the url path as a Uuid. However, it is difficult to do so now due to the fact that CollabGroup is storing workspace id in the form of string, which makes it more convenient to use String instead of Uuid, for RealtimeAccessControl.