### PR TITLE
fix: avoid using unwrap for duplicate page

### DIFF
--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1417,8 +1417,7 @@ async fn duplicate_page_handler(
     view_id,
     &suffix,
   )
-  .await
-  .unwrap();
+  .await?;
   Ok(Json(AppResponse::Ok()))
 }
 


### PR DESCRIPTION
Unwrap has the potential to cause panic for the API to duplicate page.