### PR TITLE
fix: auto patch workspace folder without space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2210,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "collab-importer"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=c45a2120361f94bbedb787cdd2192a38c94c7f5f#c45a2120361f94bbedb787cdd2192a38c94c7f5f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d51fecb64762855f9e54648c78ab1ee0d5404f97#d51fecb64762855f9e54648c78ab1ee0d5404f97"
 dependencies = [
  "anyhow",
  "collab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,13 +321,13 @@ lto = false
 [patch.crates-io]
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
-collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "c45a2120361f94bbedb787cdd2192a38c94c7f5f" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
+collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d51fecb64762855f9e54648c78ab1ee0d5404f97" }
 
 [features]
 history = []

--- a/src/biz/collab/folder_view.rs
+++ b/src/biz/collab/folder_view.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 
 use app_error::AppError;
 use chrono::DateTime;
-use collab_folder::{
-  hierarchy_builder::SpacePermission, Folder, SectionItem, ViewLayout as CollabFolderViewLayout,
-};
+use collab_folder::{Folder, SectionItem, SpacePermission, ViewLayout as CollabFolderViewLayout};
 use shared_entity::dto::workspace_dto::{
   self, FavoriteFolderView, FolderView, FolderViewMinimal, RecentFolderView, TrashFolderView,
   ViewLayout,

--- a/src/biz/collab/utils.rs
+++ b/src/biz/collab/utils.rs
@@ -34,6 +34,9 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use yrs::Map;
 
+pub const DEFAULT_SPACE_ICON: &str = "interface_essential/home-3";
+pub const DEFAULT_SPACE_ICON_COLOR: &str = "0xFFA34AFD";
+
 pub fn get_row_details_serde(
   row_detail: RowDetail,
   field_by_id_name_uniq: &HashMap<String, Field>,

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -36,7 +36,7 @@ use collab_document::document::Document;
 use collab_document::document_data::default_document_data;
 use collab_entity::{CollabType, EncodedCollab};
 use collab_folder::hierarchy_builder::NestedChildViewBuilder;
-use collab_folder::{timestamp, CollabOrigin, Folder};
+use collab_folder::{timestamp, CollabOrigin, Folder, SpaceInfo};
 use collab_rt_entity::user::RealtimeUser;
 use database::collab::{select_workspace_database_oid, CollabStorage, GetCollabOrigin};
 use database::publish::select_published_view_ids_for_workspace;
@@ -419,12 +419,14 @@ async fn add_new_space_to_folder(
       .with_view_id(view_id)
       .with_name(name)
       .with_extra(|builder| {
-        let mut extra = builder
-          .is_space(true, to_space_permission(space_permission))
-          .build();
-        extra["space_icon_color"] = json!(space_icon_color);
-        extra["space_icon"] = json!(space_icon);
-        extra
+        builder
+          .with_space_info(SpaceInfo {
+            space_icon: Some(space_icon.to_string()),
+            space_icon_color: Some(space_icon_color.to_string()),
+            space_permission: to_space_permission(space_permission),
+            ..Default::default()
+          })
+          .build()
       })
       .build()
       .view;


### PR DESCRIPTION
In older version of AppFlowy, there's no concept of space. As a result, they can't be rendered in AppFlowy Web easily. In this PR, we will attempt to fix such case based on the following logic:

1. If the view that corresponds to the workspace has children, but none of the children are a valid space, or there is no children at all, then create a new space.
2. If there is at least one children, then all the children directly under the workspace view should be moved under the newly created space.