### PR TITLE
fix: use magic link type for passcode sign in

### DIFF
--- a/libs/client-api/src/http.rs
+++ b/libs/client-api/src/http.rs
@@ -297,6 +297,28 @@ impl Client {
     Ok(())
   }
 
+  /// Sign in with recovery token
+  ///
+  /// User will receive an email with a recovery code to sign in after clicking Forget Password.
+  #[instrument(level = "debug", skip_all, err)]
+  pub async fn sign_in_with_recovery_code(
+    &self,
+    email: &str,
+    passcode: &str,
+  ) -> Result<GotrueTokenResponse, AppResponseError> {
+    let response = self
+      .gotrue_client
+      .verify(&VerifyParams {
+        email: email.to_owned(),
+        token: passcode.to_owned(),
+        type_: VerifyType::Recovery,
+      })
+      .await?;
+    let _ = self.verify_token_cloud(&response.access_token).await?;
+    self.token.write().set(response.clone());
+    Ok(response)
+  }
+
   /// Sign in with passcode (OTP)
   ///
   /// User will receive an email with a passcode to sign in.
@@ -313,7 +335,7 @@ impl Client {
       .verify(&VerifyParams {
         email: email.to_owned(),
         token: passcode.to_owned(),
-        type_: VerifyType::Recovery,
+        type_: VerifyType::MagicLink,
       })
       .await?;
     let _ = self.verify_token_cloud(&response.access_token).await?;

--- a/libs/gotrue/src/params.rs
+++ b/libs/gotrue/src/params.rs
@@ -126,6 +126,7 @@ pub struct CreateSSOProviderParams {
 #[serde(rename_all = "lowercase")]
 pub enum VerifyType {
   Recovery,
+  MagicLink,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
Use Magic link for recovery type as opposed to Recovery when sign in using Magic link OTP

## Summary by Sourcery

Update sign-in methods to use the correct verification type for magic link and recovery code authentication

New Features:
- Add a new method `sign_in_with_recovery_code` for explicit recovery token authentication

Bug Fixes:
- Fix the verification type for magic link sign-in by changing from Recovery to MagicLink type

Enhancements:
- Introduce a new MagicLink verification type in the VerifyType enum