### PR TITLE
fix: avoid panic when user does not have a last visit workspace

### DIFF
--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -645,7 +645,7 @@ pub struct AFUserProfile {
   pub updated_at: i64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AFWorkspace {
   pub workspace_id: Uuid,
   pub database_storage_id: Uuid,


### PR DESCRIPTION
Currently, we do not handle the scenario where a user does not have last visited workspace, which will cause a panic and result in 502 being sent to the end user. We should have a fallback, such that when this happen, return the first workspace which the user has access to.

Also, there is no need to use mut txn here, because we are not modifying the database.

## Summary by Sourcery

Handle the scenario where a user does not have a last visited workspace by providing a fallback mechanism

Bug Fixes:
- Prevent panic when a user does not have a last visited workspace by returning the first accessible workspace instead

Enhancements:
- Simplify database transaction handling by removing unnecessary mutable transaction
- Add fallback logic to select the first available workspace when no last visited workspace exists