### PR TITLE
fix: Minio redirect url shouldn't use API_EXTERNAL_URL

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -1,6 +1,10 @@
 # This file is a template for docker compose deployment
 # Copy this file to .env and change the values as needed
 
+# Fully qualified domain name for the deployment. Replace localhost with your domain,
+# such as http://mydomain.com.
+FQDN=http://localhost
+
 # PostgreSQL Settings
 POSTGRES_HOST=postgres
 POSTGRES_USER=postgres
@@ -74,9 +78,8 @@ GOTRUE_ADMIN_PASSWORD=password
 # Set this to true if users can only join by invite
 GOTRUE_DISABLE_SIGNUP=false
 
-# External URL where the GoTrue service is exposed. Replace `your-host` with your domain.
-# For example, if your host is `appflowy.home.com`, API_EXTERNAL_URL should be set to `http://appflowy.home.com/gotrue`
-API_EXTERNAL_URL=http://your-host/gotrue
+# External URL where the GoTrue service is exposed.
+API_EXTERNAL_URL=${FQDN}/gotrue
 
 # GoTrue connect to postgres using this url. If your password contains special characters,
 # replace ${SUPABASE_PASSWORD} with the url encoded version. For example, `p@ssword` will become `p%40ssword`

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -68,34 +68,16 @@ cp deploy.env .env
 ```
 
 - Kindly read through the comments for each option
-- Modify the values in `.env` according to your needs
+- Modify the values in `.env` according to your needs. Minimally, you will have to update $FQDN
+  to match your host server's domain, unless you are deploying on localhost.
 
-For authentication details, refer to the [Authentication](./AUTHENTICATION.md) documentation. You will need to update
-the
-redirect URI to match your host server's public IP or hostname, such
-as `http://<your-host-server-public-ip-or-hostname>/gotrue/callback`.
-If using localhost, then just keep the default value.
+If you would like to use one of the identity providers to log in, refer to the [Authentication](./AUTHENTICATION.md) documentation.
 
-```bash
-GOTRUE_EXTERNAL_GOOGLE_ENABLED=true
-GOTRUE_EXTERNAL_GOOGLE_CLIENT_ID=
-GOTRUE_EXTERNAL_GOOGLE_SECRET=
-GOTRUE_EXTERNAL_GOOGLE_REDIRECT_URI=http://your-host/gotrue/callback
+If you would like to use magic link to log in, you will need to set up env variables related to SMTP.
 
-# GitHub OAuth2
-GOTRUE_EXTERNAL_GITHUB_ENABLED=true
-GOTRUE_EXTERNAL_GITHUB_CLIENT_ID=your-github-client-id
-GOTRUE_EXTERNAL_GITHUB_SECRET=your-github-secret
-GOTRUE_EXTERNAL_GITHUB_REDIRECT_URI=http://your-host/gotrue/callback
-
-# Discord OAuth2
-GOTRUE_EXTERNAL_DISCORD_ENABLED=true
-GOTRUE_EXTERNAL_DISCORD_CLIENT_ID=your-discord-client-id
-GOTRUE_EXTERNAL_DISCORD_SECRET=your-discord-secret
-GOTRUE_EXTERNAL_DISCORD_REDIRECT_URI=http://your-host/gotrue/callback
-```
-
-### 3. Running the services
+If neither of the above are configured, then the only was to sign in is via the admin portal (the home page), using the admin email
+and password. After logging in as an admin, you can add users and set their passwords. The new user will be able to login to the admin
+portal using this credential.
 
 #### Start and run AppFlowy-Cloud
 
@@ -121,9 +103,6 @@ admin/debug tasks.
 - `portainer`/`portainer_init` (Web UI to provide some monitoring and ease of container management)
 - `tunnel` (Cloudflare tunnel to provide a secure way to connect AppFlowy to Cloudflare without a publicly routable IP
   address)
-- `admin_frontend` (admin portal to manage accounts and add authentication methods. We recommend to keep this)
-  If you wish to deploy those, edit the file accordingly and do:
-
 ```
 docker compose --file docker-compose-extras.yml up -d
 ```
@@ -223,12 +202,6 @@ by setting the `GOTRUE_DISABLE_SIGNUP` environment variable to `true`.
 
 The default configuration assumes that TLS is used for SMTP, typically on port 465. If you are using STARTTLS, such as when
 using port 587, please change `APPFLOWY_MAILER_SMTP_TLS_KIND` to `opportunistic`.
-
-### Can I sign in using only using email and password?
-
-The AppFlowy clients currently do not support email and password sign in. However, you can login to the admin portal using the admin
-email and password. In the admin section, you can then add users and set their passwords. Subseqently, users can login to the portal
-using their email and password, and launch the AppFlowy client via the portal.
 
 ### What functionality will I lose if the SMTP server is not set up?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     restart: on-failure
     image: minio/minio
     environment:
-      - MINIO_BROWSER_REDIRECT_URL=${API_EXTERNAL_URL}/minio
+      - MINIO_BROWSER_REDIRECT_URL=${FQDN?:err}/minio
       - MINIO_ROOT_USER=${APPFLOWY_S3_ACCESS_KEY:-minioadmin}
       - MINIO_ROOT_PASSWORD=${APPFLOWY_S3_SECRET_KEY:-minioadmin}
     command: server /data --console-address ":9001"


### PR DESCRIPTION
MINIO_REDIRECT_URL was set to ${API_EXTERNAL_URL}/minio. This was originally correct, as API_EXTERNAL_URL was wrongly configured to be the deployment's FQDN instead of gotrue external url. But after this bug was fixed, Minio became inaccessible instead, because of the additional gotrue prefix.

This PR will add an additional env variable, FQDN, to address this.