### PR TITLE
chore: make collab storage switch between s3 and postgres configurable

### DIFF
--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -22,10 +22,6 @@ use validator::Validate;
 /// The default compression level of ZSTD-compressed collabs.
 pub const ZSTD_COMPRESSION_LEVEL: i32 = 3;
 
-/// The threshold used to determine whether collab data should land
-/// in S3 or Postgres. Collabs with size below this value will land into Postgres.
-pub const S3_COLLAB_THRESHOLD: usize = 2000;
-
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 pub struct CreateCollabParams {
   #[validate(custom = "validate_not_empty_str")]

--- a/services/appflowy-collaborate/src/application.rs
+++ b/services/appflowy-collaborate/src/application.rs
@@ -130,6 +130,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     redis_conn_manager.clone(),
     pg_pool.clone(),
     s3_client.clone(),
+    config.collab.s3_collab_threshold as usize,
   );
 
   let collab_storage_access_control = CollabStorageAccessControlImpl {

--- a/services/appflowy-collaborate/src/config.rs
+++ b/services/appflowy-collaborate/src/config.rs
@@ -128,6 +128,7 @@ pub struct CollabSetting {
   pub group_persistence_interval_secs: u64,
   pub edit_state_max_count: u32,
   pub edit_state_max_secs: i64,
+  pub s3_collab_threshold: u64,
 }
 
 pub fn get_env_var(key: &str, default: &str) -> String {
@@ -191,6 +192,7 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
       .parse()?,
       edit_state_max_count: get_env_var("APPFLOWY_COLLAB_EDIT_STATE_MAX_COUNT", "100").parse()?,
       edit_state_max_secs: get_env_var("APPFLOWY_COLLAB_EDIT_STATE_MAX_SECS", "60").parse()?,
+      s3_collab_threshold: get_env_var("APPFLOWY_COLLAB_S3_THRESHOLD", "8000").parse()?,
     },
     redis_uri: get_env_var("APPFLOWY_REDIS_URI", "redis://localhost:6379").into(),
     ai: AISettings {

--- a/src/application.rs
+++ b/src/application.rs
@@ -285,6 +285,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     redis_conn_manager.clone(),
     pg_pool.clone(),
     s3_client.clone(),
+    config.collab.s3_collab_threshold as usize,
   );
 
   let collab_storage_access_control = CollabStorageAccessControlImpl {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -145,6 +145,7 @@ pub struct CollabSetting {
   pub group_persistence_interval_secs: u64,
   pub edit_state_max_count: u32,
   pub edit_state_max_secs: i64,
+  pub s3_collab_threshold: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -251,6 +252,7 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
       .parse()?,
       edit_state_max_count: get_env_var("APPFLOWY_COLLAB_EDIT_STATE_MAX_COUNT", "100").parse()?,
       edit_state_max_secs: get_env_var("APPFLOWY_COLLAB_EDIT_STATE_MAX_SECS", "60").parse()?,
+      s3_collab_threshold: get_env_var("APPFLOWY_COLLAB_S3_THRESHOLD", "60").parse()?,
     },
     published_collab: PublishedCollabSetting {
       storage_backend: get_env_var("APPFLOWY_PUBLISHED_COLLAB_STORAGE_BACKEND", "postgres")


### PR DESCRIPTION
This PR enables setting up a threshold, by which collabs land in either S3 or Postgres to be an env var `APPFLOWY_COLLAB_S3_THRESHOLD` (defaults to 8000 bytes so that it fits a singe Postgres TOAST page, but not more). 