### PR TITLE
feat: add endpoint to create view without collab

### DIFF
--- a/libs/client-api/src/http_view.rs
+++ b/libs/client-api/src/http_view.rs
@@ -1,7 +1,8 @@
 use client_api_entity::workspace_dto::{
-  AddRecentPagesParams, AppendBlockToPageParams, CreatePageDatabaseViewParams, CreatePageParams,
-  CreateSpaceParams, DuplicatePageParams, FavoritePageParams, MovePageParams, Page, PageCollab,
-  PublishPageParams, Space, UpdatePageParams, UpdateSpaceParams,
+  AddRecentPagesParams, AppendBlockToPageParams, CreateFolderViewParams,
+  CreatePageDatabaseViewParams, CreatePageParams, CreateSpaceParams, DuplicatePageParams,
+  FavoritePageParams, MovePageParams, Page, PageCollab, PublishPageParams, Space, UpdatePageParams,
+  UpdateSpaceParams,
 };
 use reqwest::Method;
 use serde_json::json;
@@ -11,6 +12,24 @@ use uuid::Uuid;
 use crate::{process_response_data, process_response_error, Client};
 
 impl Client {
+  pub async fn create_folder_view(
+    &self,
+    workspace_id: Uuid,
+    params: &CreateFolderViewParams,
+  ) -> Result<Page, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/folder-view",
+      self.base_url, workspace_id,
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(params)
+      .send()
+      .await?;
+    process_response_data::<Page>(resp).await
+  }
+
   pub async fn create_workspace_page_view(
     &self,
     workspace_id: Uuid,

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -154,6 +154,15 @@ pub struct CollabResponse {
   pub object_id: Uuid,
 }
 
+/// Create a view in the folder, without an associated collab
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateFolderViewParams {
+  pub parent_view_id: Uuid,
+  pub layout: ViewLayout,
+  pub name: Option<String>,
+  pub view_id: Option<Uuid>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Space {
   pub view_id: Uuid,


### PR DESCRIPTION
AppFlowy Web will use this endpoint to create a folder view, after updating the database collab locally to create a new database view.