### PR TITLE
chore: add `syntax` parser directive to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Using cargo-chef to manage Rust build cache effectively
 FROM lukemathwalker/cargo-chef:latest-rust-1.81 as chef
 

--- a/admin_frontend/Dockerfile
+++ b/admin_frontend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # User should build from parent directory
 
 FROM lukemathwalker/cargo-chef:latest-rust-1.81 as chef

--- a/docker/gotrue/Dockerfile
+++ b/docker/gotrue/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang as base
 WORKDIR /go/src/supabase
 RUN git clone https://github.com/supabase/auth.git --depth 1 --branch v2.159.1

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20.12.0 AS builder
 
 WORKDIR /app

--- a/services/appflowy-collaborate/Dockerfile
+++ b/services/appflowy-collaborate/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Using cargo-chef to manage Rust build cache effectively
 FROM lukemathwalker/cargo-chef:latest-rust-1.81 as chef
 

--- a/services/appflowy-worker/Dockerfile
+++ b/services/appflowy-worker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM lukemathwalker/cargo-chef:latest-rust-1.81 as chef
 
 # Set the initial working directory


### PR DESCRIPTION
## What?

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Why?

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.

## How?

Append `# syntax=docker/dockerfile:1` to the top of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).