### PR TITLE
feat: list database row

### DIFF
--- a/libs/client-api/src/http_collab.rs
+++ b/libs/client-api/src/http_collab.rs
@@ -3,7 +3,7 @@ use crate::{blocking_brotli_compress, brotli_compress, Client};
 use app_error::AppError;
 use bytes::Bytes;
 use client_api_entity::workspace_dto::{
-  AFDatabase, AFDatabaseRow, AFDatabaseRowDetail, ListDatabaseParam, ListDatabaseRowDetailParam,
+  AFDatabase, AFDatabaseRow, AFDatabaseRowDetail, ListDatabaseRowDetailParam,
 };
 use client_api_entity::{
   BatchQueryCollabParams, BatchQueryCollabResult, CollabParams, CreateCollabParams,
@@ -161,13 +161,11 @@ impl Client {
   pub async fn list_databases(
     &self,
     workspace_id: &str,
-    name_filter: Option<String>,
   ) -> Result<Vec<AFDatabase>, AppResponseError> {
     let url = format!("{}/api/workspace/{}/database", self.base_url, workspace_id);
     let resp = self
       .http_client_with_auth(Method::GET, &url)
       .await?
-      .query(&ListDatabaseParam { name_filter })
       .send()
       .await?;
     log_request_id(&resp);

--- a/libs/client-api/src/http_collab.rs
+++ b/libs/client-api/src/http_collab.rs
@@ -2,7 +2,7 @@ use crate::http::log_request_id;
 use crate::{blocking_brotli_compress, brotli_compress, Client};
 use app_error::AppError;
 use bytes::Bytes;
-use client_api_entity::workspace_dto::{AFDatabase, ListDatabaseParam};
+use client_api_entity::workspace_dto::{AFDatabase, AFDatabaseRow, ListDatabaseParam};
 use client_api_entity::{
   BatchQueryCollabParams, BatchQueryCollabResult, CollabParams, CreateCollabParams,
   DeleteCollabParams, PublishCollabItem, QueryCollab, QueryCollabParams, UpdateCollabWebParams,
@@ -166,6 +166,24 @@ impl Client {
       .http_client_with_auth(Method::GET, &url)
       .await?
       .query(&ListDatabaseParam { name_filter })
+      .send()
+      .await?;
+    log_request_id(&resp);
+    AppResponse::from_response(resp).await?.into_data()
+  }
+
+  pub async fn list_database_row_ids(
+    &self,
+    workspace_id: &str,
+    database_id: &str,
+  ) -> Result<Vec<AFDatabaseRow>, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/database/{}/row",
+      self.base_url, workspace_id, database_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
       .send()
       .await?;
     log_request_id(&resp);

--- a/libs/client-api/src/http_collab.rs
+++ b/libs/client-api/src/http_collab.rs
@@ -2,7 +2,9 @@ use crate::http::log_request_id;
 use crate::{blocking_brotli_compress, brotli_compress, Client};
 use app_error::AppError;
 use bytes::Bytes;
-use client_api_entity::workspace_dto::{AFDatabase, AFDatabaseRow, ListDatabaseParam};
+use client_api_entity::workspace_dto::{
+  AFDatabase, AFDatabaseRow, AFDatabaseRowDetail, ListDatabaseParam, ListDatabaseRowDetailParam,
+};
 use client_api_entity::{
   BatchQueryCollabParams, BatchQueryCollabResult, CollabParams, CreateCollabParams,
   DeleteCollabParams, PublishCollabItem, QueryCollab, QueryCollabParams, UpdateCollabWebParams,
@@ -184,6 +186,26 @@ impl Client {
     let resp = self
       .http_client_with_auth(Method::GET, &url)
       .await?
+      .send()
+      .await?;
+    log_request_id(&resp);
+    AppResponse::from_response(resp).await?.into_data()
+  }
+
+  pub async fn list_database_row_details(
+    &self,
+    workspace_id: &str,
+    database_id: &str,
+    row_ids: &[&str],
+  ) -> Result<Vec<AFDatabaseRowDetail>, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/database/{}/row/detail",
+      self.base_url, workspace_id, database_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .query(&ListDatabaseRowDetailParam::from(row_ids))
       .send()
       .await?;
     log_request_id(&resp);

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -330,19 +330,13 @@ pub struct PublishedView {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct AFDatabase {
   pub id: String,
-  pub names: Vec<String>,
+  pub views: Vec<FolderViewMinimal>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AFDatabaseField {
   pub name: String,
   pub field_type: String,
-}
-
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AFDatabaseMeta {
-  pub name: String,
-  pub icon: String,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -299,6 +299,22 @@ pub struct ListDatabaseParam {
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]
+pub struct ListDatabaseRowDetailParam {
+  // Comma separated database row ids
+  // e.g. "<uuid_1>,<uuid_2>,<uuid_3>"
+  pub ids: String,
+}
+
+impl ListDatabaseRowDetailParam {
+  pub fn from(ids: &[&str]) -> Self {
+    Self { ids: ids.join(",") }
+  }
+  pub fn into_ids(&self) -> Vec<&str> {
+    self.ids.split(',').collect()
+  }
+}
+
+#[derive(Default, Debug, Deserialize, Serialize)]
 pub struct QueryWorkspaceFolder {
   pub depth: Option<u32>,
   pub root_view_id: Option<String>,
@@ -338,4 +354,10 @@ pub struct AFDatabaseMeta {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct AFDatabaseRow {
   pub id: String,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AFDatabaseRowDetail {
+  pub id: String,
+  pub cells: HashMap<String, HashMap<String, String>>,
 }

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -294,11 +294,6 @@ pub struct QueryWorkspaceParam {
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]
-pub struct ListDatabaseParam {
-  pub name_filter: Option<String>, // logic: if database name contains
-}
-
-#[derive(Default, Debug, Deserialize, Serialize)]
 pub struct ListDatabaseRowDetailParam {
   // Comma separated database row ids
   // e.g. "<uuid_1>,<uuid_2>,<uuid_3>"
@@ -336,7 +331,6 @@ pub struct PublishedView {
 pub struct AFDatabase {
   pub id: String,
   pub names: Vec<String>,
-  pub fields: Vec<AFDatabaseField>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -334,3 +334,8 @@ pub struct AFDatabaseMeta {
   pub name: String,
   pub icon: String,
 }
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct AFDatabaseRow {
+  pub id: String,
+}

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -347,5 +347,5 @@ pub struct AFDatabaseRow {
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AFDatabaseRowDetail {
   pub id: String,
-  pub cells: HashMap<String, HashMap<String, String>>,
+  pub cells: HashMap<String, HashMap<String, serde_json::Value>>,
 }

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1866,9 +1866,7 @@ async fn list_database_handler(
   user_uuid: UserUuid,
   workspace_id: web::Path<String>,
   state: Data<AppState>,
-  query: web::Query<ListDatabaseParam>,
 ) -> Result<Json<AppResponse<Vec<AFDatabase>>>> {
-  let name_filter = query.into_inner().name_filter;
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let workspace_id = workspace_id.into_inner();
   let dbs = biz::collab::ops::list_database(
@@ -1876,7 +1874,6 @@ async fn list_database_handler(
     &state.collab_access_control_storage,
     uid,
     workspace_id,
-    name_filter,
   )
   .await?;
   Ok(Json(AppResponse::Ok().with_data(dbs)))

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -256,6 +256,10 @@ pub fn workspace_scope() -> Scope {
       .route(web::post().to(batch_get_collab_handler)),
     )
     .service(web::resource("/{workspace_id}/database").route(web::get().to(list_database_handler)))
+    .service(
+      web::resource("/{workspace_id}/database/{database_id}/row")
+        .route(web::get().to(list_database_row_id_handler)),
+    )
 }
 
 pub fn collab_scope() -> Scope {
@@ -1872,6 +1876,25 @@ async fn list_database_handler(
   )
   .await?;
   Ok(Json(AppResponse::Ok().with_data(dbs)))
+}
+
+async fn list_database_row_id_handler(
+  user_uuid: UserUuid,
+  path_param: web::Path<(String, String)>,
+  state: Data<AppState>,
+) -> Result<Json<AppResponse<Vec<AFDatabaseRow>>>> {
+  let (workspace_id, db_id) = path_param.into_inner();
+  let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+
+  state
+    .workspace_access_control
+    .enforce_action(&uid, &workspace_id, Action::Read)
+    .await?;
+
+  let db_rows =
+    biz::collab::ops::list_database_row(&state.collab_access_control_storage, workspace_id, db_id)
+      .await?;
+  Ok(Json(AppResponse::Ok().with_data(db_rows)))
 }
 
 #[inline]

--- a/tests/workspace/workspace_crud.rs
+++ b/tests/workspace/workspace_crud.rs
@@ -45,7 +45,7 @@ async fn workspace_list_database() {
         //         "field_type": "MultiSelect",
         //         "last_modified": "2024-08-16T07:23:57+00:00",
         //         "created_at": "2024-08-16T07:23:35+00:00",
-        //         "data": "BD-T,6UxM",
+        //         "data": "looks great,fast",
         //     },
         //     "Description": {
         //         "field_type": "RichText",
@@ -54,7 +54,7 @@ async fn workspace_list_database() {
         //         "data": "Install AppFlowy Mobile",
         //     },
         //     "Status": {
-        //         "data": "CEZD",
+        //         "data": "To Do",
         //         "field_type": "SingleSelect",
         //     },
         // },
@@ -64,14 +64,14 @@ async fn workspace_list_database() {
             row.cells["Multiselect"]["field_type"] == "MultiSelect"
               && row.cells["Multiselect"]["last_modified"] == "2024-08-16T07:23:57+00:00"
               && row.cells["Multiselect"]["created_at"] == "2024-08-16T07:23:35+00:00"
-              && row.cells["Multiselect"]["data"] == "BD-T,6UxM"
+              && row.cells["Multiselect"]["data"] == "looks great,fast"
               // Description
               && row.cells["Description"]["field_type"] == "RichText"
               && row.cells["Description"]["last_modified"] == "2024-08-16T07:17:03+00:00"
               && row.cells["Description"]["created_at"] == "2024-08-16T07:16:51+00:00"
               && row.cells["Description"]["data"] == "Install AppFlowy Mobile"
               // Status
-              && row.cells["Status"]["data"] == "CEZD"
+              && row.cells["Status"]["data"] == "To Do"
               && row.cells["Status"]["field_type"] == "SingleSelect"
           })
           .unwrap();

--- a/tests/workspace/workspace_crud.rs
+++ b/tests/workspace/workspace_crud.rs
@@ -15,8 +15,8 @@ async fn workspace_list_database() {
     let dbs = c.list_databases(&workspace_id).await.unwrap();
     assert_eq!(dbs.len(), 1, "{:?}", dbs);
     let todos_db = &dbs[0];
-    assert_eq!(todos_db.names.len(), 1);
-    assert!(todos_db.names.contains(&String::from("To-dos")));
+    assert_eq!(todos_db.views.len(), 1);
+    assert_eq!(todos_db.views[0].name, "To-dos");
     {
       let db_row_ids = c
         .list_database_row_ids(&workspace_id, &todos_db.id)

--- a/tests/workspace/workspace_crud.rs
+++ b/tests/workspace/workspace_crud.rs
@@ -64,6 +64,51 @@ async fn workspace_list_database() {
         .await
         .unwrap();
       assert_eq!(db_row_ids.len(), 5, "{:?}", db_row_ids);
+      {
+        let db_row_ids: Vec<&str> = db_row_ids.iter().map(|s| s.id.as_str()).collect();
+        let db_row_ids: &[&str] = &db_row_ids;
+        let db_row_details = c
+          .list_database_row_details(&workspace_id, &untitled_db.id, db_row_ids)
+          .await
+          .unwrap();
+        assert_eq!(db_row_details.len(), 5, "{:#?}", db_row_details);
+
+        // cells: {
+        //     "Multiselect": {
+        //         "field_type": "MultiSelect",
+        //         "last_modified": "2024-08-16T07:23:57+00:00",
+        //         "created_at": "2024-08-16T07:23:35+00:00",
+        //         "data": "BD-T,6UxM",
+        //     },
+        //     "Description": {
+        //         "field_type": "RichText",
+        //         "last_modified": "2024-08-16T07:17:03+00:00",
+        //         "created_at": "2024-08-16T07:16:51+00:00",
+        //         "data": "Install AppFlowy Mobile",
+        //     },
+        //     "Status": {
+        //         "data": "CEZD",
+        //         "field_type": "SingleSelect",
+        //     },
+        // },
+        let _ = db_row_details
+          .into_iter()
+          .find(|row| {
+            row.cells["Multiselect"]["field_type"] == "MultiSelect"
+              && row.cells["Multiselect"]["last_modified"] == "2024-08-16T07:23:57+00:00"
+              && row.cells["Multiselect"]["created_at"] == "2024-08-16T07:23:35+00:00"
+              && row.cells["Multiselect"]["data"] == "BD-T,6UxM"
+              // Description
+              && row.cells["Description"]["field_type"] == "RichText"
+              && row.cells["Description"]["last_modified"] == "2024-08-16T07:17:03+00:00"
+              && row.cells["Description"]["created_at"] == "2024-08-16T07:16:51+00:00"
+              && row.cells["Description"]["data"] == "Install AppFlowy Mobile"
+              // Status
+              && row.cells["Status"]["data"] == "CEZD"
+              && row.cells["Status"]["field_type"] == "SingleSelect"
+          })
+          .unwrap();
+      }
     }
   }
   {

--- a/tests/workspace/workspace_crud.rs
+++ b/tests/workspace/workspace_crud.rs
@@ -57,6 +57,14 @@ async fn workspace_list_database() {
       .await
       .unwrap();
     assert_eq!(dbs.len(), 1);
+    {
+      let untitled_db = &dbs[0];
+      let db_row_ids = c
+        .list_database_row_ids(&workspace_id, &untitled_db.id)
+        .await
+        .unwrap();
+      assert_eq!(db_row_ids.len(), 5, "{:?}", db_row_ids);
+    }
   }
   {
     let dbs = c
@@ -64,6 +72,14 @@ async fn workspace_list_database() {
       .await
       .unwrap();
     assert_eq!(dbs.len(), 1);
+    {
+      let grid_db = &dbs[0];
+      let db_row_ids = c
+        .list_database_row_ids(&workspace_id, &grid_db.id)
+        .await
+        .unwrap();
+      assert_eq!(db_row_ids.len(), 5, "{:?}", db_row_ids);
+    }
   }
 }
 


### PR DESCRIPTION
## API to list all database row ids
- Incur lookup for 1 Database Collab
- Fetches only ids of row, so operation is not expensive
- Allows external services to poll this api, using difference in ID to detect if a row was added

## API to get database row detail for row ids
- Incur 1 Database collab look up + number for rows looked up
- Transform result into human readable format

## Simplify Database Listing
- Incur 1 Workspace Database collab lookup + 1 Folder Collab lookup
- Get names based on folder
- Previously, a lookup was for every database
- As a result, there is no need for filtering in the backend