### PR TITLE
feat: allow create folder view endpoint to update workspace database if database id is provided

### DIFF
--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -161,6 +161,8 @@ pub struct CreateFolderViewParams {
   pub layout: ViewLayout,
   pub name: Option<String>,
   pub view_id: Option<Uuid>,
+  // If database id is provided, then the view will be added to the workspace database collab
+  pub database_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1273,11 +1273,13 @@ async fn post_folder_view_handler(
     server,
     user,
     &state.collab_access_control_storage,
+    &state.pg_pool,
     workspace_uuid,
     &payload.parent_view_id,
     payload.layout.clone(),
     payload.name.as_deref(),
     payload.view_id,
+    payload.database_id,
   )
   .await?;
   Ok(Json(AppResponse::Ok().with_data(page)))

--- a/tests/workspace/page_view.rs
+++ b/tests/workspace/page_view.rs
@@ -181,6 +181,7 @@ async fn create_new_folder_view() {
         layout: ViewLayout::Document,
         name: Some("New document".to_string()),
         view_id: None,
+        database_id: None,
       },
     )
     .await


### PR DESCRIPTION
## Summary by Sourcery

Allow linking a new view to an existing database upon creation.

New Features:
- Add an optional `database_id` parameter to the create folder view endpoint.
- Update the workspace database collaborative object to include the new view when a `database_id` is provided during view creation.

Tests:
- Update tests for creating folder views to include the new optional `database_id` parameter.