### PR TITLE
fix: incorrect group subscription criteria for http real time user

### DIFF
--- a/services/appflowy-collaborate/src/group/cmd.rs
+++ b/services/appflowy-collaborate/src/group/cmd.rs
@@ -266,8 +266,8 @@ where
     });
 
     // Create message router for user if it's not exist
-    let should_sub = self.msg_router_by_user.get(user).is_none();
-    if should_sub {
+    let is_router_exists = self.msg_router_by_user.get(user).is_some();
+    if !is_router_exists {
       trace!("create a new client message router for user:{}", user);
       let new_client_router = ClientMessageRouter::new(NullSender::<()>::default());
       self
@@ -285,7 +285,7 @@ where
     }
 
     // Only subscribe when the user is not subscribed to the group
-    if should_sub {
+    if !self.group_manager.contains_user(object_id, user) {
       self.subscribe_group(user, object_id, &origin).await?;
     }
     if let Some(client_stream) = self.msg_router_by_user.get(user) {


### PR DESCRIPTION
Currently, when handling realtime update via http, the decision of  whether a user should be subscribed to a group is determined by whether the client router exists for the user or not.

This is inconsistent with the web socket client behavior. It is possible, that the client router already exists for a user (eg. when multiple web updates are sent with the same device id header) , but a new subscription is still needed because the user has not yet subscribed to a different group. (eg. user is subscribed to workspace folder changes but not workspace database changes).