### PR TITLE
feat: add error code for paid plan guest limit

### DIFF
--- a/libs/app-error/src/lib.rs
+++ b/libs/app-error/src/lib.rs
@@ -200,8 +200,11 @@ pub enum AppError {
   #[error("{0} is already a member of the workspace")]
   InvalidGuest(String),
 
-  #[error("workspace guest limit exceeded")]
-  GuestLimitExceeded,
+  #[error("free plan workspace guest limit exceeded")]
+  FreePlanGuestLimitExceeded,
+
+  #[error("paid plan workspace guest limit exceeded")]
+  PaidPlanGuestLimitExceeded,
 }
 
 impl AppError {
@@ -287,7 +290,8 @@ impl AppError {
       AppError::FeatureNotAvailable(_) => ErrorCode::FeatureNotAvailable,
       AppError::InvalidInvitationCode => ErrorCode::InvalidInvitationCode,
       AppError::InvalidGuest(_) => ErrorCode::InvalidGuest,
-      AppError::GuestLimitExceeded => ErrorCode::GuestLimitExceeded,
+      AppError::FreePlanGuestLimitExceeded => ErrorCode::FreePlanGuestLimitExceeded,
+      AppError::PaidPlanGuestLimitExceeded => ErrorCode::PaidPlanGuestLimitExceeded,
     }
   }
 }
@@ -467,7 +471,8 @@ pub enum ErrorCode {
   FeatureNotAvailable = 1067,
   InvalidInvitationCode = 1068,
   InvalidGuest = 1069,
-  GuestLimitExceeded = 1070,
+  FreePlanGuestLimitExceeded = 1070,
+  PaidPlanGuestLimitExceeded = 1071,
 }
 
 impl ErrorCode {


### PR DESCRIPTION
Add error code for paid plan guest limit to distinguish the error between free and paid plan.

## Summary by Sourcery

Add distinct error variants and codes for free and paid plan guest limits to enable clearer error reporting

Enhancements:
- Replace the generic guest-limit error with FreePlanGuestLimitExceeded and PaidPlanGuestLimitExceeded variants
- Update the AppError-to-ErrorCode mapping and enum values to use the new plan-specific error codes