### PR TITLE
fix: do not merge awareness sync data info client update sync data

### DIFF
--- a/libs/client-api/src/collab_sync/collab_sink.rs
+++ b/libs/client-api/src/collab_sync/collab_sink.rs
@@ -380,20 +380,6 @@ where
               .or_insert(vec![])
               .push(next.msg_id());
 
-            // let last_message = last.message();
-            // let next_message = next.message();
-            // if last_message.is_awareness_sync() && next_message.is_update_sync()
-            //   || (last_message.is_update_sync() && next_message.is_awareness_sync())
-            // {
-            //   error!(
-            //     "[collab_sync] ❎ different type of message: id: {:?}, type: {:?}, with message: {:?}, type: {:?}",
-            //     last.msg_id(),
-            //     last_message,
-            //     next.msg_id(),
-            //     next_message,
-            //   );
-            // }
-
             // If the last message is merged with the next message, don't push the next message
             continue;
           }

--- a/libs/client-api/src/collab_sync/plugin.rs
+++ b/libs/client-api/src/collab_sync/plugin.rs
@@ -192,7 +192,7 @@ where
         trace!("queue awareness: {:?}", update);
       }
 
-      ClientCollabMessage::new_update_sync(update_sync)
+      ClientCollabMessage::new_awareness_sync(update_sync)
     });
   }
 

--- a/libs/collab-rt-entity/src/client_message.rs
+++ b/libs/collab-rt-entity/src/client_message.rs
@@ -13,6 +13,7 @@ use std::hash::{Hash, Hasher};
 use yrs::merge_updates_v1;
 use yrs::updates::decoder::DecoderV1;
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
+
 pub trait SinkMessage: Clone + Send + Sync + 'static + Ord + Display {
   fn payload_size(&self) -> usize;
   fn mergeable(&self) -> bool;
@@ -20,8 +21,10 @@ pub trait SinkMessage: Clone + Send + Sync + 'static + Ord + Display {
   fn is_client_init_sync(&self) -> bool;
   fn is_server_init_sync(&self) -> bool;
   fn is_update_sync(&self) -> bool;
+  fn is_awareness_sync(&self) -> bool;
   fn is_ping_sync(&self) -> bool;
 }
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ClientCollabMessage {
   ClientInitSync { data: InitSync },
@@ -42,6 +45,10 @@ impl ClientCollabMessage {
 
   pub fn new_server_init_sync(data: ServerInit) -> Self {
     Self::ServerInitSync(data)
+  }
+
+  pub fn new_awareness_sync(data: UpdateSync) -> Self {
+    Self::ClientAwarenessSync(data)
   }
 
   pub fn size(&self) -> usize {
@@ -183,6 +190,10 @@ impl SinkMessage for ClientCollabMessage {
 
   fn is_update_sync(&self) -> bool {
     matches!(self, ClientCollabMessage::ClientUpdateSync { .. })
+  }
+
+  fn is_awareness_sync(&self) -> bool {
+    matches!(self, ClientCollabMessage::ClientAwarenessSync { .. })
   }
 
   fn is_ping_sync(&self) -> bool {


### PR DESCRIPTION
```rs
  fn receive_local_state(
    &self,
    origin: &CollabOrigin,
    object_id: &str,
    _event: &Event,
    update: &AwarenessUpdate,
  ) {
    let payload = Message::Awareness(update.encode_v1()).encode_v1();
    // ...
      ClientCollabMessage::new_update_sync(update_sync) <- Here
```

In the previous implementation, the awareness data was associated with the `ClientCollabMessage::new_update_sync`, which caused the awareness update to be merged into the client update.