### PR TITLE
fix: remove only parent page when move to trash

### DIFF
--- a/libs/client-api/src/http_view.rs
+++ b/libs/client-api/src/http_view.rs
@@ -27,7 +27,7 @@ impl Client {
   pub async fn move_workspace_page_view_to_trash(
     &self,
     workspace_id: Uuid,
-    view_id: String,
+    view_id: &str,
   ) -> Result<(), AppResponseError> {
     let url = format!(
       "{}/api/workspace/{}/page-view/{}/move-to-trash",

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -309,9 +309,13 @@ async fn move_view_to_trash(view_id: &str, folder: &mut Folder) -> Result<Folder
     let mut txn = folder.collab.transact_mut();
     current_view_and_descendants.iter().for_each(|view_id| {
       folder.body.views.update_view(&mut txn, view_id, |update| {
-        update.set_favorite(false).set_trash(true).done()
+        update.set_favorite(false).done()
       });
     });
+    folder
+      .body
+      .views
+      .update_view(&mut txn, view_id, |update| update.set_trash(true).done());
     txn.encode_update_v1()
   };
 

--- a/tests/workspace/page_view.rs
+++ b/tests/workspace/page_view.rs
@@ -161,7 +161,7 @@ async fn move_page_to_trash() {
   for view_id in view_ids_to_be_deleted.iter() {
     app_client
       .api_client
-      .move_workspace_page_view_to_trash(Uuid::parse_str(&workspace_id).unwrap(), view_id.clone())
+      .move_workspace_page_view_to_trash(Uuid::parse_str(&workspace_id).unwrap(), view_id)
       .await
       .unwrap();
   }
@@ -227,6 +227,80 @@ async fn move_page_to_trash() {
     .views
     .iter()
     .any(|v| v.view.view_id == view_ids_to_be_deleted[1]);
+  assert!(!view_found);
+}
+
+#[tokio::test]
+async fn move_page_with_child_to_trash() {
+  let registered_user = generate_unique_registered_user().await;
+  let mut app_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let web_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let workspace_id = app_client.workspace_id().await;
+  let folder_view = web_client
+    .api_client
+    .get_workspace_folder(&workspace_id, Some(2), None)
+    .await
+    .unwrap();
+  let general_space = &folder_view
+    .children
+    .into_iter()
+    .find(|v| v.name == "General")
+    .unwrap();
+  app_client.open_workspace_collab(&workspace_id).await;
+  app_client
+    .wait_object_sync_complete(&workspace_id)
+    .await
+    .unwrap();
+  app_client
+    .api_client
+    .move_workspace_page_view_to_trash(
+      Uuid::parse_str(&workspace_id).unwrap(),
+      &general_space.view_id,
+    )
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  let views_in_trash_for_app = folder
+    .get_my_trash_sections()
+    .iter()
+    .map(|v| v.id.clone())
+    .collect::<HashSet<String>>();
+  assert!(views_in_trash_for_app.contains(&general_space.view_id));
+  for view in general_space.children.iter() {
+    assert!(!views_in_trash_for_app.contains(&view.view_id));
+  }
+  let views_in_trash_for_web = web_client
+    .api_client
+    .get_workspace_trash(&workspace_id)
+    .await
+    .unwrap()
+    .views
+    .iter()
+    .map(|v| v.view.view_id.clone())
+    .collect::<HashSet<String>>();
+  assert!(views_in_trash_for_web.contains(&general_space.view_id));
+
+  web_client
+    .api_client
+    .restore_workspace_page_view_from_trash(
+      Uuid::parse_str(&workspace_id).unwrap(),
+      &general_space.view_id,
+    )
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  assert!(!folder
+    .get_my_trash_sections()
+    .iter()
+    .any(|v| v.id == general_space.view_id));
+  let view_found = web_client
+    .api_client
+    .get_workspace_trash(&workspace_id)
+    .await
+    .unwrap()
+    .views
+    .iter()
+    .any(|v| v.view.view_id == general_space.view_id);
   assert!(!view_found);
 }
 


### PR DESCRIPTION
Modify the move to trash API behaviour such that, if a parent is move to trash section, the child doesn't.