### PR TITLE
feat: add publish info to list templates

### DIFF
--- a/.sqlx/query-e2ab2c5d0328f2a0900dfbd9080c0d867526bca0afee9aa4af294fbbebf3db0a.json
+++ b/.sqlx/query-e2ab2c5d0328f2a0900dfbd9080c0d867526bca0afee9aa4af294fbbebf3db0a.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT\n        aw.publish_namespace AS namespace,\n        apc.publish_name,\n        apc.view_id,\n        au.email AS publisher_email,\n        apc.created_at AS publish_timestamp\n      FROM af_published_collab apc\n      JOIN af_user au ON apc.published_by = au.uid\n      JOIN af_workspace aw ON apc.workspace_id = aw.workspace_id\n      WHERE apc.view_id = ANY($1);\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "namespace",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "publish_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "view_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "publisher_email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "publish_timestamp",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e2ab2c5d0328f2a0900dfbd9080c0d867526bca0afee9aa4af294fbbebf3db0a"
+}

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -1344,22 +1344,22 @@ pub struct TemplateWithPublishInfo {
   pub publish_info: PublishInfo,
 }
 
-impl TemplateWithPublishInfo {
-  pub fn from_template_and_publish_info(template: &Template, publish_info: &PublishInfo) -> Self {
+impl From<(Template, PublishInfo)> for TemplateWithPublishInfo {
+  fn from((template, publish_info): (Template, PublishInfo)) -> Self {
     Self {
       view_id: template.view_id,
       created_at: template.created_at,
       last_updated_at: template.last_updated_at,
-      name: template.name.clone(),
-      description: template.description.clone(),
-      about: template.about.clone(),
-      view_url: template.view_url.clone(),
-      categories: template.categories.clone(),
-      creator: template.creator.clone(),
+      name: template.name,
+      description: template.description,
+      about: template.about,
+      view_url: template.view_url,
+      categories: template.categories,
+      creator: template.creator,
       is_new_template: template.is_new_template,
       is_featured: template.is_featured,
-      related_templates: template.related_templates.clone(),
-      publish_info: publish_info.clone(),
+      related_templates: template.related_templates,
+      publish_info,
     }
   }
 }
@@ -1378,9 +1378,42 @@ pub struct TemplateMinimal {
   pub is_featured: bool,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TemplateMinimalWithPublishInfo {
+  pub view_id: Uuid,
+  pub created_at: DateTime<Utc>,
+  pub last_updated_at: DateTime<Utc>,
+  pub name: String,
+  pub description: String,
+  pub view_url: String,
+  pub creator: TemplateCreatorMinimal,
+  pub categories: Vec<TemplateCategoryMinimal>,
+  pub is_new_template: bool,
+  pub is_featured: bool,
+  pub publish_info: PublishInfo,
+}
+
+impl From<(TemplateMinimal, PublishInfo)> for TemplateMinimalWithPublishInfo {
+  fn from((template, publish_info): (TemplateMinimal, PublishInfo)) -> Self {
+    Self {
+      view_id: template.view_id,
+      created_at: template.created_at,
+      last_updated_at: template.last_updated_at,
+      name: template.name,
+      description: template.description,
+      view_url: template.view_url,
+      creator: template.creator,
+      categories: template.categories,
+      is_new_template: template.is_new_template,
+      is_featured: template.is_featured,
+      publish_info,
+    }
+  }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Templates {
-  pub templates: Vec<TemplateMinimal>,
+  pub templates: Vec<TemplateMinimalWithPublishInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/api/template.rs
+++ b/src/api/template.rs
@@ -219,7 +219,7 @@ async fn list_templates_handler(
   state: Data<AppState>,
 ) -> Result<JsonAppResponse<Templates>> {
   let data = data.into_inner();
-  let template_summary_list = get_templates(
+  let template_summary_list = get_templates_with_publish_info(
     &state.pg_pool,
     data.category_id,
     data.is_featured,

--- a/tests/workspace/template.rs
+++ b/tests/workspace/template.rs
@@ -361,6 +361,15 @@ async fn test_template_crud() {
   assert_eq!(templates.len(), 2);
   assert!(view_ids.contains(&published_view_ids[2]));
   assert!(view_ids.contains(&published_view_ids[3]));
+  assert_eq!(
+    templates[0]
+      .publish_info
+      .namespace
+      .as_ref()
+      .unwrap()
+      .to_string(),
+    published_view_namespace.clone()
+  );
 
   let featured_templates = guest_client
     .get_templates(None, Some(true), None, Some(template_name_prefix.clone()))


### PR DESCRIPTION
Add publish info to list templates endpoint. It is assumed that published info can always be found for a given template/view id.