### PR TITLE
chore: detailed error response for get page view

### DIFF
--- a/libs/database/src/user.rs
+++ b/libs/database/src/user.rs
@@ -265,7 +265,8 @@ pub async fn select_web_user_from_uid(pool: &PgPool, uid: i64) -> Result<AFWebUs
     uid
   )
   .fetch_one(pool)
-  .await?;
+  .await
+  .map_err(|err| anyhow::anyhow!("Unable to get user detail for {}: {}", uid, err))?;
 
   Ok(row)
 }

--- a/src/biz/collab/utils.rs
+++ b/src/biz/collab/utils.rs
@@ -377,7 +377,14 @@ pub async fn get_latest_collab_folder(
     workspace_id,
     CollabType::Folder,
   )
-  .await?;
+  .await
+  .map_err(|err| {
+    AppError::Internal(anyhow::anyhow!(
+      "Unable to retrieve workspace folder {}: {}",
+      workspace_id,
+      err
+    ))
+  })?;
   let folder = Folder::from_collab_doc_state(
     folder_uid,
     CollabOrigin::Server,
@@ -385,7 +392,13 @@ pub async fn get_latest_collab_folder(
     workspace_id,
     vec![],
   )
-  .map_err(|e| AppError::Unhandled(e.to_string()))?;
+  .map_err(|e| {
+    AppError::Internal(anyhow::anyhow!(
+      "Unable to decode workspace folder {}: {}",
+      workspace_id,
+      e
+    ))
+  })?;
   Ok(folder)
 }
 


### PR DESCRIPTION
Detailed error response for get page view so that users and developers can troubleshoot the exact error that happens if a view cannot be displayed on appflowy web.