### PR TITLE
fix: web update should update both disk and mem cache

### DIFF
--- a/libs/database/src/collab/collab_storage.rs
+++ b/libs/database/src/collab/collab_storage.rs
@@ -94,7 +94,7 @@ pub trait CollabStorage: Send + Sync + 'static {
   /// # Returns
   ///
   /// * `Result<()>` - Returns `Ok(())` if the collaboration was created successfully, `Err` otherwise.
-  async fn insert_new_collab_with_transaction(
+  async fn upsert_new_collab_with_transaction(
     &self,
     workspace_id: &str,
     uid: &i64,

--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -343,7 +343,7 @@ where
 
   #[instrument(level = "trace", skip(self, params), oid = %params.oid, ty = %params.collab_type, err)]
   #[allow(clippy::blocks_in_conditions)]
-  async fn insert_new_collab_with_transaction(
+  async fn upsert_new_collab_with_transaction(
     &self,
     workspace_id: &str,
     uid: &i64,

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -705,7 +705,7 @@ async fn create_collab_handler(
   let action = format!("Create new collab: {}", params);
   state
     .collab_access_control_storage
-    .insert_new_collab_with_transaction(&workspace_id, &uid, params, &mut transaction, &action)
+    .upsert_new_collab_with_transaction(&workspace_id, &uid, params, &mut transaction, &action)
     .await?;
 
   transaction
@@ -911,6 +911,7 @@ async fn post_web_update_handler(
     .await
     .map_err(AppResponseError::from)?;
   update_page_collab_data(
+    &state.pg_pool,
     state.collab_access_control_storage.clone(),
     state.metrics.appflowy_web_metrics.clone(),
     uid,

--- a/src/biz/user/user_init.rs
+++ b/src/biz/user/user_init.rs
@@ -130,7 +130,7 @@ pub(crate) async fn create_user_awareness(
     .map_err(|err| AppError::Internal(anyhow::Error::from(err)))?;
 
   storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       workspace_id,
       uid,
       CollabParams {
@@ -167,7 +167,7 @@ pub(crate) async fn create_workspace_collab(
     .map_err(|err| AppError::Internal(anyhow::Error::from(err)))?;
 
   storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       workspace_id,
       &uid,
       CollabParams {
@@ -206,7 +206,7 @@ pub(crate) async fn create_workspace_database_collab(
     .map_err(|err| AppError::Internal(anyhow::Error::from(err)))?;
 
   storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       workspace_id,
       uid,
       CollabParams {

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -131,7 +131,7 @@ pub async fn create_space(
   let mut transaction = pg_pool.begin().await?;
   let action = format!("Create new space: {}", view_id);
   collab_storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       &workspace_id.to_string(),
       &uid,
       default_document_collab_params,
@@ -652,7 +652,7 @@ async fn insert_and_broadcast_workspace_database_update(
   };
   let action_description = format!("Update workspace database: {}", workspace_id);
   collab_storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       &workspace_id.to_string(),
       &uid,
       params,
@@ -684,7 +684,7 @@ async fn insert_and_broadcast_workspace_folder_update(
   };
   let action_description = format!("Update workspace folder: {}", workspace_id);
   collab_storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       &workspace_id.to_string(),
       &uid,
       params,
@@ -726,7 +726,7 @@ async fn create_document_page(
   let mut transaction = pg_pool.begin().await?;
   let action = format!("Create new collab: {}", view_id);
   collab_storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       &workspace_id.to_string(),
       &uid,
       default_document_collab_params,
@@ -876,7 +876,7 @@ async fn create_database_page(
   let mut transaction = pg_pool.begin().await?;
   let action = format!("Create new database collab: {}", database_id);
   collab_storage
-    .insert_new_collab_with_transaction(
+    .upsert_new_collab_with_transaction(
       &workspace_id.to_string(),
       &uid,
       database_collab_params,
@@ -1225,7 +1225,9 @@ async fn get_page_collab_data_for_document(
   })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn update_page_collab_data(
+  pg_pool: &PgPool,
   collab_access_control_storage: Arc<CollabAccessControlStorage>,
   appflowy_web_metrics: Arc<AppFlowyWebMetrics>,
   uid: i64,
@@ -1264,9 +1266,17 @@ pub async fn update_page_collab_data(
     encoded_collab_v1: updated_encoded_collab.into(),
     embeddings: None,
   };
+  let mut transaction = pg_pool.begin().await?;
   collab_access_control_storage
-    .queue_insert_or_update_collab(&workspace_id.to_string(), &uid, params, true)
+    .upsert_new_collab_with_transaction(
+      &workspace_id.to_string(),
+      &uid,
+      params,
+      &mut transaction,
+      "upsert collab",
+    )
     .await?;
+  transaction.commit().await?;
   broadcast_update(
     &collab_access_control_storage,
     &object_id.to_string(),

--- a/src/biz/workspace/publish_dup.rs
+++ b/src/biz/workspace/publish_dup.rs
@@ -183,7 +183,7 @@ impl PublishCollabDuplicator {
       };
       let action = format!("duplicate collab: {}", params);
       collab_storage
-        .insert_new_collab_with_transaction(
+        .upsert_new_collab_with_transaction(
           &dest_workspace_id,
           &duplicator_uid,
           params,
@@ -239,7 +239,7 @@ impl PublishCollabDuplicator {
       let updated_ws_w_db_collab = updated_ws_w_db_collab?;
 
       collab_storage
-        .insert_new_collab_with_transaction(
+        .upsert_new_collab_with_transaction(
           &dest_workspace_id,
           &duplicator_uid,
           CollabParams {
@@ -331,7 +331,7 @@ impl PublishCollabDuplicator {
     .await?;
 
     collab_storage
-      .insert_new_collab_with_transaction(
+      .upsert_new_collab_with_transaction(
         &dest_workspace_id,
         &duplicator_uid,
         CollabParams {


### PR DESCRIPTION
1. Rename insert _new_collab_with_transaction to upsert_new_collab_with_transaction , as the operation will update existing collab if found.

2. web-update endpoint should use this method so that both mem and disk cache will be updated.