### PR TITLE
feat: support individual page field update and removal

### DIFF
--- a/libs/client-api/src/http_view.rs
+++ b/libs/client-api/src/http_view.rs
@@ -1,7 +1,8 @@
 use client_api_entity::workspace_dto::{
   AddRecentPagesParams, AppendBlockToPageParams, CreateFolderViewParams,
   CreatePageDatabaseViewParams, CreatePageParams, CreateSpaceParams, DuplicatePageParams,
-  FavoritePageParams, MovePageParams, Page, PageCollab, PublishPageParams, Space, UpdatePageParams,
+  FavoritePageParams, MovePageParams, Page, PageCollab, PublishPageParams, Space,
+  UpdatePageExtraParams, UpdatePageIconParams, UpdatePageNameParams, UpdatePageParams,
   UpdateSpaceParams,
 };
 use reqwest::Method;
@@ -290,6 +291,81 @@ impl Client {
       .http_client_with_auth(Method::PATCH, &url)
       .await?
       .json(params)
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+
+  pub async fn update_page_name(
+    &self,
+    workspace_id: Uuid,
+    view_id: &Uuid,
+    params: &UpdatePageNameParams,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/page-view/{}/update-name",
+      self.base_url, workspace_id, view_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(params)
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+
+  pub async fn update_page_icon(
+    &self,
+    workspace_id: Uuid,
+    view_id: &Uuid,
+    params: &UpdatePageIconParams,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/page-view/{}/update-icon",
+      self.base_url, workspace_id, view_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(params)
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+
+  pub async fn update_page_extra(
+    &self,
+    workspace_id: Uuid,
+    view_id: &Uuid,
+    params: &UpdatePageExtraParams,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/page-view/{}/update-extra",
+      self.base_url, workspace_id, view_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(params)
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+
+  pub async fn remove_page_icon(
+    &self,
+    workspace_id: Uuid,
+    view_id: &Uuid,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/page-view/{}/remove-icon",
+      self.base_url, workspace_id, view_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::POST, &url)
+      .await?
+      .json(&json!({}))
       .send()
       .await?;
     process_response_error(resp).await

--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -211,6 +211,21 @@ pub struct UpdatePageParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdatePageNameParams {
+  pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdatePageIconParams {
+  pub icon: ViewIcon,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdatePageExtraParams {
+  pub extra: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FavoritePageParams {
   pub is_favorite: bool,
   pub is_pinned: bool,

--- a/src/biz/collab/folder_view.rs
+++ b/src/biz/collab/folder_view.rs
@@ -150,10 +150,14 @@ fn to_folder_view(
 
   let is_private = parent_is_private || is_my_private_space;
   let extra = view.extra.as_deref().map(|extra| {
-    serde_json::from_str::<serde_json::Value>(extra).unwrap_or_else(|e| {
-      tracing::warn!("failed to parse extra field({}): {}", extra, e);
+    if extra.is_empty() {
       serde_json::Value::Null
-    })
+    } else {
+      serde_json::from_str::<serde_json::Value>(extra).unwrap_or_else(|e| {
+        tracing::warn!("failed to parse extra field({}): {}", extra, e);
+        serde_json::Value::Null
+      })
+    }
   });
   let children: Vec<FolderView> = view
     .children

--- a/tests/workspace/page_view.rs
+++ b/tests/workspace/page_view.rs
@@ -12,7 +12,8 @@ use shared_entity::dto::workspace_dto::{
   AddRecentPagesParams, AppendBlockToPageParams, CreateFolderViewParams,
   CreatePageDatabaseViewParams, CreatePageParams, CreateSpaceParams, DuplicatePageParams,
   FavoritePageParams, IconType, MovePageParams, PublishPageParams, SpacePermission,
-  UpdatePageParams, UpdateSpaceParams, ViewIcon, ViewLayout,
+  UpdatePageExtraParams, UpdatePageIconParams, UpdatePageNameParams, UpdatePageParams,
+  UpdateSpaceParams, ViewIcon, ViewLayout,
 };
 use tokio::time::sleep;
 use uuid::Uuid;
@@ -812,6 +813,64 @@ async fn update_page() {
     Some(json!({"is_pinned": true}).to_string())
   );
   assert_eq!(updated_view.is_locked, None);
+  web_client
+    .api_client
+    .update_page_name(
+      workspace_id,
+      &view_id_to_be_updated,
+      &UpdatePageNameParams {
+        name: "Another Name".to_string(),
+      },
+    )
+    .await
+    .unwrap();
+  web_client
+    .api_client
+    .update_page_icon(
+      workspace_id,
+      &view_id_to_be_updated,
+      &UpdatePageIconParams {
+        icon: ViewIcon {
+          ty: IconType::Emoji,
+          value: "😎".to_string(),
+        },
+      },
+    )
+    .await
+    .unwrap();
+  web_client
+    .api_client
+    .update_page_extra(
+      workspace_id,
+      &view_id_to_be_updated,
+      &UpdatePageExtraParams {
+        extra: json!({"is_pinned": false}).to_string(),
+      },
+    )
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  let updated_view = folder.get_view(&view_id_to_be_updated.to_string()).unwrap();
+  assert_eq!(updated_view.name, "Another Name");
+  assert_eq!(
+    updated_view.icon,
+    Some(collab_folder::ViewIcon {
+      ty: collab_folder::IconType::Emoji,
+      value: "😎".to_string(),
+    })
+  );
+  assert_eq!(
+    updated_view.extra,
+    Some(json!({"is_pinned": false}).to_string())
+  );
+  web_client
+    .api_client
+    .remove_page_icon(workspace_id, &view_id_to_be_updated)
+    .await
+    .unwrap();
+  let folder = get_latest_folder(&app_client, &workspace_id).await;
+  let updated_view = folder.get_view(&view_id_to_be_updated.to_string()).unwrap();
+  assert_eq!(updated_view.icon, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Add individual endpoint to update individual page field.

## Summary by Sourcery

Add granular endpoints for updating individual page fields in the workspace API

New Features:
- Support individual updates for page name, icon, and extra metadata
- Add separate endpoints for updating and removing page icons and extra fields

Enhancements:
- Implement fine-grained page field update mechanisms
- Add type-specific update parameter structs for different page field types