### PR TITLE
feat: handle duplicated publish names for a workspace

### DIFF
--- a/.sqlx/query-12dcf313d0e4c0c0da2569f3326e49e1a78fa54537cb8826a20bef2769d04dd1.json
+++ b/.sqlx/query-12dcf313d0e4c0c0da2569f3326e49e1a78fa54537cb8826a20bef2769d04dd1.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT EXISTS(\n        SELECT 1\n        FROM af_published_collab\n        WHERE workspace_id = $1\n        AND publish_name = $2\n      )\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "12dcf313d0e4c0c0da2569f3326e49e1a78fa54537cb8826a20bef2769d04dd1"
+}

--- a/.sqlx/query-2571550f7e2dd81103960741fecbf886f52f681c44344a814780b01fc06e4c8f.json
+++ b/.sqlx/query-2571550f7e2dd81103960741fecbf886f52f681c44344a814780b01fc06e4c8f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT view_id\n      FROM af_published_collab\n      WHERE workspace_id = $1\n      AND publish_name = $2\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "view_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2571550f7e2dd81103960741fecbf886f52f681c44344a814780b01fc06e4c8f"
+}

--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -155,6 +155,12 @@ pub enum AppError {
 
   #[error("There is existing access request for workspace {workspace_id} and view {view_id}")]
   AccessRequestAlreadyExists { workspace_id: Uuid, view_id: Uuid },
+
+  #[error("There is existing published view for workspace {workspace_id} with publish_name {publish_name}")]
+  PublishNameAlreadyExists {
+    workspace_id: Uuid,
+    publish_name: String,
+  },
 }
 
 impl AppError {
@@ -225,6 +231,7 @@ impl AppError {
       AppError::MissingView(_) => ErrorCode::MissingView,
       AppError::AccessRequestAlreadyExists { .. } => ErrorCode::AccessRequestAlreadyExists,
       AppError::TooManyImportTask(_) => ErrorCode::TooManyImportTask,
+      AppError::PublishNameAlreadyExists { .. } => ErrorCode::PublishNameAlreadyExists,
     }
   }
 }
@@ -360,6 +367,7 @@ pub enum ErrorCode {
   CustomNamespaceTooShort = 1047,
   CustomNamespaceTooLong = 1048,
   CustomNamespaceReserved = 1049,
+  PublishNameAlreadyExists = 1050,
 }
 
 impl ErrorCode {

--- a/libs/database/src/workspace.rs
+++ b/libs/database/src/workspace.rs
@@ -1599,3 +1599,49 @@ pub async fn update_import_task_metadata(
 
   Ok(())
 }
+
+#[inline]
+pub async fn select_publish_name_exists(
+  pg_pool: &PgPool,
+  workspace_uuid: &Uuid,
+  publish_name: &str,
+) -> Result<bool, AppError> {
+  let exists = sqlx::query_scalar!(
+    r#"
+      SELECT EXISTS(
+        SELECT 1
+        FROM af_published_collab
+        WHERE workspace_id = $1
+        AND publish_name = $2
+      )
+    "#,
+    workspace_uuid,
+    publish_name
+  )
+  .fetch_one(pg_pool)
+  .await?;
+
+  Ok(exists.unwrap_or(false))
+}
+
+#[inline]
+pub async fn select_view_id_from_publish_name(
+  pg_pool: &PgPool,
+  workspace_uuid: &Uuid,
+  publish_name: &str,
+) -> Result<Option<Uuid>, AppError> {
+  let res = sqlx::query_scalar!(
+    r#"
+      SELECT view_id
+      FROM af_published_collab
+      WHERE workspace_id = $1
+      AND publish_name = $2
+    "#,
+    workspace_uuid,
+    publish_name
+  )
+  .fetch_optional(pg_pool)
+  .await?;
+
+  Ok(res)
+}


### PR DESCRIPTION
- If a collab is already publish under a `view_id` and user tries to publish another `view_id` with same `publish_name` as the previous, an error `PublishNameAlreadyExists = 1050` will be returned.
- If a collab is already published, user cannot change the `publish_name` to one that already exists for the workspace, error `PublishNameAlreadyExists = 1050` will be returned