### PR TITLE
fix: bucket creation failure should result in the server failing, instead of proceeding

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -488,7 +488,7 @@ async fn create_bucket_if_not_exists(
         }
       } else {
         error!("Failed to create bucket: {:?}", err);
-        Ok(())
+        Err(err.into())
       }
     },
   }


### PR DESCRIPTION
Currently, if a bucket cannot be created (eg. due to permission issue), AppFlowy Cloud proceed to run as per normal, even if this would lead to issues down the road.