### PR TITLE
fix: filter out non uuid database relation to avoid template duplication failure

### DIFF
--- a/libs/shared-entity/src/dto/publish_dto.rs
+++ b/libs/shared-entity/src/dto/publish_dto.rs
@@ -60,6 +60,50 @@ pub struct PublishDatabaseData {
   pub database_relations: HashMap<Uuid, Uuid>,
 }
 
+/// For fixing invalid published template with non-uuid relations
+#[derive(Debug, Clone, Serialize, Deserialize, Default, Eq, PartialEq)]
+pub struct PublishDatabaseDataWithNonUuidRelations {
+  /// The encoded collab data for the database itself
+  pub database_collab: Vec<u8>,
+
+  /// The encoded collab data for the database rows
+  /// Use the row_id as the key
+  pub database_row_collabs: HashMap<Uuid, Vec<u8>>,
+
+  /// The encoded collab data for the documents inside the database rows
+  /// It's not used for now
+  pub database_row_document_collabs: HashMap<Uuid, Vec<u8>>,
+
+  /// Visible view ids
+  pub visible_database_view_ids: Vec<Uuid>,
+
+  /// Relation view id map. Usually database relation ids should only consist
+  /// of uuids. However, it might be possible for a published database to contain
+  /// relations which are non uuids, which we will need to filter out later.
+  pub database_relations: HashMap<String, String>,
+}
+
+impl From<PublishDatabaseDataWithNonUuidRelations> for PublishDatabaseData {
+  fn from(data: PublishDatabaseDataWithNonUuidRelations) -> Self {
+    PublishDatabaseData {
+      database_collab: data.database_collab,
+      database_row_collabs: data.database_row_collabs,
+      database_row_document_collabs: data.database_row_document_collabs,
+      visible_database_view_ids: data.visible_database_view_ids,
+      // Filter out all non-uuid relations
+      database_relations: data
+        .database_relations
+        .into_iter()
+        .filter_map(|(key, value)| {
+          let key_uuid = Uuid::parse_str(&key).ok()?;
+          let value_uuid = Uuid::parse_str(&value).ok()?;
+          Some((key_uuid, value_uuid))
+        })
+        .collect(),
+    }
+  }
+}
+
 #[derive(Default, Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct DuplicatePublishedPageResponse {
   pub view_id: Uuid,


### PR DESCRIPTION
Currently, some templates for database might contain database relations which the database id is not a uuid, and also does not exist. This resulted in deserialization error, preventing the template from being duplicated.

As a workaround, we will deserialize the published blob, with the database id as string. Then, we will filter out all the non uuid database relations.

After we have find out all the published templates with invalid database relations on the official template center, and fix them, we can revert the change introduce in this PR.

## Summary by Sourcery

Add support for deserializing published database templates with non-UUID relations to prevent template duplication failures

Bug Fixes:
- Handle deserialization of published database templates that contain non-UUID database relations by adding a fallback deserialization method

Enhancements:
- Implement a flexible deserialization approach that filters out invalid database relations during template duplication