### PR TITLE
feat: add client api for gotrue verify endpoint

### DIFF
--- a/libs/gotrue/src/api.rs
+++ b/libs/gotrue/src/api.rs
@@ -1,7 +1,7 @@
 use super::grant::Grant;
 use crate::params::{
   AdminDeleteUserParams, AdminUserParams, CreateSSOProviderParams, GenerateLinkParams,
-  GenerateLinkResponse, InviteUserParams, MagicLinkParams,
+  GenerateLinkResponse, InviteUserParams, MagicLinkParams, VerifyParams,
 };
 use anyhow::Context;
 use gotrue_entity::dto::{
@@ -79,6 +79,23 @@ impl Client {
     let url = format!("{}/token?grant_type={}", self.base_url, grant.type_as_str());
     let payload = grant.json_value();
     let resp = self.client.post(url).json(&payload).send().await?;
+    if resp.status().is_success() {
+      let token: GotrueTokenResponse = from_body(resp).await?;
+      Ok(token)
+    } else if resp.status().is_client_error() {
+      Err(from_body::<GotrueClientError>(resp).await?.into())
+    } else {
+      Err(anyhow::anyhow!("unexpected response status: {}", resp.status()).into())
+    }
+  }
+
+  #[tracing::instrument(skip_all, err)]
+  pub async fn verify(
+    &self,
+    verify_params: &VerifyParams,
+  ) -> Result<GotrueTokenResponse, GoTrueError> {
+    let url = format!("{}/verify", self.base_url);
+    let resp = self.client.post(url).json(verify_params).send().await?;
     if resp.status().is_success() {
       let token: GotrueTokenResponse = from_body(resp).await?;
       Ok(token)

--- a/libs/gotrue/src/params.rs
+++ b/libs/gotrue/src/params.rs
@@ -121,3 +121,17 @@ pub struct CreateSSOProviderParams {
   pub domains: Vec<String>,
   pub attribute_mapping: serde_json::Value,
 }
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerifyType {
+  Recovery,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct VerifyParams {
+  #[serde(rename = "type")]
+  pub type_: VerifyType,
+  pub email: String,
+  pub token: String,
+}


### PR DESCRIPTION
Add client api for gotrue verify endpoint.

## Summary by Sourcery

Add client API method for verifying GoTrue authentication tokens, specifically for recovery token verification

New Features:
- Implement a new `verify` method in the GoTrue client API to support token verification for recovery scenarios

Enhancements:
- Extend the GoTrue client with a type-safe verification mechanism for authentication tokens