### PR TITLE
Add section timestamp for get recent/favorite/trash section endpoints

### DIFF
--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -3,10 +3,10 @@ use app_error::AppError;
 use app_error::ErrorCode;
 use client_api_entity::auth_dto::DeleteUserQuery;
 use client_api_entity::server_info_dto::ServerInfoResponseItem;
-use client_api_entity::workspace_dto::FolderView;
-use client_api_entity::workspace_dto::QueryWorkspaceFolder;
-use client_api_entity::workspace_dto::QueryWorkspaceParam;
-use client_api_entity::workspace_dto::SectionItems;
+use client_api_entity::workspace_dto::FavoriteSectionItems;
+use client_api_entity::workspace_dto::RecentSectionItems;
+use client_api_entity::workspace_dto::TrashSectionItems;
+use client_api_entity::workspace_dto::{FolderView, QueryWorkspaceFolder, QueryWorkspaceParam};
 use client_api_entity::AuthProvider;
 use client_api_entity::CollabType;
 use gotrue::grant::PasswordGrant;
@@ -727,7 +727,7 @@ impl Client {
   pub async fn get_workspace_favorite(
     &self,
     workspace_id: &str,
-  ) -> Result<SectionItems, AppResponseError> {
+  ) -> Result<FavoriteSectionItems, AppResponseError> {
     let url = format!("{}/api/workspace/{}/favorite", self.base_url, workspace_id);
     let resp = self
       .http_client_with_auth(Method::GET, &url)
@@ -735,7 +735,7 @@ impl Client {
       .send()
       .await?;
     log_request_id(&resp);
-    AppResponse::<SectionItems>::from_response(resp)
+    AppResponse::<FavoriteSectionItems>::from_response(resp)
       .await?
       .into_data()
   }
@@ -744,7 +744,7 @@ impl Client {
   pub async fn get_workspace_recent(
     &self,
     workspace_id: &str,
-  ) -> Result<SectionItems, AppResponseError> {
+  ) -> Result<RecentSectionItems, AppResponseError> {
     let url = format!("{}/api/workspace/{}/recent", self.base_url, workspace_id);
     let resp = self
       .http_client_with_auth(Method::GET, &url)
@@ -752,7 +752,7 @@ impl Client {
       .send()
       .await?;
     log_request_id(&resp);
-    AppResponse::<SectionItems>::from_response(resp)
+    AppResponse::<RecentSectionItems>::from_response(resp)
       .await?
       .into_data()
   }
@@ -761,7 +761,7 @@ impl Client {
   pub async fn get_workspace_trash(
     &self,
     workspace_id: &str,
-  ) -> Result<SectionItems, AppResponseError> {
+  ) -> Result<TrashSectionItems, AppResponseError> {
     let url = format!("{}/api/workspace/{}/trash", self.base_url, workspace_id);
     let resp = self
       .http_client_with_auth(Method::GET, &url)
@@ -769,7 +769,7 @@ impl Client {
       .send()
       .await?;
     log_request_id(&resp);
-    AppResponse::<SectionItems>::from_response(resp)
+    AppResponse::<TrashSectionItems>::from_response(resp)
       .await?
       .into_data()
   }

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -143,6 +143,42 @@ pub struct PublishedDuplicate {
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct RecentFolderView {
+  #[serde(flatten)]
+  pub view: FolderView,
+  pub last_viewed_at: DateTime<Utc>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct FavoriteFolderView {
+  #[serde(flatten)]
+  pub view: FolderView,
+  pub favorited_at: DateTime<Utc>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct TrashFolderView {
+  #[serde(flatten)]
+  pub view: FolderView,
+  pub deleted_at: DateTime<Utc>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct RecentSectionItems {
+  pub views: Vec<RecentFolderView>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct FavoriteSectionItems {
+  pub views: Vec<FavoriteFolderView>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct TrashSectionItems {
+  pub views: Vec<TrashFolderView>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct FolderView {
   pub view_id: String,
   pub name: String,
@@ -171,11 +207,6 @@ pub struct FolderViewMinimal {
 pub struct PublishInfoView {
   pub view: FolderViewMinimal,
   pub info: PublishInfo,
-}
-
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct SectionItems {
-  pub views: Vec<FolderView>,
 }
 
 #[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize_repr, Deserialize_repr)]

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1575,7 +1575,7 @@ async fn get_recent_views_handler(
   user_uuid: UserUuid,
   workspace_id: web::Path<Uuid>,
   state: Data<AppState>,
-) -> Result<Json<AppResponse<SectionItems>>> {
+) -> Result<Json<AppResponse<RecentSectionItems>>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let workspace_id = workspace_id.into_inner();
   state
@@ -1589,7 +1589,7 @@ async fn get_recent_views_handler(
     workspace_id,
   )
   .await?;
-  let section_items = SectionItems {
+  let section_items = RecentSectionItems {
     views: folder_views,
   };
   Ok(Json(AppResponse::Ok().with_data(section_items)))
@@ -1599,7 +1599,7 @@ async fn get_favorite_views_handler(
   user_uuid: UserUuid,
   workspace_id: web::Path<Uuid>,
   state: Data<AppState>,
-) -> Result<Json<AppResponse<SectionItems>>> {
+) -> Result<Json<AppResponse<FavoriteSectionItems>>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let workspace_id = workspace_id.into_inner();
   state
@@ -1613,7 +1613,7 @@ async fn get_favorite_views_handler(
     workspace_id,
   )
   .await?;
-  let section_items = SectionItems {
+  let section_items = FavoriteSectionItems {
     views: folder_views,
   };
   Ok(Json(AppResponse::Ok().with_data(section_items)))
@@ -1623,7 +1623,7 @@ async fn get_trash_views_handler(
   user_uuid: UserUuid,
   workspace_id: web::Path<Uuid>,
   state: Data<AppState>,
-) -> Result<Json<AppResponse<SectionItems>>> {
+) -> Result<Json<AppResponse<TrashSectionItems>>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let workspace_id = workspace_id.into_inner();
   state
@@ -1632,7 +1632,7 @@ async fn get_trash_views_handler(
     .await?;
   let folder_views =
     get_user_trash_folder_views(&state.collab_access_control_storage, uid, workspace_id).await?;
-  let section_items = SectionItems {
+  let section_items = TrashSectionItems {
     views: folder_views,
   };
   Ok(Json(AppResponse::Ok().with_data(section_items)))

--- a/tests/workspace/workspace_folder.rs
+++ b/tests/workspace/workspace_folder.rs
@@ -85,14 +85,17 @@ async fn get_section_items() {
   .unwrap();
   let favorite_section_items = c.get_workspace_favorite(&workspace_id).await.unwrap();
   assert_eq!(favorite_section_items.views.len(), 1);
-  assert_eq!(favorite_section_items.views[0].view_id, new_favorite_id);
+  assert_eq!(
+    favorite_section_items.views[0].view.view_id,
+    new_favorite_id
+  );
   let trash_section_items = c.get_workspace_trash(&workspace_id).await.unwrap();
   assert_eq!(trash_section_items.views.len(), 1);
   assert_eq!(
-    trash_section_items.views[0].view_id,
+    trash_section_items.views[0].view.view_id,
     to_be_deleted_favorite_id
   );
   let recent_section_items = c.get_workspace_recent(&workspace_id).await.unwrap();
   assert_eq!(recent_section_items.views.len(), 1);
-  assert_eq!(recent_section_items.views[0].view_id, recent_id);
+  assert_eq!(recent_section_items.views[0].view.view_id, recent_id);
 }


### PR DESCRIPTION
Added section timestamp to the response for get recent, favorite and trash section endpoints. The response json format will be in the form of:

Favorite sections:
```
{
    views: [
     {
         ...all fields in FolderView
         favorited_at: <date time>
     }
    ]
}
```

Recent sections:
```
{
    views: [
     {
         ...all fields in FolderView
         last_viewed_at: <date time>
     }
    ]
}
```

Trash sections:
```
{
    views: [
     {
         ...all fields in FolderView
         deleted_at: <date time>
     }
    ]
}
```