### PR TITLE
feat: client api for gotrue password recovery

### DIFF
--- a/libs/gotrue/src/api.rs
+++ b/libs/gotrue/src/api.rs
@@ -1,7 +1,7 @@
 use super::grant::Grant;
 use crate::params::{
   AdminDeleteUserParams, AdminUserParams, CreateSSOProviderParams, GenerateLinkParams,
-  GenerateLinkResponse, InviteUserParams, MagicLinkParams, VerifyParams,
+  GenerateLinkResponse, InviteUserParams, MagicLinkParams, RecoverParams, VerifyParams,
 };
 use anyhow::Context;
 use gotrue_entity::dto::{
@@ -96,6 +96,23 @@ impl Client {
   ) -> Result<GotrueTokenResponse, GoTrueError> {
     let url = format!("{}/verify", self.base_url);
     let resp = self.client.post(url).json(verify_params).send().await?;
+    if resp.status().is_success() {
+      let token: GotrueTokenResponse = from_body(resp).await?;
+      Ok(token)
+    } else if resp.status().is_client_error() {
+      Err(from_body::<GotrueClientError>(resp).await?.into())
+    } else {
+      Err(anyhow::anyhow!("unexpected response status: {}", resp.status()).into())
+    }
+  }
+
+  #[tracing::instrument(skip_all, err)]
+  pub async fn recover(
+    &self,
+    recover_params: &RecoverParams,
+  ) -> Result<GotrueTokenResponse, GoTrueError> {
+    let url = format!("{}/recover", self.base_url);
+    let resp = self.client.post(url).json(recover_params).send().await?;
     if resp.status().is_success() {
       let token: GotrueTokenResponse = from_body(resp).await?;
       Ok(token)

--- a/libs/gotrue/src/params.rs
+++ b/libs/gotrue/src/params.rs
@@ -135,3 +135,8 @@ pub struct VerifyParams {
   pub email: String,
   pub token: String,
 }
+
+#[derive(Deserialize, Serialize)]
+pub struct RecoverParams {
+  pub email: String,
+}


### PR DESCRIPTION
## Summary by Sourcery

Add password recovery functionality to the GoTrue client API

New Features:
- Implement a new `recover` method in the GoTrue client API to support password recovery for users by email

Enhancements:
- Add a new `RecoveParams` struct to handle password recovery request parameters