### PR TITLE
chore: init env filter by parsing the default env variable

### DIFF
--- a/services/appflowy-worker/src/application.rs
+++ b/services/appflowy-worker/src/application.rs
@@ -50,14 +50,10 @@ pub async fn run_server(
 pub fn init_subscriber(app_env: &Environment) {
   static START: Once = Once::new();
   START.call_once(|| {
-    let level = std::env::var("RUST_LOG").unwrap_or("info".to_string());
-    let mut filters = vec![];
-    filters.push(format!("appflowy_worker={}", level));
-    let env_filter = EnvFilter::new(filters.join(","));
+    let env_filter = EnvFilter::from_default_env();
 
     let builder = tracing_subscriber::fmt()
       .with_target(true)
-      .with_max_level(tracing::Level::TRACE)
       .with_thread_ids(false)
       .with_file(false);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,19 +6,6 @@ use appflowy_cloud::telemetry::init_subscriber;
 async fn main() -> anyhow::Result<()> {
   let level = std::env::var("RUST_LOG").unwrap_or("info".to_string());
   println!("AppFlowy Cloud with RUST_LOG={}", level);
-  let mut filters = vec![];
-  filters.push(format!("actix_web={}", level));
-  filters.push(format!("collab={}", level));
-  filters.push(format!("collab_sync={}", level));
-  filters.push(format!("appflowy_cloud={}", level));
-  filters.push(format!("collab_plugins={}", level));
-  filters.push(format!("realtime={}", level));
-  filters.push(format!("database={}", level));
-  filters.push(format!("storage={}", level));
-  filters.push(format!("gotrue={}", level));
-  filters.push(format!("appflowy_collaborate={}", level));
-  filters.push(format!("appflowy_ai_client={}", level));
-  filters.push(format!("indexer={}", level));
 
   // Load environment variables from .env file
   dotenvy::dotenv().ok();
@@ -26,7 +13,7 @@ async fn main() -> anyhow::Result<()> {
   let conf =
     get_configuration().map_err(|e| anyhow::anyhow!("Failed to read configuration: {}", e))?;
 
-  init_subscriber(&conf.app_env, filters);
+  init_subscriber(&conf.app_env);
 
   let (tx, rx) = tokio::sync::mpsc::channel(1000);
   let state = init_state(&conf, tx)

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -2,18 +2,15 @@ use crate::config::config::Environment;
 use actix_web::rt::task::JoinHandle;
 use chrono::Local;
 use tracing::subscriber::set_global_default;
-use tracing_subscriber::fmt::format::Writer;
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
+use tracing_subscriber::{fmt::format::Writer, EnvFilter};
 
 /// Register a subscriber as global default to process span data.
 ///
 /// It should only be called once!
-pub fn init_subscriber(app_env: &Environment, filters: Vec<String>) {
-  let env_filter = EnvFilter::new(filters.join(","));
-
+pub fn init_subscriber(app_env: &Environment) {
   let builder = tracing_subscriber::fmt()
+    .with_env_filter(EnvFilter::from_default_env())
     .with_target(true)
-    .with_max_level(tracing::Level::TRACE)
     .with_thread_ids(false)
     .with_file(true)
     .with_line_number(true);
@@ -33,13 +30,12 @@ pub fn init_subscriber(app_env: &Environment, filters: Vec<String>) {
           .with_target(false)
           .with_file(false)
           .pretty()
-          .finish()
-          .with(env_filter);
+          .finish();
         set_global_default(subscriber).unwrap();
       }
     },
     Environment::Production => {
-      let subscriber = builder.json().finish().with(env_filter);
+      let subscriber = builder.json().finish();
       set_global_default(subscriber).unwrap();
     },
   }


### PR DESCRIPTION
Log level for different crate can be controlled directly using RUST_LOG, such as RUST_LOG=appflowy_cloud=info,appflowy_collaborate=trace. This should be controlled by env variable rather than hard coded within application.