### PR TITLE
fix: remove prometheus exporter from docker compose dev, add postgres condition check and update env

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -60,7 +60,7 @@ DATABASE_URL=postgres://postgres:password@localhost:5432/postgres
 # SQLX_OFFLINE=true
 
 # database url that gotrue will use
-GOTRUE_DATABASE_URL=postgres://supabase_auth_admin:root@postgres:5432/postgres
+GOTRUE_DATABASE_URL=postgres://postgres:password@postgres:5432/postgres?search_path=auth
 
 # Google OAuth2
 GOTRUE_EXTERNAL_GOOGLE_ENABLED=true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,14 +1,4 @@
 services:
-  nginx:
-    restart: on-failure
-    image: nginx
-    ports:
-      - 80:80   # Disable this if you are using TLS
-      - 443:443
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx/ssl/certificate.crt:/etc/nginx/ssl/certificate.crt
-      - ./nginx/ssl/private_key.key:/etc/nginx/ssl/private_key.key
   minio:
     restart: on-failure
     image: minio/minio
@@ -30,9 +20,11 @@ services:
       - SUPABASE_PASSWORD=${SUPABASE_PASSWORD:-root}
     ports:
       - 5432:5432
-    volumes:
-      # comment out the following line if you want to persist data when restarting docker
-      #- postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   redis:
     restart: on-failure
@@ -44,7 +36,8 @@ services:
     restart: on-failure
     image: appflowyinc/gotrue:${GOTRUE_VERSION:-latest}
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       # Gotrue config: https://github.com/supabase/auth/blob/master/example.env
       - GOTRUE_ADMIN_EMAIL=${GOTRUE_ADMIN_EMAIL}
@@ -90,9 +83,6 @@ services:
       - GOTRUE_EXTERNAL_DISCORD_CLIENT_ID=${GOTRUE_EXTERNAL_DISCORD_CLIENT_ID}
       - GOTRUE_EXTERNAL_DISCORD_SECRET=${GOTRUE_EXTERNAL_DISCORD_SECRET}
       - GOTRUE_EXTERNAL_DISCORD_REDIRECT_URI=${GOTRUE_EXTERNAL_DISCORD_REDIRECT_URI}
-      # Prometheus Metrics
-      - GOTRUE_METRICS_ENABLED=true
-      - GOTRUE_METRICS_EXPORTER=prometheus
       - GOTRUE_MAILER_TEMPLATES_CONFIRMATION=${GOTRUE_MAILER_TEMPLATES_CONFIRMATION}
     ports:
       - 9999:9999


### PR DESCRIPTION
1. Prometheus exporter is not working for gotrue in docker compose dev at the moment and delay the start up of gotrue service. Moreover , we are not actually using it.
2. Adding a health check so that gotrue container doesn't start before the database is ready
3. update dev.env.