### PR TITLE
fix: added missing env parameter for ADMIN_FRONTEND_APPFLOWY_CLOUD_URL to deploy.env

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -35,6 +35,8 @@ APPFLOWY_REDIS_URI=redis://${REDIS_HOST}:${REDIS_PORT}
 ADMIN_FRONTEND_REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}
 ## URL that connects to gotrue docker container
 ADMIN_FRONTEND_GOTRUE_URL=http://gotrue:9999
+## URL that connects to the cloud docker container
+ADMIN_FRONTEND_APPFLOWY_CLOUD_URL=http://appflowy_cloud:8000
 
 # authentication key, change this and keep the key safe and secret
 # self defined key, you can use any string


### PR DESCRIPTION
`docker-compose.yml` has env variable `ADMIN_FRONTEND_APPFLOWY_CLOUD_URL` set to `${ADMIN_FRONTEND_APPFLOWY_CLOUD_URL:-http://appflowy_cloud:8000}`, though `deploy.env` makes no mention of the variable. In my environment, I needed to change the hostname which would also require changing it in `deploy.env` where it is not mentioned. I suggest adding it with the default value for convenience and consistency (the other two `ADMIN_FRONTEND_...` are included) purposes.