### PR TITLE
fix: appflowy web url env var is not used

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -181,4 +181,7 @@ APPFLOWY_WORKER_REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}
 APPFLOWY_WORKER_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # AppFlowy Web
-APPFLOWY_WEB_URL=http://localhost:3000
+# If your AppFlowy Web is hosted on a different domain, update this variable to the correct domain
+APPFLOWY_WEB_URL=${FQDN}
+# If you are running AppFlowy Web locally for development purpose, use the following value instead
+# APPFLOWY_WEB_URL=http://localhost:3000

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -135,6 +135,7 @@ docker logs <NAME>
 - Then, run `docker compose up -d` to start the services.
 - Alternatively, you can use a specific image tag instead of `latest`, and checkout the corresponding tag for
   the repository.
+- If you found that `nginx.conf` or `deploy.env` has been updated, please update your env and nginx configuration based on the change.
 - Sometimes there might be additional steps required for upgrade. Refer to the [upgrade notes](https://appflowy.com/docs/self-hosters-upgrade-notes)
   for more information.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,8 +137,7 @@ services:
       - AI_SERVER_PORT=${AI_SERVER_PORT}
       - AI_OPENAI_API_KEY=${AI_OPENAI_API_KEY}
       - APPFLOWY_ADMIN_FRONTEND_PATH_PREFIX=${ADMIN_FRONTEND_PATH_PREFIX}
-      # If your AppFlowy Web is hosted on a different domain, update this variable to the correct domain
-      - APPFLOWY_WEB_URL=${FQDN}
+      - APPFLOWY_WEB_URL=${APPFLOWY_WEB_URL}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
The env variable, `APPFLOWY_WEB_URL` is not actually used by the docker compose file at the moment because the docker compose file use $FQDN directly. `APFFLOWY_WEB_URL` should be used instead, and the default value for the variable should be set to $FQDN instead of localhost:3000.