### PR TITLE
fix: change `docker-compose` to `docker compose` command

### DIFF
--- a/doc/GUIDE.md
+++ b/doc/GUIDE.md
@@ -25,7 +25,7 @@
 ## Service Routing and Access
 
 ### Access Points Post Deployment
-After executing `docker-compose up -d`, AppFlowy-Cloud is accessible at `http://localhost` on ports 80 and 443 with the following routing:
+After executing `docker compose up -d`, AppFlowy-Cloud is accessible at `http://localhost` on ports 80 and 443 with the following routing:
 
 - `/gotrue`: Redirects to the GoTrue Auth Server.
 - `/api`: AppFlowy-Cloud's HTTP API endpoint.


### PR DESCRIPTION
## Description

According to [DEPLOYMENT.md](https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/main/doc/DEPLOYMENT.md),

> [!Note]
> `docker-compose` (with the hyphen) may not be supported. You are advised to use `docker compose` (without hyphen) instead.

However, only GUIDE.md has `docker-compose` command.
This PR updated it.