### PR TITLE
feat: api to get collab as json

### DIFF
--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -134,6 +134,11 @@ pub struct EmbeddedCollabQuery {
   pub object_id: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct CollabJsonResponse {
+  pub collab: serde_json::Value,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollabResponse {
   #[serde(flatten)]


### PR DESCRIPTION
Add an endpoint to get collab as json object. This serves two purposes:
1. Help with development/debugging, when we need to inspect the content of a collab
2. Ability to read collab as json allows more advanced automation opportunity. For example, a developer can use the API to read a document collab, and perform automation/integration based on the content of the document.