### PR TITLE
fix: add device id header to allowed CORS header list to allow web-update API

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -91,14 +91,14 @@ http {
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Allow-Origin' $cors_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version, Device-Id' always;
                 add_header 'Access-Control-Max-Age' 3600 always;
                 return 204;
             }
 
             add_header 'Access-Control-Allow-Origin' $cors_origin always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version, Device-Id' always;
             add_header 'Access-Control-Max-Age' 3600 always;
 
             location ~* ^/api/workspace/([a-zA-Z0-9_-]+)/publish$ {
@@ -108,14 +108,14 @@ http {
                 if ($request_method = 'OPTIONS') {
                     add_header 'Access-Control-Allow-Origin' $cors_origin always;
                     add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-                    add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version' always;
+                    add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version, Device-Id' always;
                     add_header 'Access-Control-Max-Age' 3600 always;
                     return 204;
                 }
 
                 add_header 'Access-Control-Allow-Origin' $cors_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Client-Version, Device-Id' always;
                 add_header 'Access-Control-Max-Age' 3600 always;
             }
 
@@ -144,7 +144,7 @@ http {
                 # Handle CORS
                 add_header 'Access-Control-Allow-Origin' $cors_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, Device-Id' always;
                 add_header 'Access-Control-Max-Age' 3600 always;
 
                 # Timeouts


### PR DESCRIPTION
Not adding device id to the header may result in CORS failure when AppFlowy Web calls the web-update API.