### PR TITLE
chore: implement custom prompt usage metrics

### DIFF
--- a/libs/appflowy-ai-client/src/dto.rs
+++ b/libs/appflowy-ai-client/src/dto.rs
@@ -430,6 +430,10 @@ pub struct CompletionMetadata {
   /// When completion type is 'CustomPrompt', this field should be provided.
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub custom_prompt: Option<CustomPrompt>,
+  /// The id of the prompt used for the completion
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub prompt_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/appflowy-ai-client/tests/chat_test/completion_test.rs
+++ b/libs/appflowy-ai-client/tests/chat_test/completion_test.rs
@@ -17,6 +17,7 @@ async fn completion_explain_test() {
       rag_ids: None,
       completion_history: None,
       custom_prompt: None,
+      prompt_id: None,
     }),
     format: ResponseFormat::default(),
   };
@@ -40,6 +41,7 @@ async fn completion_image_test() {
       rag_ids: None,
       completion_history: None,
       custom_prompt: None,
+      prompt_id: None,
     }),
     format: ResponseFormat {
       output_content: OutputContent::IMAGE,
@@ -112,6 +114,7 @@ async fn custom_prompt_test() {
       custom_prompt: Some(CustomPrompt {
         system: "You are a talented artist who excels at providing detailed, creative instructions on how to draw a picture".to_string(),
       }),
+      prompt_id: None,
     }),
     format: Default::default(),
   };

--- a/libs/shared-entity/src/dto/chat_dto.rs
+++ b/libs/shared-entity/src/dto/chat_dto.rs
@@ -33,6 +33,9 @@ pub struct CreateChatMessageParams {
   #[validate(custom(function = "validate_not_empty_str"))]
   pub content: String,
   pub message_type: ChatMessageType,
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub prompt_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -166,6 +169,7 @@ impl CreateChatMessageParams {
     Self {
       content: content.to_string(),
       message_type: ChatMessageType::System,
+      prompt_id: None,
     }
   }
 
@@ -173,6 +177,7 @@ impl CreateChatMessageParams {
     Self {
       content: content.to_string(),
       message_type: ChatMessageType::User,
+      prompt_id: None,
     }
   }
 }

--- a/src/api/ai.rs
+++ b/src/api/ai.rs
@@ -41,6 +41,17 @@ async fn stream_complete_text_handler(
   let params = payload.into_inner();
   state.metrics.ai_metrics.record_total_completion_count(1);
 
+  if let Some(prompt_id) = params
+    .metadata
+    .as_ref()
+    .and_then(|metadata| metadata.prompt_id.as_ref())
+  {
+    state
+      .metrics
+      .ai_metrics
+      .record_prompt_usage_count(prompt_id, 1);
+  }
+
   match state
     .ai_client
     .stream_completion_text(params, ai_model)

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -182,6 +182,13 @@ async fn create_question_handler(
   let (_workspace_id, chat_id) = path.into_inner();
   let params = payload.into_inner();
 
+  if let Some(ref prompt_id) = params.prompt_id {
+    state
+      .metrics
+      .ai_metrics
+      .record_prompt_usage_count(prompt_id, 1);
+  }
+
   let uid = state.user_cache.get_user_uid(&uuid).await?;
   let resp = create_chat_message(&state.pg_pool, uid, *uuid, chat_id, params).await?;
   Ok(AppResponse::Ok().with_data(resp).into())

--- a/tests/ai_test/completion_test.rs
+++ b/tests/ai_test/completion_test.rs
@@ -19,6 +19,7 @@ async fn generate_chat_message_answer_test() {
       rag_ids: None,
       completion_history: None,
       custom_prompt: None,
+      prompt_id: None,
     }),
     format: Default::default(),
   };


### PR DESCRIPTION
## Summary by Sourcery

Add support for tracking and recording custom prompt usage metrics by introducing a prompt_usage_count metric, extending DTOs with an optional prompt_id, updating API handlers to log usage, and updating tests to cover the new field.

New Features:
- Track custom prompt usage count per prompt ID in metrics

Enhancements:
- Add optional prompt_id field to chat and AI client DTOs
- Update API handlers to record prompt usage metrics when prompt_id is provided

Tests:
- Update AI client completion tests to include prompt_id in test data