### PR TITLE
chore: add metrics to redis collab stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,6 +2365,7 @@ dependencies = [
  "collab-entity",
  "futures",
  "loole",
+ "prometheus-client",
  "prost 0.13.3",
  "rand 0.8.5",
  "redis 0.25.4",

--- a/libs/collab-stream/Cargo.toml
+++ b/libs/collab-stream/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { version = "0.7" }
 prost.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
+prometheus-client.workspace = true
 zstd = "0.13"
 loole = "0.4.0"
 

--- a/libs/collab-stream/src/client.rs
+++ b/libs/collab-stream/src/client.rs
@@ -1,6 +1,7 @@
 use crate::collab_update_sink::{AwarenessUpdateSink, CollabUpdateSink};
 use crate::error::{internal, StreamError};
 use crate::lease::{Lease, LeaseAcquisition};
+use crate::metrics::CollabStreamMetrics;
 use crate::model::{AwarenessStreamUpdate, CollabStreamUpdate, MessageId};
 use crate::stream_group::{StreamConfig, StreamGroup};
 use crate::stream_router::{StreamRouter, StreamRouterOptions};
@@ -21,14 +22,21 @@ pub struct CollabRedisStream {
 impl CollabRedisStream {
   pub const LEASE_TTL: Duration = Duration::from_secs(60);
 
-  pub async fn new(redis_client: redis::Client) -> Result<Self, redis::RedisError> {
+  pub async fn new(
+    redis_client: redis::Client,
+    metrics: Arc<CollabStreamMetrics>,
+  ) -> Result<Self, redis::RedisError> {
     let router_options = StreamRouterOptions {
       worker_count: 60,
       xread_streams: 100,
       xread_block_millis: Some(5000),
       xread_count: None,
     };
-    let stream_router = Arc::new(StreamRouter::with_options(&redis_client, router_options)?);
+    let stream_router = Arc::new(StreamRouter::with_options(
+      &redis_client,
+      metrics,
+      router_options,
+    )?);
     let connection_manager = redis_client.get_connection_manager().await?;
     Ok(Self::new_with_connection_manager(
       connection_manager,

--- a/libs/collab-stream/src/lib.rs
+++ b/libs/collab-stream/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod collab_update_sink;
 pub mod error;
 pub mod lease;
+pub mod metrics;
 pub mod model;
 pub mod pubsub;
 pub mod stream_group;

--- a/libs/collab-stream/src/metrics.rs
+++ b/libs/collab-stream/src/metrics.rs
@@ -1,0 +1,28 @@
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::registry::Registry;
+
+#[derive(Default)]
+pub struct CollabStreamMetrics {
+  /// Incremented each time a new collab stream read task is set (including recurring tasks).
+  pub reads_enqueued: Counter,
+  /// Incremented each time an existing task is consumed (including recurring tasks).
+  pub reads_dequeued: Counter,
+}
+
+impl CollabStreamMetrics {
+  pub fn register(registry: &mut Registry) -> Self {
+    let metrics = Self::default();
+    let realtime_registry = registry.sub_registry_with_prefix("collab_stream");
+    realtime_registry.register(
+      "reads_enqueued",
+      "Incremented each time a new collab stream read task is set (including recurring tasks).",
+      metrics.reads_enqueued.clone(),
+    );
+    realtime_registry.register(
+      "reads_dequeued",
+      "Incremented each time an existing task is consumed (including recurring tasks).",
+      metrics.reads_dequeued.clone(),
+    );
+    metrics
+  }
+}

--- a/libs/collab-stream/tests/collab_stream_test/test_util.rs
+++ b/libs/collab-stream/tests/collab_stream_test/test_util.rs
@@ -1,6 +1,8 @@
 use anyhow::Context;
 use collab_stream::client::CollabRedisStream;
+use collab_stream::metrics::CollabStreamMetrics;
 use rand::{thread_rng, Rng};
+use std::sync::Arc;
 
 pub async fn redis_client() -> redis::Client {
   let redis_uri = "redis://localhost:6379";
@@ -11,7 +13,7 @@ pub async fn redis_client() -> redis::Client {
 
 pub async fn stream_client() -> CollabRedisStream {
   let redis_client = redis_client().await;
-  CollabRedisStream::new(redis_client)
+  CollabRedisStream::new(redis_client, Arc::new(CollabStreamMetrics::default()))
     .await
     .context("failed to create stream client")
     .unwrap()

--- a/services/appflowy-collaborate/src/state.rs
+++ b/services/appflowy-collaborate/src/state.rs
@@ -13,6 +13,7 @@ use crate::pg_listener::PgListeners;
 use crate::CollabRealtimeMetrics;
 use access_control::metrics::AccessControlMetrics;
 use app_error::AppError;
+use collab_stream::metrics::CollabStreamMetrics;
 use collab_stream::stream_router::StreamRouter;
 use database::user::{select_all_uid_uuid, select_uid_from_uuid};
 use indexer::metrics::EmbeddingMetrics;
@@ -40,6 +41,7 @@ pub struct AppMetrics {
   pub access_control_metrics: Arc<AccessControlMetrics>,
   pub realtime_metrics: Arc<CollabRealtimeMetrics>,
   pub collab_metrics: Arc<CollabMetrics>,
+  pub collab_stream_metrics: Arc<CollabStreamMetrics>,
   pub embedding_metrics: Arc<EmbeddingMetrics>,
 }
 
@@ -55,12 +57,14 @@ impl AppMetrics {
     let access_control_metrics = Arc::new(AccessControlMetrics::register(&mut registry));
     let realtime_metrics = Arc::new(CollabRealtimeMetrics::register(&mut registry));
     let collab_metrics = Arc::new(CollabMetrics::register(&mut registry));
+    let collab_stream_metrics = Arc::new(CollabStreamMetrics::register(&mut registry));
     let embedding_metrics = Arc::new(EmbeddingMetrics::register(&mut registry));
     Self {
       registry: Arc::new(registry),
       access_control_metrics,
       realtime_metrics,
       collab_metrics,
+      collab_stream_metrics,
       embedding_metrics,
     }
   }

--- a/src/application.rs
+++ b/src/application.rs
@@ -42,6 +42,7 @@ use appflowy_collaborate::collab::storage::CollabStorageImpl;
 use appflowy_collaborate::command::{CLCommandReceiver, CLCommandSender};
 use appflowy_collaborate::snapshot::SnapshotControl;
 use appflowy_collaborate::CollaborationServer;
+use collab_stream::metrics::CollabStreamMetrics;
 use collab_stream::stream_router::{StreamRouter, StreamRouterOptions};
 use database::file::s3_client_impl::{AwsS3BucketClientImpl, S3BucketStorage};
 use indexer::collab_indexer::IndexerProvider;
@@ -248,8 +249,12 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
 
   // Redis
   info!("Connecting to Redis...");
-  let (redis_conn_manager, redis_stream_router) =
-    get_redis_client(config.redis_uri.expose_secret(), config.redis_worker_count).await?;
+  let (redis_conn_manager, redis_stream_router) = get_redis_client(
+    config.redis_uri.expose_secret(),
+    config.redis_worker_count,
+    metrics.collab_stream_metrics.clone(),
+  )
+  .await?;
 
   info!("Setup AppFlowy AI: {}", config.appflowy_ai.url());
   let appflowy_ai_client = AppFlowyAIClient::new(&config.appflowy_ai.url());
@@ -387,12 +392,14 @@ fn get_admin_client(
 async fn get_redis_client(
   redis_uri: &str,
   worker_count: usize,
+  metrics: Arc<CollabStreamMetrics>,
 ) -> Result<(redis::aio::ConnectionManager, Arc<StreamRouter>), Error> {
   info!("Connecting to redis with uri: {}", redis_uri);
   let client = redis::Client::open(redis_uri).context("failed to connect to redis")?;
 
   let router = StreamRouter::with_options(
     &client,
+    metrics,
     StreamRouterOptions {
       worker_count,
       xread_streams: 100,

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,6 +17,7 @@ use appflowy_collaborate::collab::cache::CollabCache;
 use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
 use appflowy_collaborate::metrics::CollabMetrics;
 use appflowy_collaborate::CollabRealtimeMetrics;
+use collab_stream::metrics::CollabStreamMetrics;
 use collab_stream::stream_router::StreamRouter;
 use database::file::s3_client_impl::{AwsS3BucketClientImpl, S3BucketStorage};
 use database::user::{select_all_uid_uuid, select_uid_from_uuid};
@@ -128,6 +129,7 @@ pub struct AppMetrics {
   pub published_collab_metrics: Arc<PublishedCollabMetrics>,
   pub appflowy_web_metrics: Arc<AppFlowyWebMetrics>,
   pub embedding_metrics: Arc<EmbeddingMetrics>,
+  pub collab_stream_metrics: Arc<CollabStreamMetrics>,
 }
 
 impl Default for AppMetrics {
@@ -146,6 +148,7 @@ impl AppMetrics {
     let published_collab_metrics = Arc::new(PublishedCollabMetrics::register(&mut registry));
     let appflowy_web_metrics = Arc::new(AppFlowyWebMetrics::register(&mut registry));
     let embedding_metrics = Arc::new(EmbeddingMetrics::register(&mut registry));
+    let collab_stream_metrics = Arc::new(CollabStreamMetrics::register(&mut registry));
     Self {
       registry: Arc::new(registry),
       request_metrics,
@@ -155,6 +158,7 @@ impl AppMetrics {
       published_collab_metrics,
       appflowy_web_metrics,
       embedding_metrics,
+      collab_stream_metrics,
     }
   }
 }


### PR DESCRIPTION
This PR comes with 2 changes:
1. `CollabStreamMetrics` type which allows us to track how many streams are we scheduling to be read at given time:
  - `collab_stream_reads_enqueued` is incremented for every stream that has been observed. When the Redis xread returns and stream needs to be rescheduled for the next poll iteration, it also becomes enqueued.
  - `collab_stream_reads_dequeued` is incremented for every stream that scheduler returned for xread. These two metrics should be fairly close to each other. If they reads_enqueued grows faster than reads_dequeued it means, that we schedule new stream read requests faster than we can handle them.
2. It fixes the issue when an observer was not correctly dropped and stayed inside of stream router for as long as no new objects where pulled from its corresponding stream.