### PR TITLE
feat: add root view id of the created web template to duplicate published page response

### DIFF
--- a/libs/client-api/src/http_publish.rs
+++ b/libs/client-api/src/http_publish.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use client_api_entity::publish_dto::DuplicatePublishedPageResponse;
 use client_api_entity::workspace_dto::{PublishInfoView, PublishedView};
 use client_api_entity::{workspace_dto::PublishedDuplicate, PublishInfo, UpdatePublishNamespace};
 use client_api_entity::{
@@ -410,7 +411,7 @@ impl Client {
     &self,
     workspace_id: &str,
     publish_duplicate: &PublishedDuplicate,
-  ) -> Result<(), AppResponseError> {
+  ) -> Result<DuplicatePublishedPageResponse, AppResponseError> {
     let url = format!(
       "{}/api/workspace/{}/published-duplicate",
       self.base_url, workspace_id
@@ -422,7 +423,9 @@ impl Client {
       .send()
       .await?;
     log_request_id(&resp);
-    AppResponse::<()>::from_response(resp).await?.into_error()
+    AppResponse::<DuplicatePublishedPageResponse>::from_response(resp)
+      .await?
+      .into_data()
   }
 
   pub async fn get_published_view_reactions(

--- a/libs/shared-entity/src/dto/publish_dto.rs
+++ b/libs/shared-entity/src/dto/publish_dto.rs
@@ -59,3 +59,8 @@ pub struct PublishDatabaseData {
   /// Relation view id map
   pub database_relations: HashMap<String, String>,
 }
+
+#[derive(Default, Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
+pub struct DuplicatePublishedPageResponse {
+  pub view_id: String,
+}


### PR DESCRIPTION
Previously, there is no need for returning the newly created page id, because there's no requirement to jump to the duplicated page once the API is called.

However, AppFlowy Web will soon have such requirement, hence the root view id of the duplicate view is required in the response now.