### PR TITLE
fix: parameterized postgres db in migration script

### DIFF
--- a/migrations/before/supabase_auth.sh
+++ b/migrations/before/supabase_auth.sh
@@ -28,7 +28,7 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
 
     -- Grant permissions
-    GRANT CREATE ON DATABASE postgres TO supabase_auth_admin;
+    GRANT CREATE ON DATABASE $POSTGRES_DB TO supabase_auth_admin;
 
     -- Set search_path for supabase_auth_admin
     ALTER USER supabase_auth_admin SET search_path = 'auth';


### PR DESCRIPTION
Database name on the migration script should be based on the postgres db env variable instead of hardcoded to postgres.