### PR TITLE
fix: get page view should handle situation where last editor or document owner cannot be found

### DIFF
--- a/libs/database/src/user.rs
+++ b/libs/database/src/user.rs
@@ -251,7 +251,10 @@ pub async fn select_name_and_email_from_uuid(
   Ok((row.name, row.email))
 }
 
-pub async fn select_web_user_from_uid(pool: &PgPool, uid: i64) -> Result<AFWebUser, AppError> {
+pub async fn select_web_user_from_uid(
+  pool: &PgPool,
+  uid: i64,
+) -> Result<Option<AFWebUser>, AppError> {
   let row = sqlx::query_as!(
     AFWebUser,
     r#"
@@ -264,7 +267,7 @@ pub async fn select_web_user_from_uid(pool: &PgPool, uid: i64) -> Result<AFWebUs
     "#,
     uid
   )
-  .fetch_one(pool)
+  .fetch_optional(pool)
   .await
   .map_err(|err| anyhow::anyhow!("Unable to get user detail for {}: {}", uid, err))?;
 

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -1290,11 +1290,11 @@ pub async fn get_page_view_collab(
     )))?;
 
   let owner = match view.created_by {
-    Some(uid) => Some(select_web_user_from_uid(pg_pool, uid).await?),
+    Some(uid) => select_web_user_from_uid(pg_pool, uid).await?,
     None => None,
   };
   let last_editor = match view.last_edited_by {
-    Some(uid) => Some(select_web_user_from_uid(pg_pool, uid).await?),
+    Some(uid) => select_web_user_from_uid(pg_pool, uid).await?,
     None => None,
   };
   let publish_view_ids = select_published_view_ids_for_workspace(pg_pool, workspace_id)


### PR DESCRIPTION
There are situations where last editor or document  owner cannot be found, as illustrated in https://github.com/AppFlowy-IO/AppFlowy/issues/7221 . Get page view API should not fail in such case because last editor and document owner information are not strictly required to render the page.