### PR TITLE
fix: avoid user verification when joining workspace

### DIFF
--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -6,7 +6,6 @@ use crate::biz::collab::ops::{
   get_user_favorite_folder_views, get_user_recent_folder_views, get_user_trash_folder_views,
 };
 use crate::biz::collab::utils::collab_from_doc_state;
-use crate::biz::user::user_verify::verify_token;
 use crate::biz::workspace;
 use crate::biz::workspace::duplicate::duplicate_view_tree_and_collab;
 use crate::biz::workspace::invite::{
@@ -542,7 +541,6 @@ async fn post_accept_workspace_invite_handler(
   invite_id: web::Path<Uuid>,
   state: Data<AppState>,
 ) -> Result<JsonAppResponse<()>> {
-  let _is_new = verify_token(&auth.token, state.as_ref()).await?;
   let user_uuid = auth.uuid()?;
   let user_uid = state.user_cache.get_user_uid(&user_uuid).await?;
   let invite_id = invite_id.into_inner();


### PR DESCRIPTION
In order to join a workspace, a user would have to login via appflowy web or the admin console, and in the process, already calls the verify_user endpoint. There's no need to verify the user again to check if the user has a workspace.

## Summary by Sourcery

Bug Fixes:
- Eliminate unnecessary user verification step during workspace invite acceptance