### PR TITLE
chore: add unique index on af_users.uuid

### DIFF
--- a/migrations/20241031094508_af_uuid_indexes.sql
+++ b/migrations/20241031094508_af_uuid_indexes.sql
@@ -1,0 +1,4 @@
+CREATE UNIQUE INDEX IF NOT EXISTS uq_af_user_uuid
+    ON af_user (uuid)
+    INCLUDE (uid);
+


### PR DESCRIPTION
I've run an explain plan one of out queries (running few minutes):
```sql
EXPLAIN SELECT EXISTS ( 
    SELECT 1 
    FROM af_workspace 
    WHERE owner_uid = (SELECT uid FROM af_user WHERE uuid = '194fe9ef-be05-47e3-9a81-7bb8b8bc3786') 
      AND workspace_id = '194fe9ef-be05-47e3-9a81-7bb8b8bc3786' ) 
```

That's how the execution plan looked like:
```
Result (cost=1703.17..1703.18 rows=1 width=1) 
InitPlan 2 (returns $1) 
  -> Index Scan using af_workspace_pkey on af_workspace (cost=1695.15..1703.17 rows=1 width=0)
     Index Cond: (workspace_id = '194fe9ef-be05-47e3-9a81-7bb8b8bc3786'::uuid) 
     Filter: (owner_uid = $0) 
InitPlan 1 (returns $0) 
  -> Seq Scan on af_user (cost=0.00..1694.74 rows=1 width=8) 
     Filter: (uuid = '194fe9ef-be05-47e3-9a81-7bb8b8bc3786'::uuid)
```
**Seq Scan** over `SELECT uid FROM af_user WHERE uuid = ?` means scanning entire `af_user` table. I've looked into schema definition on my local PG instance and `af_user.uuid` doesn't have any index on it (only foreign key constraint, but in PG foreign keys are not indexed by default).

This PR would let us change 'seq scan' to 'index only scan' which is basically the fastest way to reach the value in Postgres as long as query won't reach for non-included, non-indexed fields.