### PR TITLE
chore: update CDN for mailer assets

### DIFF
--- a/assets/mailer_templates/build_production/magic_link.html
+++ b/assets/mailer_templates/build_production/magic_link.html
@@ -32,7 +32,7 @@
           <table width="600" border="0" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="border-radius: 12px; padding: 32px; margin: 0 auto;" role="presentation">
             <tr>
               <td align="center" style="padding-bottom: 24px;">
-                <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/images/appflowy.png" width="32" height="32" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0; display: block; margin: 0 auto" alt="">
+                <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/images/appflowy.png" width="32" height="32" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0; display: block; margin: 0 auto" alt="">
               </td>
             </tr>
             <tr>
@@ -107,19 +107,19 @@
                 <p style="border-top: 1px solid #e4e8f5; padding-top: 24px; font-size: 12px; color: #6F748C; margin: 0 0 15px;">Bring projects, knowledge, and teams together with the power of AI.</p>
                 <p style="margin: 0 0 15px;">
                   <a href="https://discord.gg/9Q2xaN37tV" style="text-decoration: none; display: inline-block; margin: 0 10px 0 0;">
-                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/images/discord.png" width="20" height="20" alt="Discord" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
+                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/images/discord.png" width="20" height="20" alt="Discord" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
                   </a>
                   <a href="https://github.com/AppFlowy-IO/AppFlowy" style="text-decoration: none; display: inline-block; margin: 0 10px 0 0;">
-                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/images/github.png" width="20" height="20" alt="GitHub" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
+                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/images/github.png" width="20" height="20" alt="GitHub" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
                   </a>
                   <a href="https://www.reddit.com/r/AppFlowy" style="text-decoration: none; display: inline-block; margin: 0 10px 0 0;">
-                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/images/reddit.png" width="20" height="20" alt="Reddit" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
+                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/images/reddit.png" width="20" height="20" alt="Reddit" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
                   </a>
                   <a href="https://twitter.com/appflowy" style="text-decoration: none; display: inline-block; margin: 0 10px 0 0;">
-                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/images/twitter.png" width="20" height="20" alt="Twitter" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
+                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/images/twitter.png" width="20" height="20" alt="Twitter" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
                   </a>
                   <a href="https://www.youtube.com/@AppFlowyHQ" style="text-decoration: none; display: inline-block;">
-                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/images/youtube.png" width="20" height="20" alt="Youtube" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
+                    <img src="https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/images/youtube.png" width="20" height="20" alt="Youtube" style="max-width: 100%; vertical-align: middle; line-height: 1; border: 0;">
                   </a>
                 </p>
                 <p style="font-size: 12px; color: #6F748C; margin: 0 0 10px;">Copyright © 2025, AppFlowy Inc.</p>

--- a/email_template/config.production.js
+++ b/email_template/config.production.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   locals: {
     cdnBaseUrl:
-        "https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/magic-link-otp/assets/mailer_templates/build_production/",
+      "https://raw.githubusercontent.com/AppFlowy-IO/AppFlowy-Cloud/main/assets/mailer_templates/build_production/",
     error: "{{ error }}",
     detailError: "{{ error_detail }}",
     userIconUrl: "{{ user_icon_url }}",


### PR DESCRIPTION
Update the CDN to use the assets on main branch so that we can delete the magic-link-otp branch.

## Summary by Sourcery

Chores:
- Update image source URLs in mailer templates to point to the main branch