### PR TITLE
feat: add api for create orphaned view

### DIFF
--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -203,6 +203,11 @@ pub struct CreatePageParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateOrphanedViewParams {
+  pub document_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdatePageParams {
   pub name: String,
   pub icon: Option<ViewIcon>,

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -355,6 +355,29 @@ fn prepare_default_document_collab_param(collab_id: Uuid) -> Result<CollabParams
   })
 }
 
+pub async fn create_orphaned_view(
+  uid: i64,
+  pg_pool: &PgPool,
+  collab_storage: &CollabAccessControlStorage,
+  workspace_id: Uuid,
+  document_id: Uuid,
+) -> Result<(), AppError> {
+  let default_document_collab_params = prepare_default_document_collab_param(document_id)?;
+  let mut transaction = pg_pool.begin().await?;
+  let action = format!("Create new orphaned view: {}", document_id);
+  collab_storage
+    .upsert_new_collab_with_transaction(
+      workspace_id,
+      &uid,
+      default_document_collab_params,
+      &mut transaction,
+      &action,
+    )
+    .await?;
+  transaction.commit().await?;
+  Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn prepare_new_encoded_database(
   view_id: &Uuid,


### PR DESCRIPTION
API endpoint to create orphaned view.

## Summary by Sourcery

Add a new API for creating orphaned views, including routing, request handling, business logic, and DTO definition

New Features:
- Introduce POST /{workspace_id}/orphaned-view endpoint to create orphaned views
- Define CreateOrphanedViewParams DTO for specifying document_id
- Implement create_orphaned_view business logic to initialize collaboration and persist orphaned views