### PR TITLE
chore: awareness pubsub switch to lightweight version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,6 +2111,7 @@ dependencies = [
  "chrono",
  "collab",
  "collab-entity",
+ "dashmap 5.5.3",
  "futures",
  "loole",
  "prometheus-client",
@@ -2124,6 +2125,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
  "zstd 0.13.2",
 ]
 

--- a/libs/collab-stream/Cargo.toml
+++ b/libs/collab-stream/Cargo.toml
@@ -28,7 +28,7 @@ prometheus-client.workspace = true
 zstd = "0.13"
 loole = "0.4.0"
 dashmap.workspace = true
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid.workspace = true
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libs/collab-stream/Cargo.toml
+++ b/libs/collab-stream/Cargo.toml
@@ -27,6 +27,8 @@ async-trait.workspace = true
 prometheus-client.workspace = true
 zstd = "0.13"
 loole = "0.4.0"
+dashmap.workspace = true
+uuid = { version = "1.10.0", features = ["v4"] }
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libs/collab-stream/src/awareness_gossip.rs
+++ b/libs/collab-stream/src/awareness_gossip.rs
@@ -1,28 +1,53 @@
 use crate::error::StreamError;
 use crate::model::AwarenessStreamUpdate;
-use async_stream::try_stream;
-use futures::Stream;
+use dashmap::DashMap;
 use redis::aio::MultiplexedConnection;
-use redis::{AsyncCommands, Client};
+use redis::{AsyncCommands, Client, RedisError};
+use std::sync::Arc;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
+use uuid::Uuid;
 
 pub struct AwarenessGossip {
-  client: Client,
+  conn: MultiplexedConnection,
+  collabs: Arc<DashMap<Uuid, UnboundedSender<AwarenessStreamUpdate>>>,
 }
 
 impl AwarenessGossip {
-  /// Returns Redis stream key, that's storing entries mapped to/from [AwarenessStreamUpdate].
-  pub fn publish_key(workspace_id: &str, object_id: &str) -> String {
-    format!("af:awareness:{}:{}", workspace_id, object_id)
-  }
+  pub async fn new(client: &Client) -> Result<Self, RedisError> {
+    let collabs: Arc<DashMap<Uuid, UnboundedSender<AwarenessStreamUpdate>>> =
+      Arc::new(DashMap::new());
+    let mut pub_sub = client.get_async_pubsub().await?;
+    pub_sub.psubscribe("af:awareness:*").await?;
+    let conn = client.get_multiplexed_async_connection().await?;
 
-  pub fn state_key(workspace_id: &str, object_id: &str) -> String {
-    format!("af:awareness_state:{}:{}", workspace_id, object_id)
-  }
-
-  pub fn new(client: Client) -> Self {
-    Self { client }
+    let weak_collabs = Arc::downgrade(&collabs);
+    let _receive_awareness_pubsub = tokio::spawn(async move {
+      let mut stream = pub_sub.into_on_message();
+      while let Some(message) = stream.next().await {
+        if let Some(collabs) = weak_collabs.upgrade() {
+          let collabs_clone = collabs.clone();
+          match Self::parse_update(message) {
+            Ok((object_id, awareness_update)) => {
+              let dropped = if let Some(channel) = collabs_clone.get(&object_id) {
+                let channel = channel.value();
+                channel.send(awareness_update).is_err()
+              } else {
+                false
+              };
+              if dropped {
+                collabs.remove(&object_id);
+              }
+            },
+            Err(err) => tracing::error!("failed to parse awareness message: {}", err),
+          }
+        } else {
+          return; // dropped collabs
+        }
+      }
+    });
+    Ok(Self { conn, collabs })
   }
 
   pub async fn sink(
@@ -30,46 +55,29 @@ impl AwarenessGossip {
     workspace_id: &str,
     object_id: &str,
   ) -> Result<AwarenessUpdateSink, StreamError> {
-    tracing::trace!("publishing awareness state for object {}", object_id);
-    let mut conn = self.client.get_multiplexed_async_connection().await?;
-    // delete existing redis stream from previous versions
-    let _: redis::Value = conn
-      .del(format!("af:{}:{}:awareness", workspace_id, object_id))
-      .await?;
-    let sink = AwarenessUpdateSink::new(conn, workspace_id, object_id);
+    let sink = AwarenessUpdateSink::new(self.conn.clone(), workspace_id, object_id);
     Ok(sink)
   }
 
-  pub fn awareness_stream(
-    &self,
-    workspace_id: &str,
-    object_id: &str,
-  ) -> impl Stream<Item = Result<AwarenessStreamUpdate, StreamError>> + 'static {
-    let client = self.client.clone();
-    let pubsub_key = Self::publish_key(workspace_id, object_id);
-    try_stream! {
-        let mut pubsub = client.get_async_pubsub().await?;
-        pubsub.psubscribe(pubsub_key.clone()).await?; // try to open subscription
-        {
-            // from now on, we shouldn't throw any errors here, otherwise punsubscribe won't be called
-            let mut stream = pubsub.on_message();
-            while let Some(msg) = stream.next().await {
-                let update = Self::parse_update(msg)?;
-                yield update;
-            }
-        }
-        tracing::trace!("unsubscribing from awareness stream {}", pubsub_key);
-        pubsub.punsubscribe(pubsub_key).await?; // close subscription gracefully
-    }
+  pub fn awareness_stream(&self, object_id: &Uuid) -> UnboundedReceiver<AwarenessStreamUpdate> {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    self.collabs.insert(*object_id, tx);
+    rx
   }
 
-  fn parse_update(msg: redis::Msg) -> Result<AwarenessStreamUpdate, StreamError> {
+  fn parse_update(msg: redis::Msg) -> Result<(Uuid, AwarenessStreamUpdate), StreamError> {
     let channel_name = msg.get_channel_name();
+    let last_segment = channel_name
+      .split(':')
+      .last()
+      .ok_or_else(|| StreamError::InvalidStreamKey(channel_name.to_string()))?;
+    let object_id =
+      Uuid::parse_str(last_segment).map_err(|e| StreamError::InvalidStreamKey(e.to_string()))?;
     let payload = msg.get_payload_bytes();
     let update = serde_json::from_slice::<AwarenessStreamUpdate>(payload)
       .map_err(StreamError::SerdeJsonError)?;
     tracing::trace!("received awareness stream update for {}", channel_name);
-    Ok(update)
+    Ok((object_id, update))
   }
 }
 
@@ -80,7 +88,7 @@ pub struct AwarenessUpdateSink {
 
 impl AwarenessUpdateSink {
   pub fn new(conn: MultiplexedConnection, workspace_id: &str, object_id: &str) -> Self {
-    let publish_key = AwarenessGossip::publish_key(workspace_id, object_id);
+    let publish_key = format!("af:awareness:{workspace_id}:{object_id}");
     AwarenessUpdateSink {
       conn: conn.into(),
       publish_key,

--- a/libs/collab-stream/src/error.rs
+++ b/libs/collab-stream/src/error.rs
@@ -40,6 +40,9 @@ pub enum StreamError {
 
   #[error("Internal error: {0}")]
   Internal(anyhow::Error),
+
+  #[error("Couldn't parse stream key: {0}")]
+  InvalidStreamKey(String),
 }
 
 impl StreamError {

--- a/services/appflowy-collaborate/src/application.rs
+++ b/services/appflowy-collaborate/src/application.rs
@@ -211,7 +211,7 @@ async fn get_redis_client(
   info!("Connecting to redis with uri: {}", redis_uri);
   let client = redis::Client::open(redis_uri).context("failed to connect to redis")?;
 
-  let awareness_gossip = Arc::new(AwarenessGossip::new(client.clone()));
+  let awareness_gossip = Arc::new(AwarenessGossip::new(&client).await?);
 
   let router = StreamRouter::with_options(
     &client,

--- a/src/application.rs
+++ b/src/application.rs
@@ -374,7 +374,7 @@ async fn get_redis_client(
   info!("Connecting to redis with uri: {}", redis_uri);
   let client = redis::Client::open(redis_uri).context("failed to connect to redis")?;
 
-  let awareness_gossip = AwarenessGossip::new(client.clone());
+  let awareness_gossip = AwarenessGossip::new(&client).await?;
   let router = StreamRouter::with_options(
     &client,
     metrics,


### PR DESCRIPTION
This PR changes `AwarenessGossip` implementation to reduce a number of connections created. I suspect that current main implementation creates a 2 redis connections per collab. This one uses only 2 connections total, regardless of number of collabs.