### PR TITLE
chore: ci that build test image

### DIFF
--- a/.github/workflows/build_test_docker_image.yaml
+++ b/.github/workflows/build_test_docker_image.yaml
@@ -1,0 +1,152 @@
+name: Manually Build All Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to build from"
+        required: true
+        default: "main"
+      debug_version:
+        description: "Release version tag (e.g. v1.0.0)"
+        required: true
+      archs:
+        description: "Target architectures (comma separated), e.g. linux/amd64,linux/arm64"
+        required: false
+        default: "linux/amd64"
+
+jobs:
+  gotrue:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push GoTrue image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/gotrue
+          file: Dockerfile
+          platforms: ${{ github.event.inputs.archs }}
+          push: true
+          tags: |
+            appflowyinc/gotrue:${{ github.event.inputs.debug_version }}-test
+
+      - name: Logout from Docker Hub
+        if: always()
+        run: docker logout
+
+  appflowy_cloud:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push AppFlowy Cloud image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ github.event.inputs.archs }}
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/appflowy_cloud:${{ github.event.inputs.debug_version }}-test
+
+      - name: Logout from Docker Hub
+        if: always()
+        run: docker logout
+
+  admin_frontend:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push Admin Frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./admin_frontend/Dockerfile
+          platforms: ${{ github.event.inputs.archs }}
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/admin_frontend:${{ github.event.inputs.debug_version }}-test
+
+      - name: Logout from Docker Hub
+        if: always()
+        run: docker logout
+
+  appflowy_worker:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push AppFlowy Worker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./services/appflowy-worker/Dockerfile
+          platforms: ${{ github.event.inputs.archs }}
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/appflowy_worker:${{ github.event.inputs.debug_version }}-test
+
+      - name: Logout from Docker Hub
+        if: always()
+        run: docker logout


### PR DESCRIPTION
When triggering the workflow manually, you'll be prompted for:

- **branch**:  
  The branch to build from. Defaults to `main`.

- **debug_version**:  
  The release version tag (e.g., `v1.0.0`). The final image tag will be `${debug_version}-test`.

- **archs**:  
  (Optional) The target architectures, provided as a comma-separated list. Defaults to `linux/amd64`.  
  To build for multiple architectures, e.g., use: `linux/amd64,linux/arm64`.

## Summary by Sourcery

CI:
- Add a new GitHub Actions workflow to manually build and push Docker images for multiple components, including GoTrue, AppFlowy Cloud, Admin Frontend, and AppFlowy Worker.