### PR TITLE
chore: allow nginx conf to be more easily configurable

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -158,6 +158,15 @@ docker logs <NAME>
 - Alternatively, you can use a specific image tag instead of `latest`, and checkout the corresponding tag for
   the repository.
 
+### 7. AppFlowy Web
+
+- AppFlowy Web is a Single Page Application (SPA) that calls the endpoints in  `appflowy_cloud`, and is assumed
+  to be served on a different origin that the one used for AppFlowy Cloud (eg. if you are hosting `appflowy cloud`
+  on `appflowy.home.com`, `appflowy_web` may be hosted on `web.appflowy.home.com`). The source code and deployment
+  guide can be found in this [repository](https://github.com/AppFlowy-IO/AppFlowy-Web).
+- To prevent CORS issues, you will need to change `set $appflowy_web "http://localhost:3000";` in `nginx/nginx.conf`
+  to the origin where you are hosting `appflowy_web`.
+
 ## Ports
 
 - After Deployment, you should see that AppFlowy-Cloud is serving 2 ports

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,11 +33,18 @@ http {
         client_max_body_size 10M;
 
         underscores_in_headers on;
+        set $appflowy_web_origin "http://localhost:3000";
+        set $appflowy_cloud_backend "http://appflowy_cloud:8000";
+        set $gotrue_backend "http://gotrue:9999";
+        set $admin_frontend_backend "http://admin_frontend:3000";
+        set $appflowy_ai_backend "http://ai:5001";
+        set $minio_backend "http://minio:9001";
+        set $portainer_backend "http://portainer:9000";
+        set $pgadmin_backend "http://pgadmin:80";
 
         # GoTrue
         location /gotrue/ {
-            set $gotrue gotrue;
-            proxy_pass http://$gotrue:9999;
+            proxy_pass $gotrue_backend;
 
             rewrite ^/gotrue(/.*)$ $1 break;
 
@@ -49,8 +56,7 @@ http {
 
         # WebSocket
         location /ws {
-            set $appflowy_cloud appflowy_cloud;
-            proxy_pass http://$appflowy_cloud:8000;
+            proxy_pass $appflowy_cloud_backend;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -62,7 +68,7 @@ http {
         # AppFlowy-Cloud
         # created a separate location block for handling CORS preflight (OPTIONS) requests specifically for the /api endpoint.
         location = /api/options {
-            if ($http_origin ~* (http://127.0.0.1:8000)) {
+            if ($http_origin ~* ($appflowy_web_origin)) {
                 add_header 'Access-Control-Allow-Origin' $http_origin;
             }
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE, PATCH';
@@ -74,8 +80,7 @@ http {
         }
 
         location /api/chat {
-            set $appflowy_cloud appflowy_cloud;
-            proxy_pass http://$appflowy_cloud:8000;
+            proxy_pass $appflowy_cloud_backend;
 
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -89,15 +94,14 @@ http {
         }
 
         location /api/import {
-            set $appflowy_cloud appflowy_cloud;
-            proxy_pass http://$appflowy_cloud:8000;
+            proxy_pass $appflowy_cloud_backend;
 
             # Set headers
             proxy_set_header X-Request-Id $request_id;
             proxy_set_header Host $http_host;
 
             # Handle CORS
-            if ($http_origin ~* (http://127.0.0.1:8000)) {
+            if ($http_origin ~* ($appflowy_web_origin)) {
                 add_header 'Access-Control-Allow-Origin' $http_origin always;
             }
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
@@ -117,8 +121,7 @@ http {
         }
 
         location /api {
-            set $appflowy_cloud appflowy_cloud;
-            proxy_pass http://$appflowy_cloud:8000;
+            proxy_pass $appflowy_cloud_backend;
 
             proxy_set_header X-Request-Id $request_id;
             proxy_set_header Host $http_host;
@@ -127,7 +130,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
 
             # Set CORS headers for other requests
-            if ($http_origin ~* (http://127.0.0.1:8000)) {
+            if ($http_origin ~* ($appflowy_web_origin)) {
                 add_header 'Access-Control-Allow-Origin' $http_origin always;
             }
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH' always;
@@ -135,8 +138,7 @@ http {
             add_header 'Access-Control-Max-Age' 3600 always;
 
             location ~* ^/api/workspace/([a-zA-Z0-9_-]+)/publish$ {
-                set $appflowy_cloud appflowy_cloud;
-                proxy_pass http://$appflowy_cloud:8000;
+                proxy_pass $appflowy_cloud_backend;
                 proxy_request_buffering off;
                 client_max_body_size 256M;
             }
@@ -144,8 +146,7 @@ http {
 
         # AppFlowy AI
         location /ai {
-            set $ai ai;
-            proxy_pass http://$ai:5001;
+            proxy_pass $appflowy_ai_backend;
             proxy_set_header Host $host;
             proxy_pass_request_headers on;
         }
@@ -154,8 +155,7 @@ http {
         # Derive from: https://min.io/docs/minio/linux/integrations/setup-nginx-proxy-with-minio.html
         # Optional Module, comment this section if you are did not deploy minio in docker-compose.yml
         location /minio/ {
-            set $minio minio;
-            proxy_pass http://$minio:9001;
+            proxy_pass $minio_backend;
 
             rewrite ^/minio/(.*) /$1 break;
             proxy_set_header Host $http_host;
@@ -184,7 +184,7 @@ http {
         # Optional Module, comment this section if you are did not deploy pgadmin in docker-compose.yml
         location /pgadmin/ {
             set $pgadmin pgadmin;
-            proxy_pass http://$pgadmin:80;
+            proxy_pass $pgadmin_backend;
 
             proxy_set_header X-Script-Name /pgadmin;
             proxy_set_header X-Scheme $scheme;
@@ -193,19 +193,16 @@ http {
         }
 
         # Portainer
-	    # Optional Module, comment this section if you are did not deploy portainer in docker-compose.yml
+        # Optional Module, comment this section if you are did not deploy portainer in docker-compose.yml
         location /portainer/ {
-            set $portainer portainer;
-            proxy_pass http://$portainer:9000;
-
-	    rewrite ^/portainer/(.*) /$1 break;
+            proxy_pass $portainer_backend;
+            rewrite ^/portainer/(.*) /$1 break;
         }
 
         # Admin Frontend
-	    # Optional Module, comment this section if you are did not deploy admin_frontend in docker-compose.yml
+        # Optional Module, comment this section if you are did not deploy admin_frontend in docker-compose.yml
         location / {
-            set $admin_frontend admin_frontend;
-            proxy_pass http://$admin_frontend:3000;
+            proxy_pass $admin_frontend_backend;
 
             proxy_set_header X-Scheme $scheme;
             proxy_set_header Host $host;


### PR DESCRIPTION
This PR updates nginx.conf such that:

1. It's easier to update the proxy pass values for various services, in the event where the user needs to use the same nginx conf for their external nginx.

2. Easier to update allowed cors origin.

3. Only appflowy web is supposed to be on allowed cors origin, there's no reason why 127.0.0.1:8000 to be on allowed origin.