### PR TITLE
fix: change postgres host to env variable instead of hard-coded

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -78,7 +78,7 @@ API_EXTERNAL_URL=http://your-host
 
 # In docker environment, `postgres` is the hostname of the postgres service
 # GoTrue connect to postgres using this url
-GOTRUE_DATABASE_URL=postgres://supabase_auth_admin:${SUPABASE_PASSWORD}@postgres:${POSTGRES_PORT}/${POSTGRES_DB}
+GOTRUE_DATABASE_URL=postgres://supabase_auth_admin:${SUPABASE_PASSWORD}@{POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # Refer to this for details: https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/main/doc/AUTHENTICATION.md
 # Google OAuth2


### PR DESCRIPTION
Postgres host name for GOTRUE_DATABASE_URL is hardcoded as `postgres` , changed it to existing env variable