### PR TITLE
feat: add OTP http request

### DIFF
--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -11,8 +11,8 @@ use client_api_entity::AuthProvider;
 use client_api_entity::CollabType;
 use gotrue::grant::PasswordGrant;
 use gotrue::grant::{Grant, RefreshTokenGrant};
-use gotrue::params::MagicLinkParams;
 use gotrue::params::{AdminUserParams, GenerateLinkParams};
+use gotrue::params::{MagicLinkParams, VerifyParams, VerifyType};
 use reqwest::StatusCode;
 use shared_entity::dto::workspace_dto::{CreateWorkspaceParam, PatchWorkspaceParam};
 use std::fmt::{Display, Formatter};
@@ -267,6 +267,28 @@ impl Client {
       )
       .await?;
     Ok(())
+  }
+
+  /// Sign in with passcode (OTP)
+  ///
+  /// User will receive an email with a passcode to sign in.
+  ///
+  /// For more information, please refer to the sign_in_with_magic_link function.
+  #[instrument(level = "debug", skip_all, err)]
+  pub async fn sign_in_with_passcode(
+    &self,
+    email: &str,
+    passcode: &str,
+  ) -> Result<GotrueTokenResponse, AppResponseError> {
+    let token = self
+      .gotrue_client
+      .verify(&VerifyParams {
+        email: email.to_owned(),
+        token: passcode.to_owned(),
+        type_: VerifyType::Recovery,
+      })
+      .await?;
+    Ok(token)
   }
 
   /// Attempts to sign in using a URL, extracting refresh_token from the URL.

--- a/libs/gotrue-entity/src/dto.rs
+++ b/libs/gotrue-entity/src/dto.rs
@@ -19,7 +19,7 @@ pub struct AdminListUsersResponse {
   pub aud: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct User {
   pub id: String,
 
@@ -72,7 +72,7 @@ pub struct Factor {
   pub factor_type: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GotrueTokenResponse {
   /// the token that clients use to make authenticated requests to the server or API. It is a bearer token that provides temporary, secure access to server resources.
   pub access_token: String,


### PR DESCRIPTION
- Added login with passcode request 
- Added login with password request

## Summary by Sourcery

Add OTP (One-Time Passcode) authentication method to the client API

New Features:
- Implement sign-in with passcode (OTP) authentication method
- Add new method to verify sign-in using a passcode sent via email

Enhancements:
- Modify sign_in_password method to return GotrueTokenResponse instead of a boolean
- Add Clone derive to User and GotrueTokenResponse structs to improve token handling