### PR TITLE
chore: return error if view id is not uuid

### DIFF
--- a/src/biz/search/ops.rs
+++ b/src/biz/search/ops.rs
@@ -117,7 +117,7 @@ pub async fn search_document(
     workspace_uuid,
   )
   .await?;
-  let private_views = private_space_and_trash_view_ids(&folder);
+  let private_views = private_space_and_trash_view_ids(&folder)?;
   let mut searchable_view_ids = HashSet::new();
   populate_searchable_view_ids(
     &folder,

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -533,7 +533,7 @@ pub async fn append_block_at_the_end_of_page(
   view_id: &str,
   serde_blocks: &[SerdeBlock],
 ) -> Result<(), AppError> {
-  let oid = Uuid::parse_str(view_id).unwrap();
+  let oid = Uuid::parse_str(view_id)?;
   let update =
     append_block_to_document_collab(user.uid, collab_storage, workspace_id, oid, serde_blocks)
       .await?;


### PR DESCRIPTION
Under normal circumstances view id is always uuid, so it is normally safe to unwrap it, except in the situation where there is a bug or when someone modified the source code on the client side.