### PR TITLE
fix: sort quick notes by update time

### DIFF
--- a/libs/database/src/quick_note.rs
+++ b/libs/database/src/quick_note.rs
@@ -55,7 +55,7 @@ pub async fn select_quick_notes_with_one_more_than_limit<
     let json_path_query = format!("'$.**.insert ? (@ like_regex \".*{}.*\")'", search_term);
     query_builder.push(json_path_query);
   }
-  query_builder.push(" ORDER BY created_at DESC");
+  query_builder.push(" ORDER BY updated_at DESC");
   if let Some(limit) = limit {
     query_builder.push(" LIMIT ");
     query_builder.push_bind(limit);

--- a/tests/workspace/quick_note.rs
+++ b/tests/workspace/quick_note.rs
@@ -21,6 +21,8 @@ async fn quick_note_crud_test() {
     // To ensure that the creation time is different
     time::sleep(Duration::from_millis(1)).await;
   }
+  let quick_note_id_1 = quick_note_ids[0];
+  let quick_note_id_2 = quick_note_ids[1];
   let quick_notes = client
     .api_client
     .list_quick_notes(workspace_uuid, None, None, None)
@@ -28,9 +30,9 @@ async fn quick_note_crud_test() {
     .expect("list quick notes");
   assert_eq!(quick_notes.quick_notes.len(), 2);
   assert!(!quick_notes.has_more);
+  assert_eq!(quick_notes.quick_notes[0].id, quick_note_id_2);
+  assert_eq!(quick_notes.quick_notes[1].id, quick_note_id_1);
 
-  let quick_note_id_1 = quick_note_ids[0];
-  let quick_note_id_2 = quick_note_ids[1];
   let data_1 = json!([
     {
       "type": "paragraph",
@@ -79,12 +81,14 @@ async fn quick_note_crud_test() {
   ]);
   client
     .api_client
-    .update_quick_note(workspace_uuid, quick_note_id_1, data_1)
+    .update_quick_note(workspace_uuid, quick_note_id_2, data_2)
     .await
     .expect("update quick note");
+  // To ensure that the update time is different
+  time::sleep(Duration::from_millis(1)).await;
   client
     .api_client
-    .update_quick_note(workspace_uuid, quick_note_id_2, data_2)
+    .update_quick_note(workspace_uuid, quick_note_id_1, data_1)
     .await
     .expect("update quick note");
   let quick_notes = client
@@ -108,7 +112,7 @@ async fn quick_note_crud_test() {
   assert!(!quick_notes_with_offset_and_limit.has_more);
   assert_eq!(
     quick_notes_with_offset_and_limit.quick_notes[0].id,
-    quick_note_id_1
+    quick_note_id_2
   );
   let quick_notes_with_offset_and_limit = client
     .api_client
@@ -119,7 +123,7 @@ async fn quick_note_crud_test() {
   assert!(quick_notes_with_offset_and_limit.has_more);
   assert_eq!(
     quick_notes_with_offset_and_limit.quick_notes[0].id,
-    quick_note_id_2
+    quick_note_id_1
   );
   let filtered_quick_notes = client
     .api_client


### PR DESCRIPTION
Sort quick notes with update time instead of creation time.