### PR TITLE
feat: add publish info to publish outline items

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Build Docker Images
         run: |
           export DOCKER_DEFAULT_PLATFORM=linux/amd64
+          cp deploy.env .env
           docker compose build appflowy_cloud  appflowy_worker admin_frontend
 
       - name: Push docker images to docker hub

--- a/.sqlx/query-4787139d2189fc33ac25ac07bb9f585f578bde4cd3f75a7da95aa849a25bca9d.json
+++ b/.sqlx/query-4787139d2189fc33ac25ac07bb9f585f578bde4cd3f75a7da95aa849a25bca9d.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT\n        apc.view_id,\n        apc.publish_name,\n        au.email AS publisher_email,\n        apc.created_at AS publish_timestamp\n      FROM af_published_collab apc\n      JOIN af_user au ON apc.published_by = au.uid\n      WHERE workspace_id = $1\n      AND unpublished_at IS NULL\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "view_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "publish_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "publisher_email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "publish_timestamp",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4787139d2189fc33ac25ac07bb9f585f578bde4cd3f75a7da95aa849a25bca9d"
+}

--- a/libs/database/src/pg_row.rs
+++ b/libs/database/src/pg_row.rs
@@ -686,3 +686,10 @@ impl From<AFQuickNoteRow> for QuickNote {
     }
   }
 }
+
+pub struct AFPublishViewWithPublishInfo {
+  pub view_id: Uuid,
+  pub publish_name: String,
+  pub publisher_email: String,
+  pub publish_timestamp: DateTime<Utc>,
+}

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -389,9 +389,18 @@ pub struct PublishedView {
   pub icon: Option<ViewIcon>,
   pub layout: ViewLayout,
   pub is_published: bool,
+  #[serde(flatten)]
+  pub info: Option<PublishedViewInfo>,
   /// contains fields like `is_space`, and font information
   pub extra: Option<serde_json::Value>,
   pub children: Vec<PublishedView>,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct PublishedViewInfo {
+  pub publisher_email: String,
+  pub publish_name: String,
+  pub publish_timestamp: DateTime<Utc>,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Add additional publish info to publish outline items so that appflowy web does not need to make additional calls to fetch the additional information.