### PR TITLE
fix: admin frontend should wait for gotrue service to start

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -177,6 +177,8 @@ services:
     networks:
       - shared_network
     depends_on:
+      gotrue:
+        condition: service_healthy
       appflowy_cloud:
         condition: service_started
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
       - ADMIN_FRONTEND_APPFLOWY_CLOUD_URL=${ADMIN_FRONTEND_APPFLOWY_CLOUD_URL:-http://appflowy_cloud:8000}
       - ADMIN_FRONTEND_PATH_PREFIX=${ADMIN_FRONTEND_PATH_PREFIX:-}
     depends_on:
+      gotrue:
+        condition: service_healthy
       appflowy_cloud:
         condition: service_started
 


### PR DESCRIPTION
Admin frontend will crash if gotrue service is not ready.