### PR TITLE
fix: filter non space document from workspace's children

### DIFF
--- a/src/biz/collab/ops.rs
+++ b/src/biz/collab/ops.rs
@@ -295,7 +295,13 @@ pub async fn get_user_workspace_structure(
     .into_iter()
     .map(|id| id.to_string())
     .collect();
-  collab_folder_to_folder_view(root_view_id, &folder, depth, &publish_view_ids)
+  collab_folder_to_folder_view(
+    workspace_id,
+    root_view_id,
+    &folder,
+    depth,
+    &publish_view_ids,
+  )
 }
 
 pub async fn get_latest_workspace_database(

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -48,7 +48,7 @@ use crate::biz::collab::folder_view::{
 };
 use crate::biz::collab::ops::{collab_from_doc_state, get_latest_workspace_database};
 use crate::biz::collab::{
-  folder_view::view_is_space,
+  folder_view::check_if_view_is_space,
   ops::{get_latest_collab_encoded, get_latest_collab_folder},
 };
 
@@ -1054,7 +1054,7 @@ pub async fn get_page_view_collab(
       .icon
       .as_ref()
       .map(|icon| to_dto_view_icon(icon.clone())),
-    is_space: view_is_space(&view),
+    is_space: check_if_view_is_space(&view),
     is_private: false,
     is_published: publish_view_ids.contains(view_id),
     layout: to_dto_view_layout(&view.layout),


### PR DESCRIPTION
Filter out documents which is not a space from workspace's children.

Some existing tests failed as the documents are created under a workspace as opposed to a space, which has been modified in this PR.