### PR TITLE
fix: api external url should be for gotrue, not appflowy cloud

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -94,7 +94,7 @@ jobs:
           sed -i 's|GOTRUE_SMTP_ADMIN_EMAIL=.*|GOTRUE_SMTP_ADMIN_EMAIL=${{ secrets.CI_GOTRUE_SMTP_ADMIN_EMAIL }}|' .env
           sed -i 's|GOTRUE_EXTERNAL_GOOGLE_ENABLED=.*|GOTRUE_EXTERNAL_GOOGLE_ENABLED=true|' .env
           sed -i 's|GOTRUE_MAILER_AUTOCONFIRM=.*|GOTRUE_MAILER_AUTOCONFIRM=false|' .env
-          sed -i 's|API_EXTERNAL_URL=http://your-host|API_EXTERNAL_URL=http://localhost|' .env
+          sed -i 's|API_EXTERNAL_URL=http://your-host/gotrue|API_EXTERNAL_URL=http://localhost/gotrue|' .env
           sed -i 's|GOTRUE_RATE_LIMIT_EMAIL_SENT=100|GOTRUE_RATE_LIMIT_EMAIL_SENT=1000|' .env
           sed -i 's|APPFLOWY_MAILER_SMTP_USERNAME=.*|APPFLOWY_MAILER_SMTP_USERNAME=${{ secrets.CI_GOTRUE_SMTP_USER }}|' .env
           sed -i 's|APPFLOWY_MAILER_SMTP_PASSWORD=.*|APPFLOWY_MAILER_SMTP_PASSWORD=${{ secrets.CI_GOTRUE_SMTP_PASS }}|' .env
@@ -163,4 +163,3 @@ jobs:
           else
             echo "Successfully deleted Docker image tag for $IMAGE_TAG:${GITHUB_SHA}"
           fi
-

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -41,17 +41,17 @@ jobs:
           sed -i '' 's|RUST_LOG=.*|RUST_LOG=debug|' .env
           sed -i '' 's|API_EXTERNAL_URL=.*|API_EXTERNAL_URL=http://localhost:9999|' .env
           sed -i '' 's|APPFLOWY_INDEXER_ENABLED=.*|APPFLOWY_INDEXER_ENABLED=false|' .env
-          
+
           sed -i '' 's|APPFLOWY_GOTRUE_BASE_URL=.*|APPFLOWY_GOTRUE_BASE_URL=http://localhost:9999|' .env
           sed -i '' 's|GOTRUE_MAILER_AUTOCONFIRM=.*|GOTRUE_MAILER_AUTOCONFIRM=false|' .env
           sed -i '' 's|APPFLOWY_DATABASE_URL=.*|APPFLOWY_DATABASE_URL=postgres://postgres:password@localhost:5432/postgres|' .env
-          
+
           cat .env
         shell: bash
 
       - name: Start Docker Compose Services
         run: |
-          docker compose -f docker-compose-dev.yml up -d 
+          docker compose -f docker-compose-dev.yml up -d
           ./script/code_gen.sh
           cargo sqlx database create && cargo sqlx migrate run
 

--- a/deploy.env
+++ b/deploy.env
@@ -71,13 +71,9 @@ GOTRUE_ADMIN_PASSWORD=password
 # Set this to true if users can only join by invite
 GOTRUE_DISABLE_SIGNUP=false
 
-# User will be redirected to this after Email or OAuth login
-# Change this to your own domain where you host the docker-compose or gotrue
-# If you are using a different domain, you need to change the redirect_uri in the OAuth2 configuration
-# Make sure that this domain is accessible to the user
-# Make sure no endswith /
-# Replace with your host name instead of localhost
-API_EXTERNAL_URL=http://your-host
+# External URL where the GoTrue service is exposed. Replace `your-host` with your domain.
+# For example, if your host is `appflowy.home.com`, API_EXTERNAL_URL should be set to `http://appflowy.home.com/gotrue`
+API_EXTERNAL_URL=http://your-host/gotrue
 
 # GoTrue connect to postgres using this url. If your password contains special characters,
 # replace ${SUPABASE_PASSWORD} with the url encoded version. For example, `p@ssword` will become `p%40ssword`
@@ -88,22 +84,22 @@ GOTRUE_DATABASE_URL=postgres://supabase_auth_admin:${SUPABASE_PASSWORD}@${POSTGR
 GOTRUE_EXTERNAL_GOOGLE_ENABLED=false
 GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=
 GOTRUE_EXTERNAL_GOOGLE_SECRET=
-GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=${API_EXTERNAL_URL}/gotrue/callback
+GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=${API_EXTERNAL_URL}/callback
 # GitHub OAuth2
 GOTRUE_EXTERNAL_GITHUB_ENABLED=false
 GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=
 GOTRUE_EXTERNAL_GITHUB_SECRET=
-GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=${API_EXTERNAL_URL}/gotrue/callback
+GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=${API_EXTERNAL_URL}/callback
 # Discord OAuth2
 GOTRUE_EXTERNAL_DISCORD_ENABLED=false
 GOTRUE_EXTERNAL_DISCORD_CLIENT_ID=
 GOTRUE_EXTERNAL_DISCORD_SECRET=
-GOTRUE_EXTERNAL_DISCORD_REDIRECT_URI=${API_EXTERNAL_URL}/gotrue/callback
+GOTRUE_EXTERNAL_DISCORD_REDIRECT_URI=${API_EXTERNAL_URL}/callback
 # Apple OAuth2
 GOTRUE_EXTERNAL_APPLE_ENABLED=false
 GOTRUE_EXTERNAL_APPLE_CLIENT_ID=
 GOTRUE_EXTERNAL_APPLE_SECRET=
-GOTRUE_EXTERNAL_APPLE_REDIRECT_URI=${API_EXTERNAL_URL}/gotrue/callback
+GOTRUE_EXTERNAL_APPLE_REDIRECT_URI=${API_EXTERNAL_URL}/callback
 
 # File Storage
 # Create the bucket if not exists on AppFlowy Cloud start up.


### PR DESCRIPTION
API_EXTERNAL_URL is meant for the external endpoint for gotrue, not appflowy cloud. Not having gotrue suffix will cause SAML integration to fail.