### PR TITLE
feat: api to get and delete invitation code, new code should replace existing one

### DIFF
--- a/.sqlx/query-0d9c62acb33b96bb81536d1ad3121174403bcd40b777eb8d384fe8e81e1db3c4.json
+++ b/.sqlx/query-0d9c62acb33b96bb81536d1ad3121174403bcd40b777eb8d384fe8e81e1db3c4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT invite_code\n      FROM af_workspace_invite_code\n      WHERE workspace_id = $1\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "invite_code",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0d9c62acb33b96bb81536d1ad3121174403bcd40b777eb8d384fe8e81e1db3c4"
+}

--- a/.sqlx/query-c81848346ed2ff85f1d5fb8041fba648137a927762b385b97054552c00793a50.json
+++ b/.sqlx/query-c81848346ed2ff85f1d5fb8041fba648137a927762b385b97054552c00793a50.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      DELETE FROM af_workspace_invite_code\n      WHERE workspace_id = $1\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c81848346ed2ff85f1d5fb8041fba648137a927762b385b97054552c00793a50"
+}

--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -850,6 +850,38 @@ impl Client {
     process_response_data::<WorkspaceInviteCode>(resp).await
   }
 
+  pub async fn get_workspace_invitation_code(
+    &self,
+    workspace_id: &Uuid,
+  ) -> Result<WorkspaceInviteCode, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/invite-code",
+      self.base_url, workspace_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    process_response_data::<WorkspaceInviteCode>(resp).await
+  }
+
+  pub async fn delete_workspace_invitation_code(
+    &self,
+    workspace_id: &Uuid,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/invite-code",
+      self.base_url, workspace_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::DELETE, &url)
+      .await?
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+
   #[instrument(level = "info", skip_all, err)]
   pub async fn sign_up(&self, email: &str, password: &str) -> Result<(), AppResponseError> {
     match self.gotrue_client.sign_up(email, password, None).await? {

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -1246,7 +1246,7 @@ pub struct WorkspaceInviteCodeParams {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WorkspaceInviteToken {
-  pub code: String,
+  pub code: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/libs/database/src/workspace.rs
+++ b/libs/database/src/workspace.rs
@@ -1595,6 +1595,41 @@ pub async fn upsert_workspace_member_uid<'a, E: Executor<'a, Database = Postgres
   Ok(())
 }
 
+pub async fn select_invite_code_for_workspace_id<'a, E: Executor<'a, Database = Postgres>>(
+  executor: E,
+  workspace_id: &Uuid,
+) -> Result<Option<String>, AppError> {
+  let code = sqlx::query_scalar!(
+    r#"
+      SELECT invite_code
+      FROM af_workspace_invite_code
+      WHERE workspace_id = $1
+    "#,
+    workspace_id,
+  )
+  .fetch_optional(executor)
+  .await?;
+
+  Ok(code)
+}
+
+pub async fn delete_all_invite_code_for_workspace<'a, E: Executor<'a, Database = Postgres>>(
+  executor: E,
+  workspace_id: &Uuid,
+) -> Result<(), AppError> {
+  sqlx::query!(
+    r#"
+      DELETE FROM af_workspace_invite_code
+      WHERE workspace_id = $1
+    "#,
+    workspace_id,
+  )
+  .execute(executor)
+  .await?;
+
+  Ok(())
+}
+
 pub async fn insert_workspace_invite_code<'a, E: Executor<'a, Database = Postgres>>(
   executor: E,
   workspace_id: &Uuid,

--- a/src/biz/workspace/invite.rs
+++ b/src/biz/workspace/invite.rs
@@ -1,7 +1,7 @@
 use app_error::AppError;
 use database::workspace::{
-  insert_workspace_invite_code, select_invitation_code_info, select_invited_workspace_id,
-  upsert_workspace_member_uid,
+  delete_all_invite_code_for_workspace, insert_workspace_invite_code, select_invitation_code_info,
+  select_invite_code_for_workspace_id, select_invited_workspace_id, upsert_workspace_member_uid,
 };
 use rand::{distributions::Alphanumeric, Rng};
 use sqlx::PgPool;
@@ -16,11 +16,12 @@ pub async fn generate_workspace_invite_token(
   workspace_id: &Uuid,
   validity_period_hours: Option<i64>,
 ) -> Result<WorkspaceInviteToken, AppError> {
+  delete_all_invite_code_for_workspace(pg_pool, workspace_id).await?;
   let code = generate_workspace_invite_code();
   let expires_at = validity_period_hours.map(|v| chrono::Utc::now() + chrono::Duration::hours(v));
   insert_workspace_invite_code(pg_pool, workspace_id, &code, expires_at.as_ref()).await?;
 
-  Ok(WorkspaceInviteToken { code })
+  Ok(WorkspaceInviteToken { code: Some(code) })
 }
 
 fn generate_workspace_invite_code() -> String {
@@ -40,6 +41,22 @@ pub async fn join_workspace_invite_by_code(
   let invited_workspace_id = select_invited_workspace_id(pg_pool, invitation_code).await?;
   upsert_workspace_member_uid(pg_pool, &invited_workspace_id, uid, AFRole::Member).await?;
   Ok(invited_workspace_id)
+}
+
+pub async fn delete_workspace_invite_code(
+  pg_pool: &PgPool,
+  workspace_id: &Uuid,
+) -> Result<(), AppError> {
+  delete_all_invite_code_for_workspace(pg_pool, workspace_id).await?;
+  Ok(())
+}
+
+pub async fn get_invite_code_for_workspace(
+  pg_pool: &PgPool,
+  workspace_id: &Uuid,
+) -> Result<Option<String>, AppError> {
+  let code = select_invite_code_for_workspace_id(pg_pool, workspace_id).await?;
+  Ok(code)
 }
 
 pub async fn get_invitation_code_info(

--- a/tests/workspace/join_workspace.rs
+++ b/tests/workspace/join_workspace.rs
@@ -16,7 +16,15 @@ async fn join_workspace_by_invite_code() {
     )
     .await
     .unwrap()
-    .code;
+    .code
+    .unwrap();
+  let retrieved_invite_code = owner_client
+    .get_workspace_invitation_code(&workspace_id)
+    .await
+    .unwrap()
+    .code
+    .unwrap();
+  assert_eq!(invitation_code, retrieved_invite_code);
   let invitation_code_info = invitee_client
     .get_invitation_code_info(&invitation_code)
     .await
@@ -39,4 +47,14 @@ async fn join_workspace_by_invite_code() {
     .unwrap()
     .iter()
     .any(|w| w.workspace_id == invited_workspace_id));
+  owner_client
+    .delete_workspace_invitation_code(&workspace_id)
+    .await
+    .unwrap();
+  assert!(owner_client
+    .get_workspace_invitation_code(&workspace_id)
+    .await
+    .unwrap()
+    .code
+    .is_none());
 }


### PR DESCRIPTION
## Summary by Sourcery

Add API endpoints to retrieve and delete workspace invitation codes, with support for generating a single unique invite code per workspace

New Features:
- Implement GET endpoint to retrieve the current workspace invitation code
- Implement DELETE endpoint to remove the current workspace invitation code

Enhancements:
- Modify workspace invite code generation to automatically delete existing codes before creating a new one
- Update WorkspaceInviteToken to support optional invite codes