### PR TITLE
fix: drop 'Actions Required' from notification mail subject

### DIFF
--- a/src/mailer.rs
+++ b/src/mailer.rs
@@ -20,7 +20,7 @@ impl AFCloudMailer {
     param: WorkspaceInviteMailerParam,
   ) -> Result<(), anyhow::Error> {
     let subject = format!(
-      "Action required: {} invited you to {} in AppFlowy",
+      "{} invited you to {} in AppFlowy",
       param.username, param.workspace_name
     );
     self
@@ -51,7 +51,7 @@ impl AFCloudMailer {
     param: WorkspaceAccessRequestMailerParam,
   ) -> Result<(), anyhow::Error> {
     let subject = format!(
-      "Action required: {} requested access to {} in AppFlowy",
+      "{} requested access to {} in AppFlowy",
       param.username, param.workspace_name
     );
     self


### PR DESCRIPTION
Address https://github.com/AppFlowy-IO/AppFlowy-Cloud/issues/1185 . Based on community feedback, the term 'Actions Required' is commonly associated with spam email as it creates a sense of urgency.