### PR TITLE
Avoid leaking private document in search endpoint

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -32,6 +32,7 @@ async fn document_search(
   let metrics = &*state.metrics.request_metrics;
   let resp = search_document(
     &state.pg_pool,
+    &state.collab_access_control_storage,
     &state.indexer_scheduler,
     uid,
     workspace_id,

--- a/src/biz/collab/folder_view.rs
+++ b/src/biz/collab/folder_view.rs
@@ -11,15 +11,13 @@ use shared_entity::dto::workspace_dto::{
 };
 use uuid::Uuid;
 
-/// Return all folders belonging to a workspace, excluding private sections which the user does not have access to.
-pub fn collab_folder_to_folder_view(
-  workspace_id: Uuid,
-  root_view_id: &str,
-  folder: &Folder,
-  max_depth: u32,
-  pubished_view_ids: &HashSet<String>,
-) -> Result<FolderView, AppError> {
-  let mut unviewable = HashSet::new();
+pub struct PrivateAndNonviewableViews {
+  pub my_private_view_ids: HashSet<String>,
+  pub nonviewable_view_ids: HashSet<String>,
+}
+
+pub fn private_and_nonviewable_view_ids(folder: &Folder) -> PrivateAndNonviewableViews {
+  let mut nonviewable_view_ids = HashSet::new();
   let mut my_private_view_ids = HashSet::new();
   for private_section in folder.get_my_private_sections() {
     my_private_view_ids.insert(private_section.id);
@@ -28,21 +26,36 @@ pub fn collab_folder_to_folder_view(
     if let Some(private_view) = folder.get_view(&private_section.id) {
       if check_if_view_is_space(&private_view) && !my_private_view_ids.contains(&private_section.id)
       {
-        unviewable.insert(private_section.id);
+        nonviewable_view_ids.insert(private_section.id);
       }
     }
   }
   for trash_view in folder.get_all_trash_sections() {
-    unviewable.insert(trash_view.id);
+    nonviewable_view_ids.insert(trash_view.id);
   }
+  PrivateAndNonviewableViews {
+    my_private_view_ids,
+    nonviewable_view_ids,
+  }
+}
+
+/// Return all folders belonging to a workspace, excluding private sections which the user does not have access to.
+pub fn collab_folder_to_folder_view(
+  workspace_id: Uuid,
+  root_view_id: &str,
+  folder: &Folder,
+  max_depth: u32,
+  pubished_view_ids: &HashSet<String>,
+) -> Result<FolderView, AppError> {
+  let private_and_nonviewable_views = private_and_nonviewable_view_ids(folder);
 
   to_folder_view(
     workspace_id,
     "",
     root_view_id,
     folder,
-    &unviewable,
-    &my_private_view_ids,
+    &private_and_nonviewable_views.nonviewable_view_ids,
+    &private_and_nonviewable_views.my_private_view_ids,
     pubished_view_ids,
     false,
     0,
@@ -227,6 +240,27 @@ pub fn section_items_to_trash_folder_view(
       })
     })
     .collect()
+}
+
+pub fn check_if_view_ancestors_fulfil_condition(
+  view_id: &str,
+  collab_folder: &Folder,
+  condition: impl Fn(&collab_folder::View) -> bool,
+) -> bool {
+  let mut current_view_id = view_id.to_string();
+  loop {
+    let view = match collab_folder.get_view(&current_view_id) {
+      Some(view) => view,
+      None => return false,
+    };
+    if condition(&view) {
+      return true;
+    }
+    current_view_id = view.parent_view_id.clone();
+    if current_view_id.is_empty() {
+      return false;
+    }
+  }
 }
 
 pub fn check_if_view_is_space(view: &collab_folder::View) -> bool {

--- a/src/biz/collab/ops.rs
+++ b/src/biz/collab/ops.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use actix_web::web::Data;
 use app_error::AppError;
 use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
 use chrono::DateTime;
@@ -24,8 +25,12 @@ use collab_database::workspace_database::WorkspaceDatabaseBody;
 use collab_document::document::Document;
 use collab_entity::CollabType;
 use collab_entity::EncodedCollab;
+use collab_folder::hierarchy_builder::NestedChildViewBuilder;
+use collab_folder::hierarchy_builder::SpacePermission;
 use collab_folder::CollabOrigin;
+use collab_folder::Folder;
 use collab_folder::SectionItem;
+use collab_rt_entity::user::RealtimeUser;
 use database::collab::select_last_updated_database_row_ids;
 use database::collab::select_workspace_database_oid;
 use database::collab::{CollabStorage, GetCollabOrigin};
@@ -34,6 +39,7 @@ use database::publish::select_workspace_id_for_publish_namespace;
 use database_entity::dto::QueryCollab;
 use database_entity::dto::QueryCollabResult;
 use database_entity::dto::{CollabParams, WorkspaceCollabIdentify};
+use serde_json::json;
 use shared_entity::dto::workspace_dto::AFDatabase;
 use shared_entity::dto::workspace_dto::AFDatabaseField;
 use shared_entity::dto::workspace_dto::AFDatabaseRow;
@@ -48,8 +54,12 @@ use sqlx::PgPool;
 use std::ops::DerefMut;
 use yrs::Map;
 
+use crate::api::metrics::AppFlowyWebMetrics;
+use crate::api::ws::RealtimeServerAddr;
+use crate::biz::collab::folder_view::check_if_view_is_space;
 use crate::biz::collab::utils::get_database_row_doc_changes;
 use crate::biz::workspace::ops::broadcast_update_with_timeout;
+use crate::biz::workspace::page_view::update_workspace_folder_data;
 use access_control::collab::CollabAccessControl;
 use anyhow::Context;
 use database_entity::dto::{
@@ -293,10 +303,91 @@ pub async fn get_user_trash_folder_views(
   Ok(section_items_to_trash_folder_view(&section_items, &folder))
 }
 
+#[allow(clippy::too_many_arguments)]
+fn patch_old_workspace_folder(
+  user: RealtimeUser,
+  workspace_id: &str,
+  folder: &mut Folder,
+  child_view_id_without_space: &[String],
+) -> Result<Vec<u8>, AppError> {
+  let encoded_update = {
+    let space_id = Uuid::new_v4().to_string();
+    let space_view = NestedChildViewBuilder::new(user.uid, workspace_id.to_string())
+      .with_view_id(space_id.clone())
+      .with_name("General")
+      .with_extra(|builder| {
+        let mut extra = builder.is_space(true, SpacePermission::PublicToAll).build();
+        extra["space_icon_color"] = json!("0xFFA34AFD");
+        extra["space_icon"] = json!("interface_essential/home-3");
+        extra
+      })
+      .build()
+      .view;
+    let mut txn = folder.collab.transact_mut();
+    folder.body.views.insert(&mut txn, space_view, None);
+    for (i, current_view_id) in child_view_id_without_space.iter().enumerate() {
+      let previous_view_id = if i == 0 {
+        None
+      } else {
+        Some(child_view_id_without_space[i - 1].clone())
+      };
+      folder
+        .body
+        .move_nested_view(&mut txn, current_view_id, &space_id, previous_view_id);
+    }
+    txn.encode_update_v1()
+  };
+  Ok(encoded_update)
+}
+
+async fn fix_old_workspace_folder(
+  appflowy_web_metrics: &AppFlowyWebMetrics,
+  server: Data<RealtimeServerAddr>,
+  user: RealtimeUser,
+  mut folder: Folder,
+  workspace_id: Uuid,
+) -> Result<Folder, AppError> {
+  let root_view = folder.get_view(&workspace_id.to_string()).ok_or_else(|| {
+    AppError::InvalidRequest(format!(
+      "Failed to get view for workspace_id: {}",
+      workspace_id
+    ))
+  })?;
+  let direct_workspace_children: Vec<String> = root_view
+    .children
+    .iter()
+    .map(|view_id| view_id.to_string())
+    .collect();
+  let has_at_least_one_space = direct_workspace_children
+    .iter()
+    .filter_map(|view_id| folder.get_view(view_id))
+    .any(|view| check_if_view_is_space(&view));
+  if !has_at_least_one_space {
+    let folder_update = patch_old_workspace_folder(
+      user.clone(),
+      &workspace_id.to_string(),
+      &mut folder,
+      &direct_workspace_children,
+    )?;
+    update_workspace_folder_data(
+      appflowy_web_metrics,
+      server,
+      user,
+      workspace_id,
+      folder_update,
+    )
+    .await?;
+  }
+  Ok(folder)
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn get_user_workspace_structure(
+  appflowy_web_metrics: &AppFlowyWebMetrics,
+  server: Data<RealtimeServerAddr>,
   collab_storage: &CollabAccessControlStorage,
   pg_pool: &PgPool,
-  uid: i64,
+  user: RealtimeUser,
   workspace_id: Uuid,
   depth: u32,
   root_view_id: &str,
@@ -310,10 +401,13 @@ pub async fn get_user_workspace_structure(
   }
   let folder = get_latest_collab_folder(
     collab_storage,
-    GetCollabOrigin::User { uid },
+    GetCollabOrigin::User { uid: user.uid },
     &workspace_id.to_string(),
   )
   .await?;
+  let patched_folder =
+    fix_old_workspace_folder(appflowy_web_metrics, server, user, folder, workspace_id).await?;
+
   let publish_view_ids = select_published_view_ids_for_workspace(pg_pool, workspace_id).await?;
   let publish_view_ids: HashSet<String> = publish_view_ids
     .into_iter()
@@ -322,7 +416,7 @@ pub async fn get_user_workspace_structure(
   collab_folder_to_folder_view(
     workspace_id,
     root_view_id,
-    &folder,
+    &patched_folder,
     depth,
     &publish_view_ids,
   )

--- a/src/biz/search/ops.rs
+++ b/src/biz/search/ops.rs
@@ -1,8 +1,14 @@
 use crate::api::metrics::RequestMetrics;
+use crate::biz::collab::folder_view::{
+  check_if_view_ancestors_fulfil_condition, private_and_nonviewable_view_ids,
+};
+use crate::biz::collab::utils::get_latest_collab_folder;
 use app_error::ErrorCode;
 use appflowy_ai_client::dto::{
   EmbeddingEncodingFormat, EmbeddingInput, EmbeddingModel, EmbeddingOutput, EmbeddingRequest,
 };
+use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use database::collab::GetCollabOrigin;
 use std::sync::Arc;
 
 use database::index::{search_documents, SearchDocumentParams};
@@ -17,6 +23,7 @@ use uuid::Uuid;
 
 pub async fn search_document(
   pg_pool: &PgPool,
+  collab_storage: &CollabAccessControlStorage,
   indexer_scheduler: &Arc<IndexerScheduler>,
   uid: i64,
   workspace_id: Uuid,
@@ -75,8 +82,23 @@ pub async fn search_document(
     results.len(),
     request.query
   );
+
+  let folder = get_latest_collab_folder(
+    collab_storage,
+    GetCollabOrigin::User { uid },
+    &workspace_id.to_string(),
+  )
+  .await?;
+  let private_and_nonviewable_views = private_and_nonviewable_view_ids(&folder);
+  let non_searchable_view_ids = private_and_nonviewable_views.nonviewable_view_ids;
+  let filtered_results = results.into_iter().filter(|item| {
+    !check_if_view_ancestors_fulfil_condition(&item.object_id, &folder, |view| {
+      non_searchable_view_ids.contains(&view.id)
+    })
+  });
+
   Ok(
-    results
+    filtered_results
       .into_iter()
       .map(|item| SearchDocumentResponseItem {
         object_id: item.object_id,


### PR DESCRIPTION
Private document should not appear when searching the documents through embeddings.