### PR TITLE
chore: update appflowy gotrue version

### DIFF
--- a/docker/gotrue/Dockerfile
+++ b/docker/gotrue/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM golang as base
 WORKDIR /go/src/supabase
-RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.1.0
+RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.2.0
 WORKDIR /go/src/supabase/auth
 RUN CGO_ENABLED=0 go build -o /auth .
 


### PR DESCRIPTION
Update gotrue version in order to have more detailed internal error message when OTP validation failed.

## Summary by Sourcery

Chores:
- Upgrade the AppFlowy GoTrue library from version 0.1.0 to 0.2.0 to improve error messaging for OTP validation