### PR TITLE
fix: wait for a second after duplication to workspace

### DIFF
--- a/libs/client-api-test/src/test_client.rs
+++ b/libs/client-api-test/src/test_client.rs
@@ -40,8 +40,8 @@ use database_entity::dto::{
   QuerySnapshotParams, SnapshotData, UpdateCollabMemberParams,
 };
 use shared_entity::dto::workspace_dto::{
-  BlobMetadata, CollabResponse, WorkspaceMemberChangeset, WorkspaceMemberInvitation,
-  WorkspaceSpaceUsage,
+  BlobMetadata, CollabResponse, PublishedDuplicate, WorkspaceMemberChangeset,
+  WorkspaceMemberInvitation, WorkspaceSpaceUsage,
 };
 use shared_entity::response::AppResponseError;
 
@@ -927,6 +927,28 @@ impl TestClient {
       .publish_collabs(workspace_id, pub_items)
       .await
       .unwrap();
+  }
+
+  pub async fn duplicate_published_to_workspace(
+    &self,
+    dest_workspace_id: &str,
+    src_view_id: &str,
+    dest_view_id: &str,
+  ) {
+    self
+      .api_client
+      .duplicate_published_to_workspace(
+        &dest_workspace_id,
+        &PublishedDuplicate {
+          published_view_id: src_view_id.to_string(),
+          dest_view_id: dest_view_id.to_string(),
+        },
+      )
+      .await
+      .unwrap();
+
+    // wait a while for folder collab to be synced
+    tokio::time::sleep(Duration::from_secs(1)).await;
   }
 }
 

--- a/libs/client-api-test/src/test_client.rs
+++ b/libs/client-api-test/src/test_client.rs
@@ -938,7 +938,7 @@ impl TestClient {
     self
       .api_client
       .duplicate_published_to_workspace(
-        &dest_workspace_id,
+        dest_workspace_id,
         &PublishedDuplicate {
           published_view_id: src_view_id.to_string(),
           dest_view_id: dest_view_id.to_string(),

--- a/tests/workspace/publish.rs
+++ b/tests/workspace/publish.rs
@@ -17,7 +17,6 @@ use collab_entity::CollabType;
 use collab_folder::{CollabOrigin, Folder, UserId};
 use itertools::Itertools;
 use shared_entity::dto::publish_dto::PublishDatabaseData;
-use shared_entity::dto::workspace_dto::PublishedDuplicate;
 use std::collections::{HashMap, HashSet};
 use std::thread::sleep;
 use std::time::Duration;
@@ -784,16 +783,12 @@ async fn duplicate_to_workspace_references() {
     //     └── doc1
     //         └── grid1
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: doc_2_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &doc_2_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     let fv = client_2
       .api_client
@@ -874,16 +869,12 @@ async fn duplicate_to_workspace_doc_inline_database() {
     //     └── grid1
     //         └── View of grid1
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: doc_3_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &doc_3_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     {
       let fv = client_2
@@ -1036,16 +1027,12 @@ async fn duplicate_to_workspace_db_embedded_in_doc() {
     // ├── Getting Started (existing)
     // └── db_with_embedded_db (inside should contain the database)
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: doc_with_embedded_db_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &doc_with_embedded_db_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     {
       let fv = client_2
@@ -1141,16 +1128,12 @@ async fn duplicate_to_workspace_db_with_relation() {
     // related-db cannot be child of db_with_rel_col because they dont share the same field
     // and are 2 different databases, so we just put them in the root (dest_id)
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: db_with_rel_col_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &db_with_rel_col_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     {
       let fv = client_2
@@ -1230,16 +1213,12 @@ async fn duplicate_to_workspace_db_row_with_doc() {
     // ├── Getting Started (existing)
     // └── db_with_row_doc
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: db_with_row_doc_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &db_with_row_doc_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     {
       let fv = client_2
@@ -1313,16 +1292,12 @@ async fn duplicate_to_workspace_db_rel_self() {
       .unwrap();
 
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: db_rel_self_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &db_rel_self_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     let fv = client_2
       .api_client
@@ -1408,16 +1383,12 @@ async fn duplicate_to_workspace_inline_db_doc_with_relation() {
       .unwrap();
 
     client_2
-      .api_client
       .duplicate_published_to_workspace(
         &workspace_id_2,
-        &PublishedDuplicate {
-          published_view_id: doc_4_view_id.to_string(),
-          dest_view_id: fv.view_id, // use the root view
-        },
+        &doc_4_view_id.to_string(),
+        &fv.view_id, // use the root view
       )
-      .await
-      .unwrap();
+      .await;
 
     let fv = client_2
       .api_client


### PR DESCRIPTION
This PR attempts to fix the duplication test cases that were failing occasionally. Failing tests are not able to be reproduced in my local machine. I suspect that during duplication, it takes a while for the folder collab to be updated, and the next test steps fetches the folder structure right after duplication occurs.

Occasional failing test:
https://github.com/AppFlowy-IO/AppFlowy-Cloud/actions/runs/11493712274/job/31991004609?pr=922
https://github.com/AppFlowy-IO/AppFlowy-Cloud/actions/runs/11495849319/job/31997895457?pr=929