### PR TITLE
fix: add timeout to gotrue health check

### DIFF
--- a/docker/gotrue/Dockerfile
+++ b/docker/gotrue/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM golang as base
 WORKDIR /go/src/supabase
-RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.7.0
+RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.8.0
 WORKDIR /go/src/supabase/auth
 RUN CGO_ENABLED=0 go build -o /auth .
 

--- a/libs/gotrue/src/api.rs
+++ b/libs/gotrue/src/api.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::grant::Grant;
 use crate::params::{
   AdminDeleteUserParams, AdminUserParams, CreateSSOProviderParams, GenerateLinkParams,
@@ -38,6 +40,7 @@ impl Client {
     let resp = self
       .client
       .get(&url)
+      .timeout(Duration::from_secs(5))
       .send()
       .await
       .context(format!("calling {} failed", url))?;


### PR DESCRIPTION
AppFlowy Cloud will get stuck for about a minute if gotrue wasn't ready when the health check was performed.