### PR TITLE
feat: support is_action_allowed for workspace access control module

### DIFF
--- a/libs/access-control/src/casbin/access.rs
+++ b/libs/access-control/src/casbin/access.rs
@@ -58,6 +58,15 @@ impl AccessControl {
     })
   }
 
+  #[cfg(test)]
+  pub fn with_enforcer(enforcer: AFEnforcer) -> Self {
+    let access_control_metrics = Arc::new(AccessControlMetrics::init());
+    Self {
+      enforcer: Arc::new(enforcer),
+      access_control_metrics,
+    }
+  }
+
   pub async fn update_policy(
     &self,
     sub: SubjectType,

--- a/libs/access-control/src/casbin/enforcer.rs
+++ b/libs/access-control/src/casbin/enforcer.rs
@@ -201,7 +201,7 @@ async fn policies_for_subject_with_given_object(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
   use crate::{
     act::{Action, ActionVariant},
     casbin::access::{casbin_model, cmp_role_or_level},
@@ -213,7 +213,7 @@ mod tests {
 
   use super::AFEnforcer;
 
-  async fn test_enforcer() -> AFEnforcer {
+  pub async fn test_enforcer() -> AFEnforcer {
     let model = casbin_model().await.unwrap();
     let mut enforcer = casbin::Enforcer::new(model, MemoryAdapter::default())
       .await

--- a/libs/access-control/src/metrics.rs
+++ b/libs/access-control/src/metrics.rs
@@ -16,7 +16,7 @@ pub struct AccessControlMetrics {
 }
 
 impl AccessControlMetrics {
-  fn init() -> Self {
+  pub(crate) fn init() -> Self {
     Self {
       load_all_policies: Gauge::default(),
       total_read_enforce_count: Gauge::default(),

--- a/libs/access-control/src/noops/workspace.rs
+++ b/libs/access-control/src/noops/workspace.rs
@@ -32,6 +32,15 @@ impl WorkspaceAccessControl for WorkspaceAccessControlImpl {
     Ok(())
   }
 
+  async fn has_role(
+    &self,
+    _uid: &i64,
+    _workspace_id: &str,
+    _role: AFRole,
+  ) -> Result<bool, AppError> {
+    Ok(true)
+  }
+
   async fn enforce_action(
     &self,
     _uid: &i64,
@@ -39,6 +48,15 @@ impl WorkspaceAccessControl for WorkspaceAccessControlImpl {
     _action: Action,
   ) -> Result<(), AppError> {
     Ok(())
+  }
+
+  async fn is_action_allowed(
+    &self,
+    _uid: &i64,
+    _workspace_id: &str,
+    _action: Action,
+  ) -> Result<bool, AppError> {
+    Ok(true)
   }
 
   async fn insert_role(

--- a/libs/access-control/src/workspace.rs
+++ b/libs/access-control/src/workspace.rs
@@ -11,6 +11,10 @@ pub trait WorkspaceAccessControl: Send + Sync + 'static {
   async fn enforce_role(&self, uid: &i64, workspace_id: &str, role: AFRole)
     -> Result<(), AppError>;
 
+  /// Check if the user has the role in the workspace.
+  /// Returns False if the user does not have the role.
+  async fn has_role(&self, uid: &i64, workspace_id: &str, role: AFRole) -> Result<bool, AppError>;
+
   /// Check if the user can perform action on the workspace.
   /// Returns AppError::NotEnoughPermission if the user does not have the role.
   async fn enforce_action(
@@ -19,6 +23,15 @@ pub trait WorkspaceAccessControl: Send + Sync + 'static {
     workspace_id: &str,
     action: Action,
   ) -> Result<(), AppError>;
+
+  /// Check if the user can perform action on the workspace.
+  /// Returns false if the user is not allowed to perform the action.
+  async fn is_action_allowed(
+    &self,
+    uid: &i64,
+    workspace_id: &str,
+    action: Action,
+  ) -> Result<bool, AppError>;
 
   async fn insert_role(&self, uid: &i64, workspace_id: &Uuid, role: AFRole)
     -> Result<(), AppError>;


### PR DESCRIPTION
Currently, the workspace access control module will return NotEnoughPermission error when a user has no permission to execute a certain action. This is good for most purposes, as we can return the error directly to the user, but not convenient when we have scenarios where some other fallback can be performed if a user does not have enough permission.

Also added unitest for the workspace access control module.