### PR TITLE
chore: update gotrue image to use branch 0.6.0

### DIFF
--- a/docker/gotrue/Dockerfile
+++ b/docker/gotrue/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM golang as base
 WORKDIR /go/src/supabase
-RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.5.0
+RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.6.0
 WORKDIR /go/src/supabase/auth
 RUN CGO_ENABLED=0 go build -o /auth .
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update Git clone command to use branch 0.6.0 instead of 0.5.0