### PR TITLE
chore: add curl to appflowy cloud image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,12 @@ RUN cargo build --profile=${PROFILE} --features "${FEATURES}" --bin appflowy_clo
 FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends openssl ca-certificates \
-    && update-ca-certificates \
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends openssl ca-certificates curl \
+  && update-ca-certificates \
+  # Clean up
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/appflowy_cloud /usr/local/bin/appflowy_cloud
 ENV APP_ENVIRONMENT production


### PR DESCRIPTION
Currently, we don't have a good way to provide health check for appflowy cloud in docker compose. Adding curl so that we can use curl to call an endpoint on appflowy cloud, to verify if the server is ready to accept requests.