### PR TITLE
chore: fix appflowy ai client compile

### DIFF
--- a/libs/appflowy-ai-client/tests/chat_test/completion_test.rs
+++ b/libs/appflowy-ai-client/tests/chat_test/completion_test.rs
@@ -12,8 +12,8 @@ async fn completion_explain_test() {
     text: "Snowboarding".to_string(),
     completion_type: Some(CompletionType::Explain),
     metadata: Some(CompletionMetadata {
-      object_id: uuid::Uuid::new_v4().to_string(),
-      workspace_id: Some(uuid::Uuid::new_v4().to_string()),
+      object_id: uuid::Uuid::new_v4(),
+      workspace_id: Some(uuid::Uuid::new_v4()),
       rag_ids: None,
       completion_history: None,
       custom_prompt: None,
@@ -35,8 +35,8 @@ async fn completion_image_test() {
     text: "A yellow cat".to_string(),
     completion_type: Some(CompletionType::ImproveWriting),
     metadata: Some(CompletionMetadata {
-      object_id: uuid::Uuid::new_v4().to_string(),
-      workspace_id: Some(uuid::Uuid::new_v4().to_string()),
+      object_id: uuid::Uuid::new_v4(),
+      workspace_id: Some(uuid::Uuid::new_v4()),
       rag_ids: None,
       completion_history: None,
       custom_prompt: None,
@@ -105,8 +105,8 @@ async fn custom_prompt_test() {
     text: "A yellow cat".to_string(),
     completion_type: Some(CompletionType::CustomPrompt),
     metadata: Some(CompletionMetadata {
-      object_id: uuid::Uuid::new_v4().to_string(),
-      workspace_id: Some(uuid::Uuid::new_v4().to_string()),
+      object_id: uuid::Uuid::new_v4(),
+      workspace_id: Some(uuid::Uuid::new_v4()),
       rag_ids: None,
       completion_history: None,
       custom_prompt: Some(CustomPrompt {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Modify test cases to use Uuid type directly in CompletionMetadata instead of converting to string representation