### PR TITLE
chore: fix typo and format nginx.conf

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -154,7 +154,7 @@ docker logs <NAME>
   underscores_in_headers on;
   ```
 - If AppFlowy Web is served on a separate domain, you will need to modify the nginx conf to prevent CORS issues.
-  By default, we allow requests from `localhost:3000`, using, the configuration below:
+  By default, we allow requests from `localhost:3000`, using the configuration below:
   ```
   map $http_origin $cors_origin {
     # AppFlowy Web origin
@@ -225,8 +225,8 @@ performed via the admin portal as opposed to links provided in emails.
   from the internet.
 - An example site configuration for Nginx has been provided in `external_proxy_config/nginx/appflowy.site.conf`. You can use this as a starting point for your own configuration, and include this in nginx.conf of your external Nginx server.
 
-### I am using Nginx Proxy Manager (or similar UI based proxy manager), and i am not able to replicate the configuration in external_proxy_config/nginx/appflowy.site.conf easily.
-- Another alternative, is to keep the `nginx` service in the `docker-compose.yml` file, then pass all the requests from the proxy manager to the `nginx` service. You have to turn on `Websockets Support`, or any equivalent options that adds a connection upgrade header.
+### I am using Nginx Proxy Manager (or similar UI based proxy manager), and I am not able to replicate the configuration in external_proxy_config/nginx/appflowy.site.conf easily.
+- Another alternative is to keep the `nginx` service in the `docker-compose.yml` file, then pass all the requests from the proxy manager to the `nginx` service. You have to turn on `Websockets Support`, or any equivalent options that adds a connection upgrade header.
 
 ### AppFlowy Web keeps redirecting to the desktop application after login.
 - Refer to the AppFlowy Web section in the deployment steps. Make sure that the necessary headers are present.

--- a/external_proxy_config/nginx/appflowy.site.conf
+++ b/external_proxy_config/nginx/appflowy.site.conf
@@ -41,7 +41,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
-        proxy_read_timeout 86400;
+        proxy_read_timeout 86400s;
     }
 
     location /api {
@@ -107,7 +107,7 @@ server {
         ## This is necessary to pass the correct IP to be hashed
         real_ip_header X-Real-IP;
 
-        proxy_connect_timeout 300;
+        proxy_connect_timeout 300s;
 
         ## To support websockets in MinIO versions released after January 2023
         proxy_http_version 1.1;
@@ -133,7 +133,7 @@ server {
 
         rewrite ^/minio-api/(.*) /$1 break;
 
-        proxy_connect_timeout 300;
+        proxy_connect_timeout 300s;
         # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
         proxy_http_version 1.1;
         proxy_set_header Connection "";

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -84,7 +84,7 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
             proxy_set_header Host $host;
-            proxy_read_timeout 86400;
+            proxy_read_timeout 86400s;
         }
 
         location /api {
@@ -182,7 +182,7 @@ http {
             ## This is necessary to pass the correct IP to be hashed
             real_ip_header X-Real-IP;
 
-            proxy_connect_timeout 300;
+            proxy_connect_timeout 300s;
 
             ## To support websockets in MinIO versions released after January 2023
             proxy_http_version 1.1;
@@ -208,7 +208,7 @@ http {
 
             rewrite ^/minio-api/(.*) /$1 break;
 
-            proxy_connect_timeout 300;
+            proxy_connect_timeout 300s;
             # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
             proxy_http_version 1.1;
             proxy_set_header Connection "";


### PR DESCRIPTION
## Summary by Sourcery

Fix typos and format Nginx configuration files

Documentation:
- Updated deployment documentation with minor grammatical improvements

Chores:
- Corrected minor typos in documentation
- Added 's' suffix to time-related configuration values in Nginx config