### PR TITLE
fix: chat message endpoint should return user uuid instead of uid

### DIFF
--- a/libs/client-api/src/http_chat.rs
+++ b/libs/client-api/src/http_chat.rs
@@ -293,6 +293,8 @@ impl Client {
       .into_data()
   }
 
+  /// Return list of chat messages for a chat. Each message will have author_uuid as
+  /// as the author's uid, as author_uid will face precision issue in the browser environment.
   pub async fn get_chat_messages_with_author_uuid(
     &self,
     workspace_id: &str,
@@ -301,7 +303,7 @@ impl Client {
     limit: u64,
   ) -> Result<RepeatedChatMessageWithAuthorUuid, AppResponseError> {
     let mut url = format!(
-      "{}/api/chat/{workspace_id}/{chat_id}/v2/message",
+      "{}/api/chat/{workspace_id}/{chat_id}/message",
       self.base_url
     );
     let mut query_params = vec![("limit", limit.to_string())];

--- a/libs/client-api/src/http_chat.rs
+++ b/libs/client-api/src/http_chat.rs
@@ -4,7 +4,7 @@ use crate::Client;
 use app_error::AppError;
 use client_api_entity::chat_dto::{
   ChatMessage, CreateAnswerMessageParams, CreateChatMessageParams, CreateChatParams, MessageCursor,
-  RepeatedChatMessage, UpdateChatMessageContentParams,
+  RepeatedChatMessage, RepeatedChatMessageWithAuthorUuid, UpdateChatMessageContentParams,
 };
 use futures_core::{ready, Stream};
 use pin_project::pin_project;
@@ -256,7 +256,7 @@ impl Client {
       .into_data()
   }
 
-  /// Return list of chat messages for a chat
+  /// Deprecated since v0.9.24. Return list of chat messages for a chat
   pub async fn get_chat_messages(
     &self,
     workspace_id: &str,
@@ -289,6 +289,42 @@ impl Client {
       .send()
       .await?;
     AppResponse::<RepeatedChatMessage>::from_response(resp)
+      .await?
+      .into_data()
+  }
+
+  pub async fn get_chat_messages_with_author_uuid(
+    &self,
+    workspace_id: &str,
+    chat_id: &str,
+    offset: MessageCursor,
+    limit: u64,
+  ) -> Result<RepeatedChatMessageWithAuthorUuid, AppResponseError> {
+    let mut url = format!(
+      "{}/api/chat/{workspace_id}/{chat_id}/v2/message",
+      self.base_url
+    );
+    let mut query_params = vec![("limit", limit.to_string())];
+    match offset {
+      MessageCursor::Offset(offset_value) => {
+        query_params.push(("offset", offset_value.to_string()));
+      },
+      MessageCursor::AfterMessageId(message_id) => {
+        query_params.push(("after", message_id.to_string()));
+      },
+      MessageCursor::BeforeMessageId(message_id) => {
+        query_params.push(("before", message_id.to_string()));
+      },
+      MessageCursor::NextBack => {},
+    }
+    let query = serde_urlencoded::to_string(&query_params).unwrap();
+    url = format!("{}?{}", url, query);
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    AppResponse::<RepeatedChatMessageWithAuthorUuid>::from_response(resp)
       .await?
       .into_data()
   }

--- a/libs/database/src/chat/chat_ops.rs
+++ b/libs/database/src/chat/chat_ops.rs
@@ -647,6 +647,7 @@ pub async fn select_chat_messages_with_author_uuid(
         match serde_json::from_value::<ChatAuthor>(author) {
           Ok(author) => Some(ChatMessageWithAuthorUuid {
             author: ChatAuthorWithUuid {
+              author_id: author.author_id,
               author_type: author.author_type,
               author_uuid,
               meta: author.meta,

--- a/libs/database/src/chat/chat_ops.rs
+++ b/libs/database/src/chat/chat_ops.rs
@@ -551,7 +551,7 @@ pub async fn select_chat_messages_with_author_uuid(
           cm.meta_data,
           cm.reply_message_id
         FROM af_chat_messages AS cm
-        RIGHT JOIN af_user ON (cm.author->>'uid')::BIGINT = af_user.uid
+        LEFT OUTER JOIN af_user ON (cm.author->>'uid')::BIGINT = af_user.uid
         WHERE chat_id = $1
     "#
   .to_string();
@@ -633,7 +633,7 @@ pub async fn select_chat_messages_with_author_uuid(
     String,
     DateTime<Utc>,
     serde_json::Value,
-    Uuid,
+    Option<Uuid>,
     serde_json::Value,
     Option<i64>,
   )> = sqlx::query_as_with(&query, args)
@@ -649,7 +649,7 @@ pub async fn select_chat_messages_with_author_uuid(
             author: ChatAuthorWithUuid {
               author_id: author.author_id,
               author_type: author.author_type,
-              author_uuid,
+              author_uuid: author_uuid.unwrap_or(Uuid::nil()),
               meta: author.meta,
             },
             message_id,

--- a/libs/database/src/chat/chat_ops.rs
+++ b/libs/database/src/chat/chat_ops.rs
@@ -3,9 +3,10 @@ use anyhow::anyhow;
 use app_error::AppError;
 use chrono::{DateTime, Utc};
 use shared_entity::dto::chat_dto::{
-  ChatAuthor, ChatMessage, ChatMessageMetadata, ChatSettings, CreateChatParams,
-  GetChatMessageParams, MessageCursor, RepeatedChatMessage, UpdateChatMessageContentParams,
-  UpdateChatMessageMetaParams, UpdateChatParams,
+  ChatAuthor, ChatAuthorWithUuid, ChatMessage, ChatMessageMetadata, ChatMessageWithAuthorUuid,
+  ChatSettings, CreateChatParams, GetChatMessageParams, MessageCursor, RepeatedChatMessage,
+  RepeatedChatMessageWithAuthorUuid, UpdateChatMessageContentParams, UpdateChatMessageMetaParams,
+  UpdateChatParams,
 };
 
 use serde_json::json;
@@ -361,6 +362,7 @@ pub async fn insert_question_message<'a, E: Executor<'a, Database = Postgres>>(
   Ok(chat_message)
 }
 
+// Deprecated since v0.9.24
 pub async fn select_chat_messages(
   txn: &mut Transaction<'_, Postgres>,
   chat_id: &str,
@@ -527,6 +529,191 @@ pub async fn select_chat_messages(
   };
 
   Ok(RepeatedChatMessage {
+    messages,
+    total,
+    has_more,
+  })
+}
+
+pub async fn select_chat_messages_with_author_uuid(
+  txn: &mut Transaction<'_, Postgres>,
+  chat_id: &str,
+  params: GetChatMessageParams,
+) -> Result<RepeatedChatMessageWithAuthorUuid, AppError> {
+  let chat_id = Uuid::from_str(chat_id)?;
+  let mut query = r#"
+        SELECT
+          cm.message_id,
+          cm.content,
+          cm.created_at,
+          cm.author,
+          af_user.uuid AS author_uuid,
+          cm.meta_data,
+          cm.reply_message_id
+        FROM af_chat_messages AS cm
+        RIGHT JOIN af_user ON (cm.author->>'uid')::BIGINT = af_user.uid
+        WHERE chat_id = $1
+    "#
+  .to_string();
+
+  let mut args = PgArguments::default();
+  args
+    .add(&chat_id)
+    .map_err(|err| AppError::SqlxArgEncodingError {
+      desc: format!("unable to encode chat id {}", chat_id),
+      err,
+    })?;
+
+  // Message IDs:   1    2    3    4    5
+  // AfterMessageId(3, 5):   [4]  [5]  has_more = false
+  // BeforeMessageId(3, 5):  [1]  [2]  has_more = false
+  // Offset(3, 5):           [4]  [5]  has_more = true
+  match params.cursor {
+    MessageCursor::AfterMessageId(after_message_id) => {
+      query += " AND message_id > $2";
+      args
+        .add(after_message_id)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode message id {}", after_message_id),
+          err,
+        })?;
+      query += " ORDER BY message_id DESC LIMIT $3";
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode row limit {}", params.limit as i64),
+          err,
+        })?;
+    },
+    MessageCursor::Offset(offset) => {
+      query += " ORDER BY message_id ASC LIMIT $2 OFFSET $3";
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode row limit {}", params.limit as i64),
+          err,
+        })?;
+      args
+        .add(offset as i64)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode offset {}", offset as i64),
+          err,
+        })?;
+    },
+    MessageCursor::BeforeMessageId(before_message_id) => {
+      query += " AND message_id < $2";
+      args
+        .add(before_message_id)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode message id {}", before_message_id),
+          err,
+        })?;
+      query += " ORDER BY message_id DESC LIMIT $3";
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode row limit {}", params.limit as i64),
+          err,
+        })?;
+    },
+    MessageCursor::NextBack => {
+      query += " ORDER BY message_id DESC LIMIT $2";
+      args
+        .add(params.limit as i64)
+        .map_err(|err| AppError::SqlxArgEncodingError {
+          desc: format!("unable to encode row limit {}", params.limit as i64),
+          err,
+        })?;
+    },
+  }
+
+  #[allow(clippy::type_complexity)]
+  let rows: Vec<(
+    i64,
+    String,
+    DateTime<Utc>,
+    serde_json::Value,
+    Uuid,
+    serde_json::Value,
+    Option<i64>,
+  )> = sqlx::query_as_with(&query, args)
+    .fetch_all(txn.deref_mut())
+    .await?;
+
+  let messages = rows
+    .into_iter()
+    .flat_map(
+      |(message_id, content, created_at, author, author_uuid, meta_data, reply_message_id)| {
+        match serde_json::from_value::<ChatAuthor>(author) {
+          Ok(author) => Some(ChatMessageWithAuthorUuid {
+            author: ChatAuthorWithUuid {
+              author_type: author.author_type,
+              author_uuid,
+              meta: author.meta,
+            },
+            message_id,
+            content,
+            created_at,
+            meta_data,
+            reply_message_id,
+          }),
+          Err(err) => {
+            warn!("Failed to deserialize author: {}", err);
+            None
+          },
+        }
+      },
+    )
+    .collect::<Vec<ChatMessageWithAuthorUuid>>();
+
+  let total = sqlx::query_scalar!(
+    r#"
+        SELECT COUNT(*)
+        FROM public.af_chat_messages
+        WHERE chat_id = $1
+        "#,
+    &chat_id
+  )
+  .fetch_one(txn.deref_mut())
+  .await?
+  .unwrap_or(0);
+
+  let has_more = match params.cursor {
+    MessageCursor::AfterMessageId(_) => {
+      if messages.is_empty() {
+        false
+      } else {
+        sqlx::query!(
+          "SELECT EXISTS(SELECT 1 FROM af_chat_messages WHERE chat_id = $1 AND message_id > $2)",
+          &chat_id,
+          messages[0].message_id
+        )
+        .fetch_one(txn.deref_mut())
+        .await?
+        .exists
+        .unwrap_or(false)
+      }
+    },
+    MessageCursor::Offset(offset) => (offset + params.limit) < total as u64,
+    MessageCursor::BeforeMessageId(_) => {
+      if messages.is_empty() {
+        false
+      } else {
+        sqlx::query!(
+          "SELECT EXISTS(SELECT 1 FROM af_chat_messages WHERE chat_id = $1 AND message_id < $2)",
+          &chat_id,
+          messages.last().as_ref().unwrap().message_id
+        )
+        .fetch_one(txn.deref_mut())
+        .await?
+        .exists
+        .unwrap_or(false)
+      }
+    },
+    MessageCursor::NextBack => params.limit < total as u64,
+  };
+
+  Ok(RepeatedChatMessageWithAuthorUuid {
     messages,
     total,
     has_more,

--- a/libs/shared-entity/src/dto/chat_dto.rs
+++ b/libs/shared-entity/src/dto/chat_dto.rs
@@ -373,6 +373,7 @@ impl ChatAuthor {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatAuthorWithUuid {
+  pub author_id: i64,
   pub author_uuid: Uuid,
   #[serde(default)]
   pub author_type: ChatAuthorType,
@@ -382,8 +383,9 @@ pub struct ChatAuthorWithUuid {
 }
 
 impl ChatAuthorWithUuid {
-  pub fn new(author_uuid: Uuid, author_type: ChatAuthorType) -> Self {
+  pub fn new(author_id: i64, author_uuid: Uuid, author_type: ChatAuthorType) -> Self {
     Self {
+      author_id,
       author_uuid,
       author_type,
       meta: None,
@@ -392,6 +394,7 @@ impl ChatAuthorWithUuid {
 
   pub fn ai() -> Self {
     Self {
+      author_id: 0,
       author_uuid: Uuid::nil(),
       author_type: ChatAuthorType::AI,
       meta: None,

--- a/libs/shared-entity/src/dto/chat_dto.rs
+++ b/libs/shared-entity/src/dto/chat_dto.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::collections::HashMap;
 use std::fmt::Display;
+use uuid::Uuid;
 use validator::Validate;
 
 #[derive(Debug, Clone, Validate, Serialize, Deserialize)]
@@ -295,6 +296,16 @@ pub struct ChatMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessageWithAuthorUuid {
+  pub author: ChatAuthorWithUuid,
+  pub message_id: i64,
+  pub content: String,
+  pub created_at: DateTime<Utc>,
+  pub meta_data: serde_json::Value,
+  pub reply_message_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QAChatMessage {
   pub question: ChatMessage,
   pub answer: Option<ChatMessage>,
@@ -303,6 +314,13 @@ pub struct QAChatMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepeatedChatMessage {
   pub messages: Vec<ChatMessage>,
+  pub has_more: bool,
+  pub total: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepeatedChatMessageWithAuthorUuid {
+  pub messages: Vec<ChatMessageWithAuthorUuid>,
   pub has_more: bool,
   pub total: i64,
 }
@@ -347,6 +365,34 @@ impl ChatAuthor {
   pub fn ai() -> Self {
     Self {
       author_id: 0,
+      author_type: ChatAuthorType::AI,
+      meta: None,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatAuthorWithUuid {
+  pub author_uuid: Uuid,
+  #[serde(default)]
+  pub author_type: ChatAuthorType,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub meta: Option<serde_json::Value>,
+}
+
+impl ChatAuthorWithUuid {
+  pub fn new(author_uuid: Uuid, author_type: ChatAuthorType) -> Self {
+    Self {
+      author_uuid,
+      author_type,
+      meta: None,
+    }
+  }
+
+  pub fn ai() -> Self {
+    Self {
+      author_uuid: Uuid::nil(),
       author_type: ChatAuthorType::AI,
       meta: None,
     }

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -1,5 +1,5 @@
 use crate::biz::chat::ops::{
-  create_chat, create_chat_message, delete_chat, generate_chat_message_answer, get_chat_messages,
+  create_chat, create_chat_message, delete_chat, generate_chat_message_answer,
   get_chat_messages_with_author_uuid, get_question_message, update_chat_message,
 };
 use crate::state::AppState;
@@ -23,8 +23,7 @@ use pin_project::pin_project;
 use shared_entity::dto::chat_dto::{
   ChatAuthor, ChatMessage, ChatSettings, CreateAnswerMessageParams, CreateChatMessageParams,
   CreateChatMessageParamsV2, CreateChatParams, GetChatMessageParams, MessageCursor,
-  RepeatedChatMessage, RepeatedChatMessageWithAuthorUuid, UpdateChatMessageContentParams,
-  UpdateChatParams,
+  RepeatedChatMessageWithAuthorUuid, UpdateChatMessageContentParams, UpdateChatParams,
 };
 use shared_entity::response::{AppResponse, JsonAppResponse};
 use std::collections::HashMap;
@@ -62,10 +61,6 @@ pub fn chat_scope() -> Scope {
             .route(web::put().to(update_question_handler))
             .route(web::get().to(get_chat_message_handler))
       )
-      .service(
-        web::resource("/{chat_id}/v2/message")
-          .route(web::get().to(get_chat_message_v2_handler))
-        )
       .service(
         web::resource("/{chat_id}/message/question")
             .route(web::post().to(create_question_handler))
@@ -422,38 +417,8 @@ async fn answer_stream_v3_handler(
   }
 }
 
-// Depcrecated since v0.9.24
 #[instrument(level = "debug", skip_all, err)]
 async fn get_chat_message_handler(
-  path: web::Path<(String, String)>,
-  query: web::Query<HashMap<String, String>>,
-  state: Data<AppState>,
-) -> actix_web::Result<JsonAppResponse<RepeatedChatMessage>> {
-  let mut params = GetChatMessageParams {
-    cursor: MessageCursor::Offset(0),
-    limit: query
-      .get("limit")
-      .and_then(|s| s.parse::<u64>().ok())
-      .unwrap_or(10),
-  };
-  if let Some(value) = query.get("offset").and_then(|s| s.parse::<u64>().ok()) {
-    params.cursor = MessageCursor::Offset(value);
-  } else if let Some(value) = query.get("after").and_then(|s| s.parse::<i64>().ok()) {
-    params.cursor = MessageCursor::AfterMessageId(value);
-  } else if let Some(value) = query.get("before").and_then(|s| s.parse::<i64>().ok()) {
-    params.cursor = MessageCursor::BeforeMessageId(value);
-  } else {
-    params.cursor = MessageCursor::NextBack;
-  }
-
-  trace!("get chat messages: {:?}", params);
-  let (_workspace_id, chat_id) = path.into_inner();
-  let messages = get_chat_messages(&state.pg_pool, params, &chat_id).await?;
-  Ok(AppResponse::Ok().with_data(messages).into())
-}
-
-#[instrument(level = "debug", skip_all, err)]
-async fn get_chat_message_v2_handler(
   path: web::Path<(String, String)>,
   query: web::Query<HashMap<String, String>>,
   state: Data<AppState>,

--- a/tests/ai_test/chat_test.rs
+++ b/tests/ai_test/chat_test.rs
@@ -140,7 +140,7 @@ async fn create_chat_and_create_messages_test() {
   assert_eq!(messages[7].content, "hello world 2");
   let message_before_third = test_client
     .api_client
-    .get_chat_messages(
+    .get_chat_messages_with_author_uuid(
       &workspace_id,
       &chat_id,
       MessageCursor::BeforeMessageId(messages[7].message_id),
@@ -157,7 +157,7 @@ async fn create_chat_and_create_messages_test() {
   assert_eq!(messages[2].content, "hello world 7");
   let message_after_third = test_client
     .api_client
-    .get_chat_messages(
+    .get_chat_messages_with_author_uuid(
       &workspace_id,
       &chat_id,
       MessageCursor::AfterMessageId(messages[2].message_id),
@@ -172,7 +172,7 @@ async fn create_chat_and_create_messages_test() {
 
   let next_back = test_client
     .api_client
-    .get_chat_messages(&workspace_id, &chat_id, MessageCursor::NextBack, 3)
+    .get_chat_messages_with_author_uuid(&workspace_id, &chat_id, MessageCursor::NextBack, 3)
     .await
     .unwrap();
   assert!(next_back.has_more);
@@ -182,7 +182,7 @@ async fn create_chat_and_create_messages_test() {
 
   let next_back = test_client
     .api_client
-    .get_chat_messages(&workspace_id, &chat_id, MessageCursor::NextBack, 100)
+    .get_chat_messages_with_author_uuid(&workspace_id, &chat_id, MessageCursor::NextBack, 100)
     .await
     .unwrap();
   assert!(!next_back.has_more);

--- a/tests/ai_test/chat_test.rs
+++ b/tests/ai_test/chat_test.rs
@@ -140,7 +140,7 @@ async fn create_chat_and_create_messages_test() {
   assert_eq!(messages[7].content, "hello world 2");
   let message_before_third = test_client
     .api_client
-    .get_chat_messages_with_author_uuid(
+    .get_chat_messages(
       &workspace_id,
       &chat_id,
       MessageCursor::BeforeMessageId(messages[7].message_id),
@@ -157,7 +157,7 @@ async fn create_chat_and_create_messages_test() {
   assert_eq!(messages[2].content, "hello world 7");
   let message_after_third = test_client
     .api_client
-    .get_chat_messages_with_author_uuid(
+    .get_chat_messages(
       &workspace_id,
       &chat_id,
       MessageCursor::AfterMessageId(messages[2].message_id),
@@ -172,7 +172,7 @@ async fn create_chat_and_create_messages_test() {
 
   let next_back = test_client
     .api_client
-    .get_chat_messages_with_author_uuid(&workspace_id, &chat_id, MessageCursor::NextBack, 3)
+    .get_chat_messages(&workspace_id, &chat_id, MessageCursor::NextBack, 3)
     .await
     .unwrap();
   assert!(next_back.has_more);
@@ -182,7 +182,7 @@ async fn create_chat_and_create_messages_test() {
 
   let next_back = test_client
     .api_client
-    .get_chat_messages_with_author_uuid(&workspace_id, &chat_id, MessageCursor::NextBack, 100)
+    .get_chat_messages(&workspace_id, &chat_id, MessageCursor::NextBack, 100)
     .await
     .unwrap();
   assert!(!next_back.has_more);


### PR DESCRIPTION
Currently, the get chat messages endpoint returns author uid, which is of i64 type,  as one of the fields in the response. By default, serde will serialize i64 as number in json. This is not an issue when the json response is deserialized in the rust client, as the Rust client can deserialize this field without loss in precision.

On the browser, however, there will be lost in precision, which leads to incorrect uid being return to the web frontend. This will cause further problem down stream, when the uid is used as parameter for other request, like retrieving profile information of the author.