### PR TITLE
fix: ignore views that are not present during duplication

### DIFF
--- a/src/biz/workspace/duplicate.rs
+++ b/src/biz/workspace/duplicate.rs
@@ -378,14 +378,10 @@ fn duplicate_views(views: &[View], suffix: &str) -> Result<DuplicateContext, App
     let mut duplicated_view = view.clone();
     let mut duplicated_children = vec![];
     for child in view.children.items.iter() {
-      let new_view_id = view_id_mapping
-        .get(&child.id)
-        .cloned()
-        .ok_or(AppError::Internal(anyhow::anyhow!(
-          "Failed to find duplicated child view id {}",
-          child.id
-        )))?;
-      duplicated_children.push(ViewIdentifier { id: new_view_id });
+      let new_view_id = view_id_mapping.get(&child.id).cloned();
+      if let Some(view_id) = new_view_id {
+        duplicated_children.push(ViewIdentifier { id: view_id });
+      }
     }
     duplicated_view.id = view_id_mapping
       .get(&view.id)


### PR DESCRIPTION
We filtered out some of the child views (eg. those in trash) before duplication. We should remove those views from duplication context as well.