### PR TITLE
added a hint to warn user of GoTrue password incompability with special characters

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -58,6 +58,7 @@ GOTRUE_SMTP_ADMIN_EMAIL=comp_admin@some_company.com
 
 # This user will be created when GoTrue starts successfully
 # You can use this user to login to the admin panel
+# Note: You cannot use special characters for this password or GoTrue will fail to start.
 GOTRUE_ADMIN_EMAIL=admin@example.com
 GOTRUE_ADMIN_PASSWORD=password
 


### PR DESCRIPTION
Today I tried to set up appflowy cloud, but was not able to log into the admin panel.
After a few hours of debugging it dawned upon me: I had set a password containing special characters like ^!# and +.

To prevent other users from falling into the same pit, I added a warning note to the deployment .env