### PR TITLE
feat: join workspace by invite code

### DIFF
--- a/.sqlx/query-084655c4e26f78c9c0924ea39a099dc9c00ee73dc6ade2dcff27c03042ebe8c3.json
+++ b/.sqlx/query-084655c4e26f78c9c0924ea39a099dc9c00ee73dc6ade2dcff27c03042ebe8c3.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      INSERT INTO af_workspace_invite_code (workspace_id, invite_code, expires_at)\n      VALUES ($1, $2, $3)\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "084655c4e26f78c9c0924ea39a099dc9c00ee73dc6ade2dcff27c03042ebe8c3"
+}

--- a/.sqlx/query-32fd3dcd1a3e02c32ddedb232b6af2e7f9ea160354528f3299cca62367af10f7.json
+++ b/.sqlx/query-32fd3dcd1a3e02c32ddedb232b6af2e7f9ea160354528f3299cca62367af10f7.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      INSERT INTO af_workspace_member (workspace_id, uid, role_id)\n      VALUES ($1, $2, $3)\n      ON CONFLICT (workspace_id, uid) DO NOTHING\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "32fd3dcd1a3e02c32ddedb232b6af2e7f9ea160354528f3299cca62367af10f7"
+}

--- a/.sqlx/query-90a302af791eeb5c5f60c3f95145e0e73c2a1652c5b547e4118bac1d005300de.json
+++ b/.sqlx/query-90a302af791eeb5c5f60c3f95145e0e73c2a1652c5b547e4118bac1d005300de.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT workspace_id\n      FROM af_workspace_invite_code\n      WHERE invite_code = $1\n        AND (expires_at IS NULL OR expires_at > NOW())\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "workspace_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "90a302af791eeb5c5f60c3f95145e0e73c2a1652c5b547e4118bac1d005300de"
+}

--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -9,6 +9,10 @@ use client_api_entity::workspace_dto::TrashSectionItems;
 use client_api_entity::workspace_dto::{FolderView, QueryWorkspaceFolder, QueryWorkspaceParam};
 use client_api_entity::AuthProvider;
 use client_api_entity::CollabType;
+use client_api_entity::InvitedWorkspace;
+use client_api_entity::JoinWorkspaceByInviteCodeParams;
+use client_api_entity::WorkspaceInviteCodeParams;
+use client_api_entity::WorkspaceInviteToken as WorkspaceInviteCode;
 use gotrue::grant::PasswordGrant;
 use gotrue::grant::{Grant, RefreshTokenGrant};
 use gotrue::params::MagicLinkParams;
@@ -773,6 +777,44 @@ impl Client {
       .await?;
     log_request_id(&resp);
     AppResponse::<TrashSectionItems>::from_response(resp)
+      .await?
+      .into_data()
+  }
+
+  pub async fn join_workspace_by_invitation_code(
+    &self,
+    invitation_code: &str,
+  ) -> Result<InvitedWorkspace, AppResponseError> {
+    let url = format!("{}/api/workspace/join-by-invite-code", self.base_url);
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(&JoinWorkspaceByInviteCodeParams {
+        code: invitation_code.to_string(),
+      })
+      .send()
+      .await?;
+    AppResponse::<InvitedWorkspace>::from_response(resp)
+      .await?
+      .into_data()
+  }
+
+  pub async fn create_workspace_invitation_code(
+    &self,
+    workspace_id: &Uuid,
+    params: &WorkspaceInviteCodeParams,
+  ) -> Result<WorkspaceInviteCode, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/invite-code",
+      self.base_url, workspace_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(params)
+      .send()
+      .await?;
+    AppResponse::<WorkspaceInviteCode>::from_response(resp)
       .await?
       .into_data()
   }

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -1222,6 +1222,26 @@ pub struct ListQuickNotesQueryParams {
   pub limit: Option<i32>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WorkspaceInviteCodeParams {
+  pub validity_period_hours: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WorkspaceInviteToken {
+  pub code: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct InvitedWorkspace {
+  pub workspace_id: Uuid,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JoinWorkspaceByInviteCodeParams {
+  pub code: String,
+}
+
 #[cfg(test)]
 mod test {
   use crate::dto::{CollabParams, CollabParamsV0};

--- a/migrations/20250403021559_workspace_invite_code.sql
+++ b/migrations/20250403021559_workspace_invite_code.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS af_workspace_invite_code (
+  id UUID PRIMARY KEY DEFAULT UUID_GENERATE_V4 (),
+  invite_code TEXT NOT NULL,
+  expires_at TIMESTAMP,
+  workspace_id UUID NOT NULL REFERENCES af_workspace (workspace_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_af_workspace_invite_code ON af_workspace_invite_code (invite_code);

--- a/src/biz/workspace/invite.rs
+++ b/src/biz/workspace/invite.rs
@@ -1,0 +1,42 @@
+use app_error::AppError;
+use database::workspace::{
+  insert_workspace_invite_code, select_invited_workspace_id, upsert_workspace_member_uid,
+};
+use rand::{distributions::Alphanumeric, Rng};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use database_entity::dto::{AFRole, WorkspaceInviteToken};
+
+const INVITE_LINK_CODE_LENGTH: usize = 16;
+
+pub async fn generate_workspace_invite_token(
+  pg_pool: &PgPool,
+  workspace_id: &Uuid,
+  validity_period_hours: Option<i64>,
+) -> Result<WorkspaceInviteToken, AppError> {
+  let code = generate_workspace_invite_code();
+  let expires_at = validity_period_hours.map(|v| chrono::Utc::now() + chrono::Duration::hours(v));
+  insert_workspace_invite_code(pg_pool, workspace_id, &code, expires_at.as_ref()).await?;
+
+  Ok(WorkspaceInviteToken { code })
+}
+
+fn generate_workspace_invite_code() -> String {
+  let rng = rand::thread_rng();
+  rng
+    .sample_iter(&Alphanumeric)
+    .take(INVITE_LINK_CODE_LENGTH)
+    .map(char::from)
+    .collect()
+}
+
+pub async fn join_workspace_invite_by_code(
+  pg_pool: &PgPool,
+  invitation_code: &str,
+  uid: i64,
+) -> Result<Uuid, AppError> {
+  let invited_workspace_id = select_invited_workspace_id(pg_pool, invitation_code).await?;
+  upsert_workspace_member_uid(pg_pool, &invited_workspace_id, uid, AFRole::Member).await?;
+  Ok(invited_workspace_id)
+}

--- a/src/biz/workspace/mod.rs
+++ b/src/biz/workspace/mod.rs
@@ -1,4 +1,5 @@
 pub mod duplicate;
+pub mod invite;
 pub mod ops;
 pub mod page_view;
 pub mod publish;

--- a/tests/workspace/join_workspace.rs
+++ b/tests/workspace/join_workspace.rs
@@ -1,0 +1,32 @@
+use client_api::entity::WorkspaceInviteCodeParams;
+use client_api_test::generate_unique_registered_user_client;
+
+#[tokio::test]
+async fn join_workspace_by_invite_code() {
+  let (owner_client, _) = generate_unique_registered_user_client().await;
+  let workspaces = owner_client.get_workspaces().await.unwrap();
+  let workspace_id = workspaces[0].workspace_id;
+  let (invitee_client, _) = generate_unique_registered_user_client().await;
+  let invitation_code = owner_client
+    .create_workspace_invitation_code(
+      &workspace_id,
+      &WorkspaceInviteCodeParams {
+        validity_period_hours: None,
+      },
+    )
+    .await
+    .unwrap()
+    .code;
+  let invited_workspace_id = invitee_client
+    .join_workspace_by_invitation_code(&invitation_code)
+    .await
+    .unwrap()
+    .workspace_id;
+  assert_eq!(workspace_id, invited_workspace_id);
+  assert!(invitee_client
+    .get_workspaces()
+    .await
+    .unwrap()
+    .iter()
+    .any(|w| w.workspace_id == invited_workspace_id));
+}

--- a/tests/workspace/mod.rs
+++ b/tests/workspace/mod.rs
@@ -3,6 +3,7 @@ mod default_user_workspace;
 mod edit_workspace;
 mod import_test;
 mod invitation_crud;
+mod join_workspace;
 mod member_crud;
 mod page_view;
 mod publish;


### PR DESCRIPTION
Two additional API, to allow a user to join a workspace by invite code.

The first API will return a 16 character alphanumerical code, which can be used as an input parameter to the other API to join a workspace.

Only a workspace owner can generate the invite code, but any authenticated users with the code can use it to join a workspace without approval.

## Summary by Sourcery

Implement workspace invitation functionality by adding APIs to generate and use invite codes for joining workspaces

New Features:
- Add ability for workspace owners to generate a 16-character invite code
- Allow authenticated users to join a workspace using an invite code

Enhancements:
- Create new database table to track workspace invite codes
- Implement client-side methods for creating and using invite codes