### PR TITLE
Remove async awaits from RealtimeServerActor

### DIFF
--- a/services/appflowy-collaborate/src/actix_ws/client/rt_client.rs
+++ b/services/appflowy-collaborate/src/actix_ws/client/rt_client.rs
@@ -28,8 +28,8 @@ pub type HandlerResult = ResponseFuture<anyhow::Result<(), RealtimeError>>;
 pub trait RealtimeServer:
   Actor<Context = Context<Self>>
   + Handler<ClientMessage, Result = HandlerResult>
-  + Handler<Connect, Result = HandlerResult>
-  + Handler<Disconnect, Result = HandlerResult>
+  + Handler<Connect, Result = anyhow::Result<(), RealtimeError>>
+  + Handler<Disconnect, Result = anyhow::Result<(), RealtimeError>>
 {
 }
 

--- a/services/appflowy-collaborate/src/actix_ws/client/rt_client.rs
+++ b/services/appflowy-collaborate/src/actix_ws/client/rt_client.rs
@@ -3,7 +3,7 @@ use crate::error::RealtimeError;
 use crate::RealtimeClientWebsocketSink;
 use actix::{
   fut, Actor, ActorContext, ActorFutureExt, Addr, AsyncContext, Context, ContextFutureSpawner,
-  Handler, MailboxError, Recipient, ResponseFuture, Running, StreamHandler, WrapFuture,
+  Handler, MailboxError, Recipient, Running, StreamHandler, WrapFuture,
 };
 use actix_web_actors::ws;
 use actix_web_actors::ws::{CloseCode, CloseReason, ProtocolError, WebsocketContext};
@@ -24,12 +24,12 @@ use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tracing::{debug, error, trace, warn};
 
-pub type HandlerResult = ResponseFuture<anyhow::Result<(), RealtimeError>>;
+pub type HandlerResult = anyhow::Result<(), RealtimeError>;
 pub trait RealtimeServer:
   Actor<Context = Context<Self>>
   + Handler<ClientMessage, Result = HandlerResult>
-  + Handler<Connect, Result = anyhow::Result<(), RealtimeError>>
-  + Handler<Disconnect, Result = anyhow::Result<(), RealtimeError>>
+  + Handler<Connect, Result = HandlerResult>
+  + Handler<Disconnect, Result = HandlerResult>
 {
 }
 

--- a/services/appflowy-collaborate/src/actix_ws/server/rt_actor.rs
+++ b/services/appflowy-collaborate/src/actix_ws/server/rt_actor.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use actix::{Actor, Context, Handler, ResponseFuture};
+use actix::{Actor, Context, Handler};
 use tracing::{error, info, warn};
 
 use crate::error::RealtimeError;
@@ -85,7 +85,7 @@ impl<S> Handler<ClientMessage> for RealtimeServerActor<S>
 where
   S: CollabStorage + Unpin,
 {
-  type Result = ResponseFuture<anyhow::Result<(), RealtimeError>>;
+  type Result = anyhow::Result<(), RealtimeError>;
 
   fn handle(&mut self, client_msg: ClientMessage, _ctx: &mut Context<Self>) -> Self::Result {
     let ClientMessage { user, message } = client_msg;
@@ -95,7 +95,7 @@ where
         if cfg!(debug_assertions) {
           error!("parse client message error: {}", err);
         }
-        Box::pin(async { Ok(()) })
+        Ok(())
       },
     }
   }
@@ -105,7 +105,7 @@ impl<S> Handler<ClientStreamMessage> for RealtimeServerActor<S>
 where
   S: CollabStorage + Unpin,
 {
-  type Result = ResponseFuture<anyhow::Result<(), RealtimeError>>;
+  type Result = anyhow::Result<(), RealtimeError>;
 
   fn handle(&mut self, client_msg: ClientStreamMessage, _ctx: &mut Context<Self>) -> Self::Result {
     let ClientStreamMessage {
@@ -121,13 +121,13 @@ where
       (Some(user), Ok(messages)) => self.handle_client_message(user, messages),
       (None, _) => {
         warn!("Can't find the realtime user uid:{}, device:{}. User should connect via websocket before", uid,device_id);
-        Box::pin(async { Ok(()) })
+        Ok(())
       },
       (Some(_), Err(err)) => {
         if cfg!(debug_assertions) {
           error!("parse client message error: {}", err);
         }
-        Box::pin(async { Ok(()) })
+        Ok(())
       },
     }
   }

--- a/services/appflowy-collaborate/src/actix_ws/server/rt_actor.rs
+++ b/services/appflowy-collaborate/src/actix_ws/server/rt_actor.rs
@@ -63,7 +63,7 @@ impl<S> Handler<Connect> for RealtimeServerActor<S>
 where
   S: CollabStorage + Unpin,
 {
-  type Result = ResponseFuture<anyhow::Result<(), RealtimeError>>;
+  type Result = anyhow::Result<(), RealtimeError>;
 
   fn handle(&mut self, new_conn: Connect, _ctx: &mut Context<Self>) -> Self::Result {
     let conn_sink = RealtimeClientWebsocketSinkImpl(new_conn.socket);
@@ -75,7 +75,7 @@ impl<S> Handler<Disconnect> for RealtimeServerActor<S>
 where
   S: CollabStorage + Unpin,
 {
-  type Result = ResponseFuture<anyhow::Result<(), RealtimeError>>;
+  type Result = anyhow::Result<(), RealtimeError>;
   fn handle(&mut self, msg: Disconnect, _: &mut Context<Self>) -> Self::Result {
     self.handle_disconnect(msg.user)
   }

--- a/services/appflowy-collaborate/src/group/broadcast.rs
+++ b/services/appflowy-collaborate/src/group/broadcast.rs
@@ -10,6 +10,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::select;
 use tokio::sync::broadcast::{channel, Sender};
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, trace, warn};
 use yrs::encoding::write::Write;
 use yrs::updates::decoder::DecoderV1;
@@ -164,7 +165,7 @@ impl CollabBroadcast {
   /// # Returns
   /// A `Subscription` instance that represents the active subscription. Dropping this structure or
   /// calling its `stop` method will unsubscribe the connection and cease all related activities.
-  ///
+  #[allow(clippy::too_many_arguments)]
   pub fn subscribe<Sink, Stream>(
     &self,
     user: &RealtimeUser,
@@ -173,95 +174,85 @@ impl CollabBroadcast {
     mut stream: Stream,
     collab: Weak<RwLock<Collab>>,
     metrics_calculate: Arc<CollabRealtimeMetrics>,
+    cancel: CancellationToken,
   ) -> Subscription
   where
     Sink: SinkExt<CollabMessage> + Clone + Send + Sync + Unpin + 'static,
     Stream: StreamExt<Item = MessageByObjectId> + Send + Sync + Unpin + 'static,
     <Sink as futures_util::Sink<CollabMessage>>::Error: std::error::Error + Send + Sync,
   {
-    let sink_stop_tx = {
-      let mut sink = sink.clone();
-      let (stop_tx, mut stop_rx) = tokio::sync::mpsc::channel::<()>(1);
+    // the receiver will continue to receive updates from the document observer and forward the update to
+    // connected subscriber using its Sink. The loop will break if the stop_rx receives a message.
+    let mut receiver = self.broadcast_sender.subscribe();
+    let cloned_user = user.clone();
+    let cancel_sink = cancel.clone();
+    let mut sink2 = sink.clone();
+    tokio::spawn(async move {
+      loop {
+        select! {
+          _ = cancel_sink.cancelled() => break,
+          result = receiver.recv() => {
+            match result {
+              Ok(message) => {
 
-      // the receiver will continue to receive updates from the document observer and forward the update to
-      // connected subscriber using its Sink. The loop will break if the stop_rx receives a message.
-      let mut receiver = self.broadcast_sender.subscribe();
-      let cloned_user = user.clone();
-      tokio::spawn(async move {
-        loop {
-          select! {
-            _ = stop_rx.recv() => break,
-            result = receiver.recv() => {
-              match result {
-                Ok(message) => {
-
-                  // No need to broadcast the message back to the originator
-                  if message.origin() == &subscriber_origin {
-                    continue;
-                  }
-
-                  trace!("[realtime]: send {} => {}", message, cloned_user.user_device());
-                  if let Err(err) = sink.send(message).await {
-                    warn!("fail to broadcast message:{}", err);
-                  }
+                // No need to broadcast the message back to the originator
+                if message.origin() == &subscriber_origin {
+                  continue;
                 }
-                Err(_) => {
-                  // Err(RecvError::Closed) is returned when all Sender halves have dropped,
-                  // indicating that no further values can be sent on the channel.
-                  break;
-                },
+
+                trace!("[realtime]: send {} => {}", message, cloned_user.user_device());
+                if let Err(err) = sink2.send(message).await {
+                  warn!("fail to broadcast message:{}", err);
+                }
               }
-            },
-          }
+              Err(_) => {
+                // Err(RecvError::Closed) is returned when all Sender halves have dropped,
+                // indicating that no further values can be sent on the channel.
+                break;
+              },
+            }
+          },
         }
-      });
-      stop_tx
-    };
+      }
+    });
 
     let user = user.clone();
-    let stream_stop_tx = {
-      let (stream_stop_tx, mut stop_rx) = tokio::sync::mpsc::channel::<()>(1);
-      let object_id = self.object_id.clone();
-      let edit_state = self.edit_state.clone();
+    let cancel_stream = cancel.clone();
+    let object_id = self.object_id.clone();
+    let edit_state = self.edit_state.clone();
 
-      // the stream will continue to receive messages from the client and it will stop if the stop_rx
-      // receives a message. If the client's message alter the document state, it will trigger the
-      // document observer and broadcast the update to all connected subscribers. Check out the [observe_update_v1] and [sink_task] above.
-      tokio::spawn(async move {
-        loop {
-          select! {
-            _ = stop_rx.recv() => {
-             trace!("stop receiving {} stream from user:{} connect at:{}", object_id, user.uid, user.connect_at);
+    // the stream will continue to receive messages from the client and it will stop if the stop_rx
+    // receives a message. If the client's message alter the document state, it will trigger the
+    // document observer and broadcast the update to all connected subscribers. Check out the [observe_update_v1] and [sink_task] above.
+    tokio::spawn(async move {
+      loop {
+        select! {
+          _ = cancel_stream.cancelled() => {
+           trace!("stop receiving {} stream from user:{} connect at:{}", object_id, user.uid, user.connect_at);
+            break
+          },
+          result = stream.next() => {
+            if result.is_none() {
+              trace!("{} stop receiving user:{} messages", object_id, user.user_device());
               break
-            },
-            result = stream.next() => {
-              if result.is_none() {
-                trace!("{} stop receiving user:{} messages", object_id, user.user_device());
+            }
+            let message_map = result.unwrap();
+            match collab.upgrade() {
+              None => {
+                trace!("{} stop receiving user:{} messages because of collab is drop", user.user_device(), object_id);
+                // break the loop if the collab is dropped
                 break
-              }
-              let message_map = result.unwrap();
-              match collab.upgrade() {
-                None => {
-                  trace!("{} stop receiving user:{} messages because of collab is drop", user.user_device(), object_id);
-                  // break the loop if the collab is dropped
-                  break
-                },
-                Some(collab) => {
-                  handle_client_messages(&object_id, message_map, &mut sink, collab, &metrics_calculate, &edit_state).await;
-                }
+              },
+              Some(collab) => {
+                handle_client_messages(&object_id, message_map, &mut sink, collab, &metrics_calculate, &edit_state).await;
               }
             }
           }
         }
-      });
+      }
+    });
 
-      stream_stop_tx
-    };
-
-    Subscription {
-      sink_stop_tx: Some(sink_stop_tx),
-      stream_stop_tx: Some(stream_stop_tx),
-    }
+    Subscription { cancel }
   }
 }
 
@@ -487,32 +478,12 @@ fn ack_code_from_error(error: &RTProtocolError) -> AckCode {
 /// connection error or closed connection).
 #[derive(Debug)]
 pub struct Subscription {
-  sink_stop_tx: Option<tokio::sync::mpsc::Sender<()>>,
-  stream_stop_tx: Option<tokio::sync::mpsc::Sender<()>>,
-}
-
-impl Subscription {
-  pub async fn stop(&mut self) {
-    if let Some(sink_stop_tx) = self.sink_stop_tx.take() {
-      if let Err(err) = sink_stop_tx.send(()).await {
-        warn!("the sink might be already stop, error: {}", err);
-      }
-    }
-    if let Some(stream_stop_tx) = self.stream_stop_tx.take() {
-      if let Err(err) = stream_stop_tx.send(()).await {
-        if cfg!(debug_assertions) {
-          warn!("the stream might be already stop, error: {}", err);
-        }
-      }
-    }
-  }
+  cancel: CancellationToken,
 }
 
 impl Drop for Subscription {
   fn drop(&mut self) {
-    if self.stream_stop_tx.is_some() || self.stream_stop_tx.is_some() {
-      error!("Subscription is not stopped before dropping");
-    }
+    self.cancel.cancel();
   }
 }
 

--- a/services/appflowy-collaborate/src/group/cmd.rs
+++ b/services/appflowy-collaborate/src/group/cmd.rs
@@ -145,10 +145,10 @@ where
       return Ok(());
     }
 
-    let is_group_exist = self.group_manager.contains_group(&object_id).await;
+    let is_group_exist = self.group_manager.contains_group(&object_id);
     if is_group_exist {
       // subscribe the user to the group. then the user will receive the changes from the group
-      let is_user_subscribed = self.group_manager.contains_user(&object_id, user).await;
+      let is_user_subscribed = self.group_manager.contains_user(&object_id, user);
       if !is_user_subscribed {
         // safety: messages is not empty because we have checked it before
         let first_message = messages.first().unwrap();
@@ -209,14 +209,12 @@ where
     if let Some(group) = self.group_manager.get_group(&object_id).await {
       let (collab_message_sender, _collab_message_receiver) = futures::channel::mpsc::channel(1);
       let (mut message_by_oid_sender, message_by_oid_receiver) = futures::channel::mpsc::channel(1);
-      group
-        .subscribe(
-          &server_rt_user,
-          CollabOrigin::Server,
-          collab_message_sender,
-          message_by_oid_receiver,
-        )
-        .await;
+      group.subscribe(
+        &server_rt_user,
+        CollabOrigin::Server,
+        collab_message_sender,
+        message_by_oid_receiver,
+      );
       let message = HashMap::from([(object_id.clone(), messages)]);
       if let Err(err) = message_by_oid_sender.try_send(message) {
         tracing::error!(

--- a/services/appflowy-collaborate/src/group/cmd.rs
+++ b/services/appflowy-collaborate/src/group/cmd.rs
@@ -59,7 +59,7 @@ impl<S> GroupCommandRunner<S>
 where
   S: CollabStorage,
 {
-  pub async fn run(mut self, object_id: String, notify: Arc<tokio::sync::Notify>) {
+  pub async fn run(mut self, object_id: String) {
     let mut receiver = self.recv.take().expect("Only take once");
     let stream = stream! {
       while let Some(msg) = receiver.recv().await {
@@ -67,7 +67,6 @@ where
       }
       trace!("Collab group:{} command runner is stopped", object_id);
     };
-    notify.notify_one();
     stream
       .for_each(|command| async {
         match command {

--- a/tests/websocket/actor_test.rs
+++ b/tests/websocket/actor_test.rs
@@ -3,6 +3,7 @@ use appflowy_collaborate::actix_ws::client::rt_client::{
   HandlerResult, RealtimeClient, RealtimeServer,
 };
 use appflowy_collaborate::actix_ws::entities::{ClientMessage, Connect, Disconnect};
+use appflowy_collaborate::error::RealtimeError;
 use collab_rt_entity::user::RealtimeUser;
 use collab_rt_entity::RealtimeMessage;
 use semver::Version;
@@ -161,18 +162,18 @@ impl Handler<ClientMessage> for MockRealtimeServer {
 }
 
 impl Handler<Connect> for MockRealtimeServer {
-  type Result = HandlerResult;
+  type Result = anyhow::Result<(), RealtimeError>;
 
   fn handle(&mut self, _msg: Connect, _ctx: &mut Self::Context) -> Self::Result {
-    Box::pin(async { Ok(()) })
+    Ok(())
   }
 }
 
 impl Handler<Disconnect> for MockRealtimeServer {
-  type Result = HandlerResult;
+  type Result = anyhow::Result<(), RealtimeError>;
 
   fn handle(&mut self, _msg: Disconnect, _ctx: &mut Self::Context) -> Self::Result {
-    Box::pin(async { Ok(()) })
+    Ok(())
   }
 }
 

--- a/tests/websocket/actor_test.rs
+++ b/tests/websocket/actor_test.rs
@@ -9,7 +9,6 @@ use collab_rt_entity::RealtimeMessage;
 use semver::Version;
 use std::collections::HashMap;
 use std::time::Duration;
-use tokio::time::sleep;
 
 #[actix_rt::test]
 async fn test_handle_message() {
@@ -153,11 +152,7 @@ impl Handler<ClientMessage> for MockRealtimeServer {
   type Result = HandlerResult;
 
   fn handle(&mut self, _msg: ClientMessage, _ctx: &mut Self::Context) -> Self::Result {
-    Box::pin(async {
-      // simulate some work
-      sleep(Duration::from_millis(500)).await;
-      Ok(())
-    })
+    Ok(())
   }
 }
 


### PR DESCRIPTION
This PR turns off necessity of using async message handlers in `RealtimeServerActor`. The major reason for using these were:
1. Stopping group requires calling an async `stop` method, which was using an async channel to notify group processing loop that it should be stopped. Now I've changed it to use `CancellationToken` which stops the group when the group instance is dropped. The same goes for group subscribers.
2. `CollabGroup::new` was async because of async lock over collab used inside. However we can pass a `Collab` which isn't wrapped with lock into a group, initialise everything and then wrap it with necessary lock at the end of group constructor.
3. Client message handler was async due to [this](https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/ee2ff899a3bb16a13bbabadd88a1625526c67fd2/services/appflowy-collaborate/src/rt_server.rs#L202). However the notifier here is not necessary. We're just scheduling the new messages onto group command runner while its processing loop starts on its own.