### PR TITLE
fix: add cors for nginx gotrue configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       - AI_SERVER_PORT=${AI_SERVER_PORT}
       - AI_OPENAI_API_KEY=${AI_OPENAI_API_KEY}
       # Uncomment this line if AppFlowy Web has been deployed
+      # - APPFLOWY_WEB_URL=${APPFLOWY_WEB_URL}
     build:
       context: .
       dockerfile: Dockerfile

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -49,6 +49,17 @@ http {
 
         # GoTrue
         location /gotrue/ {
+            if ($request_method = 'OPTIONS') {
+              add_header 'Access-Control-Allow-Origin' $cors_origin always;
+              add_header 'Access-Control-Allow-Credentials' 'true' always;
+              add_header 'Access-Control-Allow-Headers' '*' always;
+              add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+              add_header 'Access-Control-Max-Age' 3600 always;
+              add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+              add_header 'Content-Length' 0 always;
+              return 204;
+            }
+
             proxy_pass $gotrue_backend;
 
             rewrite ^/gotrue(/.*)$ $1 break;


### PR DESCRIPTION
The current Nginx configuration did not add CORS related header to the gotrue endpoint, which cause sign in via AppFlowy Web to fail when using magic link.