### PR TITLE
fix: wrong minio browser redirect url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: on-failure
     image: minio/minio
     environment:
-      - MINIO_BROWSER_REDIRECT_URL=http://localhost/minio
+      - MINIO_BROWSER_REDIRECT_URL=${API_EXTERNAL_URL}/minio
       - MINIO_ROOT_USER=${APPFLOWY_S3_ACCESS_KEY:-minioadmin}
       - MINIO_ROOT_PASSWORD=${APPFLOWY_S3_SECRET_KEY:-minioadmin}
     command: server /data --console-address ":9001"


### PR DESCRIPTION
Minio browser redirect url was wrongly set to localhost.