### PR TITLE
chore: simplify access control implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,6 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "prometheus-client",
- "redis 0.25.4",
  "serde",
  "sqlx",
  "tokio",

--- a/libs/access-control/Cargo.toml
+++ b/libs/access-control/Cargo.toml
@@ -18,7 +18,6 @@ database-entity.workspace = true
 futures-util.workspace = true
 lazy_static.workspace = true
 prometheus-client.workspace = true
-redis.workspace = true
 sqlx = { workspace = true, default-features = false, features = ["postgres"] }
 tracing.workspace = true
 tokio = { workspace = true, features = ["macros", "time"] }

--- a/libs/access-control/src/casbin/adapter.rs
+++ b/libs/access-control/src/casbin/adapter.rs
@@ -80,7 +80,7 @@ async fn load_workspace_policies(
   while let Some(Ok(member_permission)) = stream.next().await {
     let uid = member_permission.uid;
     let workspace_id = member_permission.workspace_id.to_string();
-    let object_type = ObjectType::Workspace(&workspace_id);
+    let object_type = ObjectType::Workspace(workspace_id.to_string());
     for act in member_permission.role.policy_acts() {
       let policy = vec![
         uid.to_string(),

--- a/libs/access-control/src/entity.rs
+++ b/libs/access-control/src/entity.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SubjectType {
   User(i64),
   Group(String),
@@ -14,15 +14,15 @@ impl SubjectType {
 }
 
 /// Represents the object type that is stored in the access control policy.
-#[derive(Debug)]
-pub enum ObjectType<'id> {
+#[derive(Debug, Clone)]
+pub enum ObjectType {
   /// Stored as `workspace::<uuid>`
-  Workspace(&'id str),
+  Workspace(String),
   /// Stored as `collab::<uuid>`
-  Collab(&'id str),
+  Collab(String),
 }
 
-impl ObjectType<'_> {
+impl ObjectType {
   pub fn policy_object(&self) -> String {
     match self {
       ObjectType::Collab(s) => format!("collab::{}", s),
@@ -30,10 +30,10 @@ impl ObjectType<'_> {
     }
   }
 
-  pub fn object_id(&self) -> &str {
+  pub fn object_id(&self) -> String {
     match self {
-      ObjectType::Collab(s) => s,
-      ObjectType::Workspace(s) => s,
+      ObjectType::Collab(s) => s.clone(),
+      ObjectType::Workspace(s) => s.clone(),
     }
   }
 }

--- a/libs/access-control/src/metrics.rs
+++ b/libs/access-control/src/metrics.rs
@@ -16,7 +16,7 @@ pub struct AccessControlMetrics {
 }
 
 impl AccessControlMetrics {
-  fn init() -> Self {
+  pub(crate) fn init() -> Self {
     Self {
       load_all_policies: Gauge::default(),
       total_read_enforce_count: Gauge::default(),

--- a/libs/access-control/src/request.rs
+++ b/libs/access-control/src/request.rs
@@ -1,63 +1,21 @@
-use crate::act::ActionVariant;
+use crate::act::Acts;
 use crate::entity::ObjectType;
 
-pub struct WorkspacePolicyRequest<'a> {
-  workspace_id: &'a str,
-  uid: &'a i64,
-  pub object_type: &'a ObjectType<'a>,
-  pub action: &'a ActionVariant<'a>,
+pub struct PolicyRequest {
+  uid: i64,
+  object_type: ObjectType,
+  action_policy_string: String,
 }
 
-impl<'a> WorkspacePolicyRequest<'a> {
-  pub fn new(
-    workspace_id: &'a str,
-    uid: &'a i64,
-    object_type: &'a ObjectType<'a>,
-    action: &'a ActionVariant<'a>,
-  ) -> Self {
-    Self {
-      workspace_id,
-      uid,
-      object_type,
-      action,
-    }
-  }
-
-  pub fn to_policy(&self) -> Vec<String> {
-    match self.object_type {
-      ObjectType::Workspace(_) => {
-        // If the object type is a workspace, then keep using the original object type
-        vec![
-          self.uid.to_string(),
-          self.object_type.policy_object(),
-          self.action.to_enforce_act().to_string(),
-        ]
-      },
-      ObjectType::Collab(_) => {
-        // If the object type is a collab, then convert it to a workspace object type
-        let object_type = ObjectType::Workspace(self.workspace_id);
-        vec![
-          self.uid.to_string(),
-          object_type.policy_object(),
-          self.action.to_enforce_act().to_string(),
-        ]
-      },
-    }
-  }
-}
-
-pub struct PolicyRequest<'a> {
-  pub uid: i64,
-  pub object_type: &'a ObjectType<'a>,
-  pub action: &'a ActionVariant<'a>,
-}
-
-impl<'a> PolicyRequest<'a> {
-  pub fn new(uid: i64, object_type: &'a ObjectType<'a>, action: &'a ActionVariant<'a>) -> Self {
+impl PolicyRequest {
+  pub fn new<T>(uid: i64, object_type: ObjectType, action: T) -> Self
+  where
+    T: Acts,
+  {
     Self {
       uid,
       object_type,
-      action,
+      action_policy_string: action.to_enforce_act().to_string(),
     }
   }
 
@@ -65,7 +23,7 @@ impl<'a> PolicyRequest<'a> {
     vec![
       self.uid.to_string(),
       self.object_type.policy_object(),
-      self.action.to_enforce_act().to_string(),
+      self.action_policy_string.clone(),
     ]
   }
 }

--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -64,10 +64,8 @@ pub enum AppError {
   #[error("Not Logged In:{0}")]
   NotLoggedIn(String),
 
-  #[error(
-    "User:{user} does not have permissions to execute this action in workspace:{workspace_id}"
-  )]
-  NotEnoughPermissions { user: String, workspace_id: String },
+  #[error("User does not have permissions to execute this action")]
+  NotEnoughPermissions,
 
   #[error("s3 response error:{0}")]
   S3ResponseError(String),

--- a/libs/database/src/workspace.rs
+++ b/libs/database/src/workspace.rs
@@ -472,10 +472,7 @@ pub async fn delete_workspace_members(
   .unwrap_or(false);
 
   if is_owner {
-    return Err(AppError::NotEnoughPermissions {
-      user: member_email.to_string(),
-      workspace_id: workspace_id.to_string(),
-    });
+    return Err(AppError::NotEnoughPermissions);
   }
 
   sqlx::query!(

--- a/src/biz/access_request/ops.rs
+++ b/src/biz/access_request/ops.rs
@@ -79,13 +79,7 @@ pub async fn get_access_request(
     select_access_request_by_request_id(pg_pool, access_request_id).await?;
 
   if access_request_with_view_id.workspace.owner_uid != user_uid {
-    return Err(AppError::NotEnoughPermissions {
-      user: user_uid.to_string(),
-      workspace_id: access_request_with_view_id
-        .workspace
-        .workspace_id
-        .to_string(),
-    });
+    return Err(AppError::NotEnoughPermissions);
   }
   let folder = get_latest_collab_folder(
     collab_storage,


### PR DESCRIPTION
In order to make it easier to introduce fine grain access control, the following changes have been made:
1. Business logic to determine access control will now reside solely on WorkspaceAccessControl, CollabAccessControl and RealtimeAccessControl, instead of having some of them on the AFEnforcer.
2. Enforcer now receive the Acts trait directly instead of ActionVariant. This would make it easier for WorkspaceAccessControl and CollabAccessControl to introduce Workspace and Collab specific actions.