### PR TITLE
chore: update appflowy gotrue version to 0.4.0

### DIFF
--- a/docker/gotrue/Dockerfile
+++ b/docker/gotrue/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM golang as base
 WORKDIR /go/src/supabase
-RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.3.0
+RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.4.0
 WORKDIR /go/src/supabase/auth
 RUN CGO_ENABLED=0 go build -o /auth .
 


### PR DESCRIPTION
Version 0.4.0 allow new users that has not confirmed their email yet to use the confirmation token for OTP verification.

## Summary by Sourcery

Build:
- Update the `AppFlowy-IO/auth` dependency from branch `0.3.0` to `0.4.0` in the GoTrue Dockerfile.