### PR TITLE
chore: update supabase gotrue URL

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -75,7 +75,7 @@ services:
       retries: 12
     environment:
       # There are a lot of options to configure GoTrue. You can reference the example config:
-      # https://github.com/supabase/gotrue/blob/master/example.env
+      # https://github.com/supabase/auth/blob/master/example.env
       - GOTRUE_ADMIN_EMAIL=${GOTRUE_ADMIN_EMAIL}
       - GOTRUE_ADMIN_PASSWORD=${GOTRUE_ADMIN_PASSWORD}
       - GOTRUE_DISABLE_SIGNUP=${GOTRUE_DISABLE_SIGNUP:-false}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -47,7 +47,7 @@ services:
     depends_on:
       - postgres
     environment:
-      # Gotrue config: https://github.com/supabase/gotrue/blob/master/example.env
+      # Gotrue config: https://github.com/supabase/auth/blob/master/example.env
       - GOTRUE_ADMIN_EMAIL=${GOTRUE_ADMIN_EMAIL}
       - GOTRUE_ADMIN_PASSWORD=${GOTRUE_ADMIN_PASSWORD}
       - GOTRUE_DISABLE_SIGNUP=${GOTRUE_DISABLE_SIGNUP:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     image: appflowyinc/gotrue:${GOTRUE_VERSION:-latest}
     environment:
       # There are a lot of options to configure GoTrue. You can reference the example config:
-      # https://github.com/supabase/gotrue/blob/master/example.env
+      # https://github.com/supabase/auth/blob/master/example.env
       - GOTRUE_ADMIN_EMAIL=${GOTRUE_ADMIN_EMAIL}
       - GOTRUE_ADMIN_PASSWORD=${GOTRUE_ADMIN_PASSWORD}
       - GOTRUE_DISABLE_SIGNUP=${GOTRUE_DISABLE_SIGNUP:-false}

--- a/libs/app-error/src/gotrue.rs
+++ b/libs/app-error/src/gotrue.rs
@@ -81,7 +81,7 @@ impl Display for GoTrueErrorSerde {
 }
 
 /// The gotrue error definition:
-/// https://github.com/supabase/gotrue/blob/cc07b4aa2ace75d9c8e46ae5107dbabadf944e87/internal/models/errors.go#L65
+/// https://github.com/supabase/auth/blob/cc07b4aa2ace75d9c8e46ae5107dbabadf944e87/internal/models/errors.go#L65
 /// Used to deserialize the response from the gotrue server
 #[derive(Serialize, Deserialize, Debug, Error)]
 pub struct GotrueClientError {

--- a/libs/gotrue/src/api.rs
+++ b/libs/gotrue/src/api.rs
@@ -75,7 +75,7 @@ impl Client {
 
   #[tracing::instrument(skip_all, err)]
   pub async fn token(&self, grant: &Grant) -> Result<GotrueTokenResponse, GoTrueError> {
-    // https://github.com/supabase/gotrue/blob/master/internal/api/verify.go#L219
+    // https://github.com/supabase/auth/blob/master/internal/api/verify.go#L219
     let url = format!("{}/token?grant_type={}", self.base_url, grant.type_as_str());
     let payload = grant.json_value();
     let resp = self.client.post(url).json(&payload).send().await?;


### PR DESCRIPTION
## Summary

[Supabase gotrue repository](https://github.com/supabase/auth/tree/master) was renamed **auth**.
So update the old links like the below code.

```diff
- https://github.com/supabase/gotrue
+ https://github.com/supabase/auth
```

## Summary by Sourcery

Chores:
- Update references to Supabase GoTrue repository URL across project configuration and source files