### PR TITLE
feat: api for delete items from trash permanently

### DIFF
--- a/libs/client-api/src/http_view.rs
+++ b/libs/client-api/src/http_view.rs
@@ -97,6 +97,40 @@ impl Client {
     AppResponse::<()>::from_response(resp).await?.into_error()
   }
 
+  pub async fn delete_workspace_page_view_from_trash(
+    &self,
+    workspace_id: Uuid,
+    view_id: &str,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/trash/{}",
+      self.base_url, workspace_id, view_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::DELETE, &url)
+      .await?
+      .send()
+      .await?;
+    AppResponse::<()>::from_response(resp).await?.into_error()
+  }
+
+  pub async fn delete_all_workspace_page_views_from_trash(
+    &self,
+    workspace_id: Uuid,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/delete-all-pages-from-trash",
+      self.base_url, workspace_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(&json!({}))
+      .send()
+      .await?;
+    AppResponse::<()>::from_response(resp).await?.into_error()
+  }
+
   pub async fn update_workspace_page_view(
     &self,
     workspace_id: Uuid,

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -233,6 +233,7 @@ pub struct AppFlowyWebMetrics {
   pub update_size_bytes: Histogram,
   pub decoding_failure_count: Gauge,
   pub apply_update_failure_count: Gauge,
+  pub apply_update_timeout_count: Gauge,
 }
 
 impl AppFlowyWebMetrics {
@@ -243,6 +244,7 @@ impl AppFlowyWebMetrics {
       update_size_bytes: Histogram::new(update_size_buckets),
       decoding_failure_count: Default::default(),
       apply_update_failure_count: Default::default(),
+      apply_update_timeout_count: Default::default(),
     }
   }
 
@@ -264,6 +266,11 @@ impl AppFlowyWebMetrics {
       "Number of updates that failed to apply",
       metrics.apply_update_failure_count.clone(),
     );
+    web_update_registry.register(
+      "apply_update_timeout_count",
+      "Number of updates that failed to apply within timeout",
+      metrics.apply_update_timeout_count.clone(),
+    );
     metrics
   }
 
@@ -277,5 +284,9 @@ impl AppFlowyWebMetrics {
 
   pub fn incr_apply_update_failure_count(&self, count: i64) {
     self.apply_update_failure_count.inc_by(count);
+  }
+
+  pub fn incr_apply_update_timeout_count(&self, count: i64) {
+    self.apply_update_timeout_count.inc_by(count);
   }
 }

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -50,7 +50,8 @@ use shared_entity::dto::workspace_dto::{
 use sqlx::{PgPool, Transaction};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use tokio::time::timeout_at;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -627,6 +628,43 @@ async fn move_all_views_out_from_trash(folder: &mut Folder) -> Result<FolderUpda
   })
 }
 
+async fn delete_view_from_trash(view_id: &str, folder: &mut Folder) -> Result<Vec<u8>, AppError> {
+  let encoded_update = {
+    let mut txn = folder.collab.transact_mut();
+    folder
+      .body
+      .views
+      .update_view(&mut txn, view_id, |update| update.set_trash(false).done());
+    folder.body.views.delete_views(&mut txn, vec![view_id]);
+    txn.encode_update_v1()
+  };
+
+  Ok(encoded_update)
+}
+
+async fn delete_all_views_from_trash(folder: &mut Folder) -> Result<Vec<u8>, AppError> {
+  let all_trash_ids: Vec<String> = folder
+    .get_all_trash_sections()
+    .iter()
+    .map(|s| s.id.clone())
+    .collect();
+
+  let encoded_update = {
+    let mut txn = folder.collab.transact_mut();
+    if let Some(op) = folder
+      .body
+      .section
+      .section_op(&txn, collab_folder::Section::Trash)
+    {
+      op.clear(&mut txn);
+    };
+    folder.body.views.delete_views(&mut txn, all_trash_ids);
+    txn.encode_update_v1()
+  };
+
+  Ok(encoded_update)
+}
+
 fn folder_to_encoded_collab(folder: &Folder) -> Result<Vec<u8>, AppError> {
   let collab_type = CollabType::Folder;
   let encoded_folder_collab = folder
@@ -1031,6 +1069,39 @@ pub async fn restore_all_pages_from_trash(
   Ok(())
 }
 
+pub async fn delete_trash(
+  appflowy_web_metrics: &AppFlowyWebMetrics,
+  server: Data<RealtimeServerAddr>,
+  user: RealtimeUser,
+  collab_storage: &CollabAccessControlStorage,
+  workspace_id: Uuid,
+  view_id: &str,
+) -> Result<(), AppError> {
+  let uid = user.uid;
+  let collab_origin = GetCollabOrigin::User { uid };
+  let mut folder =
+    get_latest_collab_folder(collab_storage, collab_origin, &workspace_id.to_string()).await?;
+  let update = delete_view_from_trash(view_id, &mut folder).await?;
+  update_workspace_folder_data(appflowy_web_metrics, server, user, workspace_id, update).await?;
+  Ok(())
+}
+
+pub async fn delete_all_pages_from_trash(
+  appflowy_web_metrics: &AppFlowyWebMetrics,
+  server: Data<RealtimeServerAddr>,
+  user: RealtimeUser,
+  collab_storage: &CollabAccessControlStorage,
+  workspace_id: Uuid,
+) -> Result<(), AppError> {
+  let uid = user.uid;
+  let collab_origin = GetCollabOrigin::User { uid };
+  let mut folder =
+    get_latest_collab_folder(collab_storage, collab_origin, &workspace_id.to_string()).await?;
+  let update = delete_all_views_from_trash(&mut folder).await?;
+  update_workspace_folder_data(appflowy_web_metrics, server, user, workspace_id, update).await?;
+  Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn update_page(
   pg_pool: &PgPool,
@@ -1273,7 +1344,7 @@ async fn get_page_collab_data_for_document(
 
 #[instrument(level = "debug", skip_all)]
 pub async fn update_page_collab_data(
-  appflowy_web_metrics: &Arc<AppFlowyWebMetrics>,
+  appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   workspace_id: Uuid,
@@ -1299,4 +1370,55 @@ pub async fn update_page_collab_data(
     .map_err(|err| AppError::Internal(anyhow!("Failed to send message to server: {}", err)))?;
 
   Ok(())
+}
+
+#[instrument(level = "debug", skip_all)]
+pub async fn update_workspace_folder_data(
+  appflowy_web_metrics: &AppFlowyWebMetrics,
+  server: Data<RealtimeServerAddr>,
+  user: RealtimeUser,
+  workspace_id: Uuid,
+  update: Vec<u8>,
+) -> Result<(), AppError> {
+  appflowy_web_metrics.record_update_size_bytes(update.len());
+
+  let (tx, rx) = tokio::sync::oneshot::channel();
+  let message = ClientHttpUpdateMessage {
+    user,
+    workspace_id: workspace_id.to_string(),
+    object_id: workspace_id.to_string(),
+    collab_type: CollabType::Folder,
+    update: Bytes::from(update),
+    state_vector: None,
+    return_tx: Some(tx),
+  };
+
+  server
+    .try_send(message)
+    .map_err(|err| AppError::Internal(anyhow!("Failed to send message to server: {}", err)))?;
+
+  let resp = timeout_at(
+    tokio::time::Instant::now() + Duration::from_millis(2000),
+    rx,
+  )
+  .await
+  .map_err(|err| {
+    appflowy_web_metrics.incr_apply_update_timeout_count(1);
+    AppError::Internal(anyhow!(
+      "Failed to receive apply update within timeout: {}",
+      err
+    ))
+  })?
+  .map_err(|err| AppError::Internal(anyhow!("Unable to receive folder update reply: {}", err)))?;
+
+  match resp {
+    Ok(_) => Ok(()),
+    Err(err) => {
+      appflowy_web_metrics.incr_apply_update_failure_count(1);
+      Err(AppError::Internal(anyhow!(
+        "Failed to apply folder update: {}",
+        err
+      )))
+    },
+  }
 }

--- a/tests/workspace/page_view.rs
+++ b/tests/workspace/page_view.rs
@@ -262,7 +262,7 @@ async fn move_page_to_another_space() {
 }
 
 #[tokio::test]
-async fn move_page_to_trash() {
+async fn move_page_to_trash_then_restore() {
   let registered_user = generate_unique_registered_user().await;
   let mut app_client = TestClient::user_with_new_device(registered_user.clone()).await;
   let web_client = TestClient::user_with_new_device(registered_user.clone()).await;
@@ -359,7 +359,7 @@ async fn move_page_to_trash() {
 }
 
 #[tokio::test]
-async fn move_page_with_child_to_trash() {
+async fn move_page_with_child_to_trash_then_restore() {
   let registered_user = generate_unique_registered_user().await;
   let mut app_client = TestClient::user_with_new_device(registered_user.clone()).await;
   let web_client = TestClient::user_with_new_device(registered_user.clone()).await;
@@ -417,6 +417,153 @@ async fn move_page_with_child_to_trash() {
     .await
     .unwrap();
   let folder = get_latest_folder(&app_client, &workspace_id).await;
+  assert!(!folder
+    .get_my_trash_sections()
+    .iter()
+    .any(|v| v.id == general_space.view_id));
+  let view_found = web_client
+    .api_client
+    .get_workspace_trash(&workspace_id)
+    .await
+    .unwrap()
+    .views
+    .iter()
+    .any(|v| v.view.view_id == general_space.view_id);
+  assert!(!view_found);
+}
+
+#[tokio::test]
+async fn move_page_with_child_to_trash_then_delete_permanently() {
+  let registered_user = generate_unique_registered_user().await;
+  let mut app_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let web_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let workspace_id = app_client.workspace_id().await;
+  let folder_view = web_client
+    .api_client
+    .get_workspace_folder(&workspace_id, Some(2), None)
+    .await
+    .unwrap();
+  let general_space = &folder_view
+    .children
+    .into_iter()
+    .find(|v| v.name == "General")
+    .unwrap();
+  app_client.open_workspace_collab(&workspace_id).await;
+  app_client
+    .wait_object_sync_complete(&workspace_id)
+    .await
+    .unwrap();
+  app_client
+    .api_client
+    .move_workspace_page_view_to_trash(
+      Uuid::parse_str(&workspace_id).unwrap(),
+      &general_space.view_id,
+    )
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  let views_in_trash_for_app = folder
+    .get_my_trash_sections()
+    .iter()
+    .map(|v| v.id.clone())
+    .collect::<HashSet<String>>();
+  assert!(views_in_trash_for_app.contains(&general_space.view_id));
+  for view in general_space.children.iter() {
+    assert!(!views_in_trash_for_app.contains(&view.view_id));
+  }
+  let views_in_trash_for_web = web_client
+    .api_client
+    .get_workspace_trash(&workspace_id)
+    .await
+    .unwrap()
+    .views
+    .iter()
+    .map(|v| v.view.view_id.clone())
+    .collect::<HashSet<String>>();
+  assert!(views_in_trash_for_web.contains(&general_space.view_id));
+
+  web_client
+    .api_client
+    .delete_workspace_page_view_from_trash(
+      Uuid::parse_str(&workspace_id).unwrap(),
+      &general_space.view_id,
+    )
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  assert!(folder.get_view(&general_space.view_id).is_none());
+  assert!(!folder
+    .get_my_trash_sections()
+    .iter()
+    .any(|v| v.id == general_space.view_id));
+  let view_found = web_client
+    .api_client
+    .get_workspace_trash(&workspace_id)
+    .await
+    .unwrap()
+    .views
+    .iter()
+    .any(|v| v.view.view_id == general_space.view_id);
+  assert!(!view_found);
+}
+
+#[tokio::test]
+async fn move_page_with_child_to_trash_then_delete_all_permanently() {
+  let registered_user = generate_unique_registered_user().await;
+  let mut app_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let web_client = TestClient::user_with_new_device(registered_user.clone()).await;
+  let workspace_id = app_client.workspace_id().await;
+  let folder_view = web_client
+    .api_client
+    .get_workspace_folder(&workspace_id, Some(2), None)
+    .await
+    .unwrap();
+  let general_space = &folder_view
+    .children
+    .into_iter()
+    .find(|v| v.name == "General")
+    .unwrap();
+  app_client.open_workspace_collab(&workspace_id).await;
+  app_client
+    .wait_object_sync_complete(&workspace_id)
+    .await
+    .unwrap();
+  app_client
+    .api_client
+    .move_workspace_page_view_to_trash(
+      Uuid::parse_str(&workspace_id).unwrap(),
+      &general_space.view_id,
+    )
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  let views_in_trash_for_app = folder
+    .get_my_trash_sections()
+    .iter()
+    .map(|v| v.id.clone())
+    .collect::<HashSet<String>>();
+  assert!(views_in_trash_for_app.contains(&general_space.view_id));
+  for view in general_space.children.iter() {
+    assert!(!views_in_trash_for_app.contains(&view.view_id));
+  }
+  let views_in_trash_for_web = web_client
+    .api_client
+    .get_workspace_trash(&workspace_id)
+    .await
+    .unwrap()
+    .views
+    .iter()
+    .map(|v| v.view.view_id.clone())
+    .collect::<HashSet<String>>();
+  assert!(views_in_trash_for_web.contains(&general_space.view_id));
+
+  web_client
+    .api_client
+    .delete_all_workspace_page_views_from_trash(Uuid::parse_str(&workspace_id).unwrap())
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  assert!(folder.get_view(&general_space.view_id).is_none());
   assert!(!folder
     .get_my_trash_sections()
     .iter()


### PR DESCRIPTION
API for deleting items from trash permanently. Currently, this API only modifies the workspace folder, as opposed to actually delete the collab from the database. This is consistent with the behavior of the current version of AppFlowy desktop app. We will need to revisit this in the future.

This API is also differ from other page view related APIs, as the updates are written to in-memory Collab Group as opposed to directly to the database. After this PR is merged, we will migrate all the other APIs to follow similar approach.