### PR TITLE
chore: add explantion for password for special characters

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -8,7 +8,7 @@ POSTGRES_PASSWORD=password
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres
 
-# Supabase user settings
+# Postgres credential for supabase_auth_admin
 SUPABASE_PASSWORD=root
 
 # Redis Settings
@@ -22,7 +22,8 @@ MINIO_PORT=9000
 # AppFlowy Cloud
 ## URL that connects to the gotrue docker container
 APPFLOWY_GOTRUE_BASE_URL=http://gotrue:9999
-## URL that connects to the postgres docker container
+## URL that connects to the postgres docker container. If your password contains special characters, instead of using ${POSTGRES_PASSWORD},
+## you will need to convert them into url encoded format. For example, `p@ssword` will become `p%40ssword`.
 APPFLOWY_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 APPFLOWY_ACCESS_CONTROL=true
 APPFLOWY_WEBSOCKET_MAILBOX_SIZE=6000
@@ -78,8 +79,8 @@ GOTRUE_DISABLE_SIGNUP=false
 # Replace with your host name instead of localhost
 API_EXTERNAL_URL=http://your-host
 
-# In docker environment, `postgres` is the hostname of the postgres service
-# GoTrue connect to postgres using this url
+# GoTrue connect to postgres using this url. If your password contains special characters,
+# replace ${SUPABASE_PASSWORD} with the url encoded version. For example, `p@ssword` will become `p%40ssword`
 GOTRUE_DATABASE_URL=postgres://supabase_auth_admin:${SUPABASE_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # Refer to this for details: https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/main/doc/AUTHENTICATION.md


### PR DESCRIPTION
Add additional explanation to avoid start up failure due to special characters in SUPABASE_PASSWORD and POSTGRES_PASSWORD.