### PR TITLE
feat: add a polling api for getting database row id updates

### DIFF
--- a/.sqlx/query-1331f64dbbf63fc694e3358aefd2bdc4b3bcff64eda36420acde1a948884239d.json
+++ b/.sqlx/query-1331f64dbbf63fc694e3358aefd2bdc4b3bcff64eda36420acde1a948884239d.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT\n        updated_at as updated_at,\n        oid as row_id\n      FROM af_collab_database_row\n      WHERE workspace_id = $1\n        AND oid = ANY($2)\n        AND updated_at > $3\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 1,
+        "name": "row_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "1331f64dbbf63fc694e3358aefd2bdc4b3bcff64eda36420acde1a948884239d"
+}

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -300,6 +300,17 @@ pub struct ListDatabaseRowDetailParam {
   pub ids: String,
 }
 
+#[derive(Default, Debug, Deserialize, Serialize)]
+pub struct ListDatabaseRowUpdatedParam {
+  pub after: Option<DateTime<Utc>>,
+}
+
+#[derive(Default, Debug, Deserialize, Serialize)]
+pub struct DatabaseRowUpdatedItem {
+  pub updated_at: DateTime<Utc>,
+  pub row_id: String,
+}
+
 impl ListDatabaseRowDetailParam {
   pub fn from(ids: &[&str]) -> Self {
     Self { ids: ids.join(",") }

--- a/migrations/20241124212630_af_collab_updated_at.sql
+++ b/migrations/20241124212630_af_collab_updated_at.sql
@@ -1,0 +1,22 @@
+-- Add `updated_at` column to `af_collab` table
+ALTER TABLE public.af_collab
+ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Create or replace function to update `updated_at` column
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to update `updated_at` column
+CREATE TRIGGER set_updated_at
+BEFORE INSERT OR UPDATE ON public.af_collab
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+-- Create index on `updated_at` column
+CREATE INDEX idx_af_collab_updated_at
+ON public.af_collab (updated_at);

--- a/tests/workspace/workspace_crud.rs
+++ b/tests/workspace/workspace_crud.rs
@@ -24,6 +24,13 @@ async fn workspace_list_database() {
         .unwrap();
       assert_eq!(db_row_ids.len(), 5, "{:?}", db_row_ids);
     }
+    {
+      let db_row_ids = c
+        .list_database_row_ids_updated(&workspace_id, &todos_db.id, None)
+        .await
+        .unwrap();
+      assert_eq!(db_row_ids.len(), 5, "{:?}", db_row_ids);
+    }
 
     {
       let db_row_ids = c


### PR DESCRIPTION
## Add API endpoint to poll for database row update
- Optionally receives `after` as param, if not given, will be defaulted to 1 hour ago.
- Read after Write is not supported, i.e. if database row is updated or inserted, and this api is called right after, it will not fetch the latest update. Update will be eventually be fetched (within 5 minutes).
- Returns only database row id, not the data itself.
