### PR TITLE
feat: separate smtp username from email

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -113,6 +113,7 @@ APPFLOWY_S3_BUCKET=appflowy
 APPFLOWY_MAILER_SMTP_HOST=smtp.gmail.com
 APPFLOWY_MAILER_SMTP_PORT=465
 APPFLOWY_MAILER_SMTP_USERNAME=email_sender@some_company.com
+APPFLOWY_MAILER_SMTP_EMAIL=email_sender@some_company.com
 APPFLOWY_MAILER_SMTP_PASSWORD=email_sender_password
 
 # Log level for the appflowy-cloud service

--- a/dev.env
+++ b/dev.env
@@ -88,6 +88,7 @@ APPFLOWY_S3_BUCKET=appflowy
 # Note that smtps (TLS) is always required, even for ports other than 465
 APPFLOWY_MAILER_SMTP_HOST=smtp.gmail.com
 APPFLOWY_MAILER_SMTP_USERNAME=notify@appflowy.io
+APPFLOWY_MAILER_SMTP_EMAIL=notify@appflowy.io
 APPFLOWY_MAILER_SMTP_PASSWORD=email_sender_password
 
 RUST_LOG=info

--- a/libs/mailer/src/config.rs
+++ b/libs/mailer/src/config.rs
@@ -5,5 +5,6 @@ pub struct MailerSetting {
   pub smtp_host: String,
   pub smtp_port: u16,
   pub smtp_username: String,
+  pub smtp_email: String,
   pub smtp_password: Secret<String>,
 }

--- a/services/appflowy-worker/src/application.rs
+++ b/services/appflowy-worker/src/application.rs
@@ -145,7 +145,8 @@ pub struct AppState {
 async fn get_worker_mailer(config: &Config) -> Result<AFWorkerMailer, Error> {
   let mailer = Mailer::new(
     config.mailer.smtp_username.clone(),
-    config.mailer.smtp_password.expose_secret().clone(),
+    config.mailer.smtp_email.clone(),
+    config.mailer.smtp_password.clone(),
     &config.mailer.smtp_host,
     config.mailer.smtp_port,
   )

--- a/services/appflowy-worker/src/config.rs
+++ b/services/appflowy-worker/src/config.rs
@@ -48,6 +48,12 @@ impl Config {
       mailer: MailerSetting {
         smtp_host: get_env_var("APPFLOWY_MAILER_SMTP_HOST", "smtp.gmail.com"),
         smtp_port: get_env_var("APPFLOWY_MAILER_SMTP_PORT", "465").parse()?,
+        smtp_email: get_env_var("APPFLOWY_MAILER_SMTP_EMAIL", "sender@example.com"),
+        // `smtp_username` could be the same as `smtp_email`, but may not have to be.
+        // For example:
+        //  - Azure Communication services uses a string of the format <resource name>.<app id>.<tenant id>
+        //  - SendGrid uses the string apikey
+        // Adapted from: https://github.com/AppFlowy-IO/AppFlowy-Cloud/issues/984
         smtp_username: get_env_var("APPFLOWY_MAILER_SMTP_USERNAME", "sender@example.com"),
         smtp_password: get_env_var("APPFLOWY_MAILER_SMTP_PASSWORD", "password").into(),
       },

--- a/services/appflowy-worker/src/mailer.rs
+++ b/services/appflowy-worker/src/mailer.rs
@@ -58,8 +58,9 @@ mod tests {
   #[tokio::test]
   async fn render_import_report() {
     let mailer = Mailer::new(
-      "test mailer".to_string(),
-      "123".to_string(),
+      "smtp_username".to_string(),
+      "stmp_email".to_string(),
+      "smtp_password".to_string().into(),
       "localhost",
       465,
     )

--- a/src/application.rs
+++ b/src/application.rs
@@ -511,7 +511,8 @@ async fn create_bucket_if_not_exists(
 async fn get_mailer(config: &Config) -> Result<AFCloudMailer, Error> {
   let mailer = Mailer::new(
     config.mailer.smtp_username.clone(),
-    config.mailer.smtp_password.expose_secret().clone(),
+    config.mailer.smtp_email.clone(),
+    config.mailer.smtp_password.clone(),
     &config.mailer.smtp_host,
     config.mailer.smtp_port,
   )

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -261,6 +261,7 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
       smtp_host: get_env_var("APPFLOWY_MAILER_SMTP_HOST", "smtp.gmail.com"),
       smtp_port: get_env_var("APPFLOWY_MAILER_SMTP_PORT", "465").parse()?,
       smtp_username: get_env_var("APPFLOWY_MAILER_SMTP_USERNAME", "sender@example.com"),
+      smtp_email: get_env_var("APPFLOWY_MAILER_SMTP_EMAIL", "sender@example.com"),
       smtp_password: get_env_var("APPFLOWY_MAILER_SMTP_PASSWORD", "password").into(),
     },
     apple_oauth: AppleOAuthSetting {


### PR DESCRIPTION
SMTP username is may not be the same as SMTP email, this PR gives option for user to specify both of them differently.

Resolves https://github.com/AppFlowy-IO/AppFlowy-Cloud/issues/984