### PR TITLE
chore: update readme for email template

### DIFF
--- a/email_template/README.md
+++ b/email_template/README.md
@@ -1,22 +1,6 @@
-<div align="center">
-  <p>
-    <a href="https://maizzle.com" target="_blank">
-      <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="https://github.com/maizzle/maizzle/raw/master/.github/logo-dark.svg">
-        <img alt="Maizzle Starter" src="https://github.com/maizzle/maizzle/raw/master/.github/logo-light.svg" width="300" height="225" style="max-width: 100%;">
-      </picture>
-    </a>
-  </p>
-  <p>Quickly build HTML emails with Tailwind CSS</p>
-<div>
-
-[![Version][npm-version-shield]][npm]
-[![Build][github-ci-shield]][github-ci]
-[![Downloads][npm-stats-shield]][npm-stats]
-[![License][license-shield]][license]
-
-  </div>
-</div>
+## About
+This contains the source code for the mail templates used by GoTrue and
+AppFlowy Cloud services.
 
 ## Development
 


### PR DESCRIPTION
The ReadMe for email template is currently broken due to missing links. There is also no need to include the Maizzle logo as the underlying tech stack which we use to build the email assets might change any time.