### PR TITLE
feat: add allow guest to access list members endpoint but not retrieving any information but themselves

### DIFF
--- a/libs/database/src/pg_row.rs
+++ b/libs/database/src/pg_row.rs
@@ -4,10 +4,10 @@ use chrono::{DateTime, Utc};
 
 use database_entity::dto::{
   AFAccessLevel, AFRole, AFUserProfile, AFWebUser, AFWebUserWithObfuscatedName, AFWorkspace,
-  AFWorkspaceInvitationStatus, AccessRequestMinimal, AccessRequestStatus, AccessRequestWithViewId,
-  AccessRequesterInfo, AccountLink, GlobalComment, QuickNote, Reaction, Template, TemplateCategory,
-  TemplateCategoryMinimal, TemplateCategoryType, TemplateCreator, TemplateCreatorMinimal,
-  TemplateGroup, TemplateMinimal,
+  AFWorkspaceInvitationStatus, AFWorkspaceMember, AccessRequestMinimal, AccessRequestStatus,
+  AccessRequestWithViewId, AccessRequesterInfo, AccountLink, GlobalComment, QuickNote, Reaction,
+  Template, TemplateCategory, TemplateCategoryMinimal, TemplateCategoryType, TemplateCreator,
+  TemplateCreatorMinimal, TemplateGroup, TemplateMinimal,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
@@ -184,6 +184,18 @@ pub struct AFWorkspaceMemberRow {
   pub avatar_url: Option<String>,
   pub role: AFRole,
   pub created_at: Option<DateTime<Utc>>,
+}
+
+impl From<AFWorkspaceMemberRow> for AFWorkspaceMember {
+  fn from(value: AFWorkspaceMemberRow) -> Self {
+    AFWorkspaceMember {
+      name: value.name.clone(),
+      email: value.email.clone(),
+      role: value.role.clone(),
+      avatar_url: value.avatar_url.clone(),
+      joined_at: value.created_at,
+    }
+  }
 }
 
 #[derive(FromRow)]

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -556,8 +556,8 @@ pub async fn remove_workspace_members(
 pub async fn get_workspace_members(
   pg_pool: &PgPool,
   workspace_id: &Uuid,
-) -> Result<Vec<AFWorkspaceMemberRow>, AppResponseError> {
-  Ok(select_workspace_member_list(pg_pool, workspace_id).await?)
+) -> Result<Vec<AFWorkspaceMemberRow>, AppError> {
+  select_workspace_member_list(pg_pool, workspace_id).await
 }
 
 pub async fn get_workspace_member(

--- a/tests/workspace/member_crud.rs
+++ b/tests/workspace/member_crud.rs
@@ -408,11 +408,11 @@ async fn add_workspace_member_and_then_member_get_member_list() {
   assert_eq!(members.len(), 3);
 
   // guest should not be able to get the member list of the workspace
-  let error = guest
+  let members = guest
     .try_get_workspace_members(&workspace_id)
     .await
-    .unwrap_err();
-  assert_eq!(error.code, ErrorCode::NotEnoughPermissions);
+    .unwrap();
+  assert_eq!(members.len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Allow workspace guest to access the list members endpoint, but the result should not contain information other than their own.

## Summary by Sourcery

Allow workspace guests to call the list members endpoint while restricting returned data to only their own membership information, falling back to the full member list for non-guests.

New Features:
- Enable workspace guests to access the list members endpoint with limited visibility.

Enhancements:
- Return only the requester’s own member data when their role is Guest, otherwise return the full member list.
- Add a From implementation to convert AFWorkspaceMemberRow to AFWorkspaceMember for cleaner mapping.