### PR TITLE
refactor: remove collab access control

### DIFF
--- a/src/api/access_request.rs
+++ b/src/api/access_request.rs
@@ -41,7 +41,7 @@ async fn get_access_request_handler(
   let uid = state.user_cache.get_user_uid(&uuid).await?;
   let access_request = get_access_request(
     &state.pg_pool,
-    &state.collab_access_control_storage,
+    &state.collab_storage,
     access_request_id,
     uid,
   )

--- a/src/api/data_import.rs
+++ b/src/api/data_import.rs
@@ -63,7 +63,7 @@ async fn create_import_handler(
   let workspace = create_empty_workspace(
     &state.pg_pool,
     state.workspace_access_control.clone(),
-    &state.collab_access_control_storage,
+    &state.collab_storage,
     &user_uuid,
     uid,
     &params.workspace_name,
@@ -209,7 +209,7 @@ async fn import_data_handler(
   let workspace = create_empty_workspace(
     &state.pg_pool,
     state.workspace_access_control.clone(),
-    &state.collab_access_control_storage,
+    &state.collab_storage,
     &user_uuid,
     uid,
     &file.name,

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -40,7 +40,7 @@ async fn document_search_handler(
   let metrics = &*state.metrics.request_metrics;
   let resp = search_document(
     &state.pg_pool,
-    &state.collab_access_control_storage,
+    &state.collab_storage,
     &state.indexer_scheduler,
     uid,
     workspace_id,

--- a/src/api/ws.rs
+++ b/src/api/ws.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, instrument, trace};
 use app_error::AppError;
 use appflowy_collaborate::actix_ws::client::rt_client::RealtimeClient;
 use appflowy_collaborate::actix_ws::server::RealtimeServerActor;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use collab_rt_entity::user::{AFUserChange, RealtimeUser, UserMessage};
 use collab_rt_entity::RealtimeMessage;
 use shared_entity::response::AppResponseError;
@@ -30,7 +30,7 @@ pub fn ws_scope() -> Scope {
 }
 const MAX_FRAME_SIZE: usize = 65_536; // 64 KiB
 
-pub type RealtimeServerAddr = Addr<RealtimeServerActor<CollabAccessControlStorage>>;
+pub type RealtimeServerAddr = Addr<RealtimeServerActor<CollabStorageWithCache>>;
 
 /// This function will not be used after the 0.5.0 of the client.
 #[instrument(skip_all, err)]

--- a/src/biz/access_request/ops.rs
+++ b/src/biz/access_request/ops.rs
@@ -10,7 +10,7 @@ use crate::{
 use access_control::workspace::WorkspaceAccessControl;
 use anyhow::Context;
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use database::{
   access_request::{
     insert_new_access_request, select_access_request_by_request_id, update_access_request_status,
@@ -71,7 +71,7 @@ pub async fn create_access_request(
 
 pub async fn get_access_request(
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   access_request_id: Uuid,
   user_uid: i64,
 ) -> Result<AccessRequest, AppError> {

--- a/src/biz/collab/database.rs
+++ b/src/biz/collab/database.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use async_trait::async_trait;
 use collab::preclude::Collab;
 use collab_database::{
@@ -172,7 +172,7 @@ fn create_card_status_field() -> Field {
 #[derive(Clone)]
 pub struct PostgresDatabaseCollabService {
   pub workspace_id: Uuid,
-  pub collab_storage: Arc<CollabAccessControlStorage>,
+  pub collab_storage: Arc<CollabStorageWithCache>,
 }
 
 impl PostgresDatabaseCollabService {

--- a/src/biz/collab/ops.rs
+++ b/src/biz/collab/ops.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use actix_web::web::Data;
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use chrono::DateTime;
 use chrono::Utc;
 use collab::preclude::Collab;
@@ -85,7 +85,7 @@ use sqlx::types::Uuid;
 use std::collections::HashSet;
 
 pub async fn get_user_favorite_folder_views(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   pg_pool: &PgPool,
   uid: i64,
   workspace_id: Uuid,
@@ -115,7 +115,7 @@ pub async fn get_user_favorite_folder_views(
 }
 
 pub async fn get_user_recent_folder_views(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   pg_pool: &PgPool,
   uid: i64,
   workspace_id: Uuid,
@@ -145,7 +145,7 @@ pub async fn get_user_recent_folder_views(
 }
 
 pub async fn get_user_trash_folder_views(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
 ) -> Result<Vec<TrashFolderView>, AppError> {
@@ -241,7 +241,7 @@ async fn fix_old_workspace_folder(
 pub async fn get_user_workspace_structure(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   pg_pool: &PgPool,
   user: RealtimeUser,
   workspace_id: Uuid,
@@ -276,7 +276,7 @@ pub async fn get_user_workspace_structure(
 }
 
 pub async fn get_latest_workspace_database(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   pg_pool: &PgPool,
   collab_origin: GetCollabOrigin,
   workspace_id: Uuid,
@@ -297,7 +297,7 @@ pub async fn get_latest_workspace_database(
 }
 
 pub async fn get_published_view(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   publish_namespace: String,
   pg_pool: &PgPool,
 ) -> Result<PublishedView, AppError> {
@@ -333,7 +333,7 @@ pub async fn get_published_view(
 
 pub async fn list_database(
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
 ) -> Result<Vec<AFDatabase>, AppError> {
@@ -385,7 +385,7 @@ pub async fn list_database(
 }
 
 pub async fn list_database_row_ids(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_uuid_str: Uuid,
   database_uuid_str: Uuid,
 ) -> Result<Vec<AFDatabaseRow>, AppError> {
@@ -412,7 +412,7 @@ pub async fn list_database_row_ids(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_database_row(
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   pg_pool: &PgPool,
   workspace_uuid: Uuid,
   database_uuid: Uuid,
@@ -595,7 +595,7 @@ pub async fn insert_database_row(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn upsert_database_row(
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   pg_pool: &PgPool,
   workspace_uuid: Uuid,
   database_uuid: Uuid,
@@ -739,7 +739,7 @@ pub async fn upsert_database_row(
 }
 
 pub async fn get_database_fields(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_uuid: Uuid,
   database_uuid: Uuid,
 ) -> Result<Vec<AFDatabaseField>, AppError> {
@@ -765,7 +765,7 @@ pub async fn get_database_fields(
 // returns the id of the field created
 pub async fn add_database_field(
   uid: i64,
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   pg_pool: &PgPool,
   workspace_id: Uuid,
   database_id: Uuid,
@@ -832,7 +832,7 @@ pub async fn add_database_field(
 }
 
 pub async fn list_database_row_ids_updated(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   pg_pool: &PgPool,
   workspace_uuid: Uuid,
   database_uuid: Uuid,
@@ -850,7 +850,7 @@ pub async fn list_database_row_ids_updated(
 }
 
 pub async fn list_database_row_details(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_uuid: Uuid,
   database_uuid: Uuid,

--- a/src/biz/collab/utils.rs
+++ b/src/biz/collab/utils.rs
@@ -1,5 +1,5 @@
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use collab::core::collab::DataSource;
 use collab::preclude::Collab;
 use collab_database::database::DatabaseBody;
@@ -195,7 +195,7 @@ pub fn type_options_serde(
 }
 
 pub async fn get_latest_collab_database_row_body(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   db_row_id: Uuid,
 ) -> Result<(Collab, DatabaseRowBody), AppError> {
@@ -221,7 +221,7 @@ pub async fn get_latest_collab_database_row_body(
 }
 
 pub async fn get_latest_collab_database_body(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   database_id: Uuid,
 ) -> Result<(Collab, DatabaseBody), AppError> {
@@ -248,7 +248,7 @@ pub async fn get_latest_collab_database_body(
 }
 
 pub async fn get_latest_collab_encoded(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   collab_origin: GetCollabOrigin,
   workspace_id: Uuid,
   object_id: Uuid,
@@ -270,7 +270,7 @@ pub async fn get_latest_collab_encoded(
 }
 
 pub async fn batch_get_latest_collab_encoded(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   collab_origin: GetCollabOrigin,
   workspace_id: Uuid,
   oid_list: &[Uuid],
@@ -317,7 +317,7 @@ pub async fn batch_get_latest_collab_encoded(
 }
 
 pub async fn get_latest_collab(
-  storage: &CollabAccessControlStorage,
+  storage: &CollabStorageWithCache,
   origin: GetCollabOrigin,
   workspace_id: Uuid,
   oid: Uuid,
@@ -342,7 +342,7 @@ pub async fn get_latest_collab(
 
 pub async fn get_latest_collab_workspace_database_body(
   pg_pool: &PgPool,
-  storage: &CollabAccessControlStorage,
+  storage: &CollabStorageWithCache,
   origin: GetCollabOrigin,
   workspace_id: Uuid,
 ) -> Result<WorkspaceDatabaseBody, AppError> {
@@ -365,7 +365,7 @@ pub async fn get_latest_collab_workspace_database_body(
 }
 
 pub async fn get_latest_collab_folder(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   collab_origin: GetCollabOrigin,
   workspace_id: Uuid,
 ) -> Result<Folder, AppError> {
@@ -408,7 +408,7 @@ pub async fn get_latest_collab_folder(
 }
 
 pub async fn get_latest_collab_document(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   collab_origin: GetCollabOrigin,
   workspace_id: Uuid,
   doc_oid: Uuid,
@@ -524,7 +524,7 @@ pub async fn create_row_document(
   workspace_id: Uuid,
   uid: i64,
   new_doc_id: Uuid,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   row_doc_content: String,
 ) -> Result<CreatedRowDocument, AppError> {
   let md_importer = MDImporter::new(None);
@@ -573,7 +573,7 @@ pub enum DocChanges {
 }
 
 pub async fn get_database_row_doc_changes(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   row_doc_content: Option<String>,
   db_row_body: &DatabaseRowBody,

--- a/src/biz/search/ops.rs
+++ b/src/biz/search/ops.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use app_error::AppError;
 use appflowy_ai_client::dto::EmbeddingModel;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use collab_folder::{Folder, View};
 use database::collab::GetCollabOrigin;
 use database::index::{search_documents, SearchDocumentParams};
@@ -75,7 +75,7 @@ fn populate_searchable_view_ids(
 #[allow(clippy::too_many_arguments)]
 pub async fn search_document(
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   indexer_scheduler: &Arc<IndexerScheduler>,
   uid: i64,
   workspace_uuid: Uuid,

--- a/src/biz/user/user_init.rs
+++ b/src/biz/user/user_init.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use collab::core::origin::CollabOrigin;
 use collab::preclude::Collab;
 use collab_database::workspace_database::WorkspaceDatabase;
@@ -25,7 +25,7 @@ pub async fn initialize_workspace_for_user<T>(
   row: &AFWorkspaceRow,
   txn: &mut Transaction<'_, sqlx::Postgres>,
   templates: Vec<T>,
-  collab_storage: &Arc<CollabAccessControlStorage>,
+  collab_storage: &Arc<CollabStorageWithCache>,
 ) -> anyhow::Result<(), AppError>
 where
   T: WorkspaceTemplate + Send + Sync + 'static,
@@ -112,7 +112,7 @@ pub(crate) async fn create_user_awareness(
   uid: &i64,
   user_uuid: &Uuid,
   workspace_id: Uuid,
-  storage: &Arc<CollabAccessControlStorage>,
+  storage: &Arc<CollabStorageWithCache>,
   txn: &mut Transaction<'_, sqlx::Postgres>,
 ) -> Result<Uuid, AppError> {
   let object_id = user_awareness_object_id(user_uuid, &workspace_id);
@@ -148,7 +148,7 @@ pub(crate) async fn create_workspace_collab(
   uid: i64,
   workspace_id: Uuid,
   name: &str,
-  storage: &Arc<CollabAccessControlStorage>,
+  storage: &Arc<CollabStorageWithCache>,
   txn: &mut Transaction<'_, sqlx::Postgres>,
 ) -> Result<(), AppError> {
   let workspace = Workspace::new(workspace_id.to_string(), name.to_string(), uid);
@@ -185,7 +185,7 @@ pub(crate) async fn create_workspace_database_collab(
   workspace_id: Uuid,
   uid: &i64,
   object_id: Uuid,
-  storage: &Arc<CollabAccessControlStorage>,
+  storage: &Arc<CollabStorageWithCache>,
   txn: &mut Transaction<'_, sqlx::Postgres>,
   initial_database_records: Vec<(String, String)>,
 ) -> Result<(), AppError> {

--- a/src/biz/user/user_verify.rs
+++ b/src/biz/user/user_verify.rs
@@ -58,7 +58,7 @@ pub async fn verify_token(access_token: &str, state: &AppState) -> Result<bool, 
       &workspace_row,
       &mut txn2,
       vec![GettingStartedTemplate],
-      &state.collab_access_control_storage,
+      &state.collab_storage,
     )
     .await?;
     txn2

--- a/src/biz/workspace/duplicate.rs
+++ b/src/biz/workspace/duplicate.rs
@@ -6,7 +6,7 @@ use std::{
 use actix_web::web::Data;
 use anyhow::anyhow;
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use collab_database::{
   database::{gen_database_id, gen_row_id, timestamp, Database, DatabaseContext, DatabaseData},
   entity::{CreateDatabaseParams, CreateViewParams},
@@ -39,7 +39,7 @@ pub async fn duplicate_view_tree_and_collab(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   pg_pool: &PgPool,
   workspace_id: Uuid,
   view_id: Uuid,
@@ -194,7 +194,7 @@ async fn duplicate_database(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   workspace_id: Uuid,
   duplicate_context: &DuplicateContext,
   workspace_database: &mut WorkspaceDatabase,
@@ -296,7 +296,7 @@ async fn duplicate_database(
 }
 
 async fn duplicate_document(
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   workspace_id: Uuid,
   uid: i64,
   duplicate_context: &DuplicateContext,

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -17,7 +17,7 @@ use yrs::updates::encoder::Encode;
 
 use access_control::workspace::WorkspaceAccessControl;
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use database::file::s3_client_impl::S3BucketStorage;
 use database::pg_row::AFWorkspaceMemberRow;
 
@@ -68,7 +68,7 @@ pub async fn delete_workspace_for_user(
 pub async fn create_empty_workspace(
   pg_pool: &PgPool,
   workspace_access_control: Arc<dyn WorkspaceAccessControl>,
-  collab_storage: &Arc<CollabAccessControlStorage>,
+  collab_storage: &Arc<CollabStorageWithCache>,
   user_uuid: &Uuid,
   user_uid: i64,
   workspace_name: &str,
@@ -115,7 +115,7 @@ pub async fn create_empty_workspace(
 pub async fn create_workspace_for_user(
   pg_pool: &PgPool,
   workspace_access_control: Arc<dyn WorkspaceAccessControl>,
-  collab_storage: &Arc<CollabAccessControlStorage>,
+  collab_storage: &Arc<CollabStorageWithCache>,
   user_uuid: &Uuid,
   user_uid: i64,
   workspace_name: &str,
@@ -706,7 +706,7 @@ pub async fn num_pending_task(uid: i64, pg_pool: &PgPool) -> Result<i64, AppErro
 
 /// broadcast updates to collab group if exists
 pub async fn broadcast_update(
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   oid: Uuid,
   encoded_update: Vec<u8>,
 ) -> Result<(), AppError> {
@@ -731,7 +731,7 @@ pub async fn broadcast_update(
 /// like [broadcast_update] but in separate tokio task
 /// waits for a maximum of 30 seconds for the broadcast to complete
 pub async fn broadcast_update_with_timeout(
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   oid: Uuid,
   encoded_update: Vec<u8>,
 ) -> tokio::task::JoinHandle<()> {

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -17,7 +17,7 @@ use actix_web::web::Data;
 use anyhow::anyhow;
 use app_error::AppError;
 use appflowy_collaborate::actix_ws::entities::ClientHttpUpdateMessage;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use bytes::Bytes;
 use chrono::DateTime;
 use collab::core::collab::Collab;
@@ -76,7 +76,7 @@ pub async fn update_space(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   space_permission: &SpacePermission,
@@ -112,7 +112,7 @@ pub async fn create_space(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   space_permission: &SpacePermission,
   name: &str,
@@ -166,7 +166,7 @@ pub async fn create_folder_view(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   pg_pool: &PgPool,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
@@ -233,7 +233,7 @@ pub async fn create_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   view_layout: &ViewLayout,
@@ -528,7 +528,7 @@ pub async fn append_block_at_the_end_of_page(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   serde_blocks: &[SerdeBlock],
@@ -551,7 +551,7 @@ pub async fn append_block_at_the_end_of_page(
 
 async fn append_block_to_document_collab(
   uid: i64,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   oid: Uuid,
   serde_blocks: &[SerdeBlock],
@@ -1013,7 +1013,7 @@ async fn create_document_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   name: Option<&str>,
@@ -1072,7 +1072,7 @@ async fn create_grid_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   name: Option<&str>,
@@ -1103,7 +1103,7 @@ async fn create_board_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   name: Option<&str>,
@@ -1135,7 +1135,7 @@ async fn create_calendar_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   name: Option<&str>,
@@ -1167,7 +1167,7 @@ async fn create_database_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   view_id: &Uuid,
@@ -1278,7 +1278,7 @@ async fn create_chat_page(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   parent_view_id: &Uuid,
   name: Option<&str>,
@@ -1323,7 +1323,7 @@ pub async fn move_page(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   new_parent_view_id: &str,
@@ -1348,7 +1348,7 @@ pub async fn reorder_favorite_page(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   prev_view_id: Option<&str>,
@@ -1371,7 +1371,7 @@ pub async fn move_page_to_trash(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
 ) -> Result<(), AppError> {
@@ -1397,7 +1397,7 @@ pub async fn restore_page_from_trash(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
 ) -> Result<(), AppError> {
@@ -1419,7 +1419,7 @@ pub async fn add_recent_pages(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   recent_view_ids: Vec<String>,
 ) -> Result<(), AppError> {
@@ -1441,7 +1441,7 @@ pub async fn restore_all_pages_from_trash(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
 ) -> Result<(), AppError> {
   let collab_origin = GetCollabOrigin::User { uid: user.uid };
@@ -1462,7 +1462,7 @@ pub async fn delete_trash(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
 ) -> Result<(), AppError> {
@@ -1478,7 +1478,7 @@ pub async fn delete_all_pages_from_trash(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
 ) -> Result<(), AppError> {
   let uid = user.uid;
@@ -1494,7 +1494,7 @@ pub async fn update_page(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   name: &str,
@@ -1522,7 +1522,7 @@ pub async fn update_page_name(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   name: &str,
@@ -1546,7 +1546,7 @@ pub async fn update_page_icon(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   icon: Option<&ViewIcon>,
@@ -1570,7 +1570,7 @@ pub async fn update_page_extra(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   extra: &str,
@@ -1595,7 +1595,7 @@ pub async fn favorite_page(
   appflowy_web_metrics: &AppFlowyWebMetrics,
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   view_id: &str,
   is_favorite: bool,
@@ -1641,7 +1641,7 @@ fn generate_publish_name(view_id: &str, name: &str) -> String {
 #[allow(clippy::too_many_arguments)]
 pub async fn publish_page(
   pg_pool: &PgPool,
-  collab_access_control_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   publish_collab_store: &dyn PublishedCollabStore,
   uid: i64,
   user_uuid: Uuid,
@@ -1652,12 +1652,8 @@ pub async fn publish_page(
   comments_enabled: bool,
   duplicate_enabled: bool,
 ) -> Result<(), AppError> {
-  let folder = get_latest_collab_folder(
-    collab_access_control_storage,
-    GetCollabOrigin::User { uid },
-    workspace_id,
-  )
-  .await?;
+  let folder =
+    get_latest_collab_folder(collab_storage, GetCollabOrigin::User { uid }, workspace_id).await?;
   let view = folder
     .get_view(&view_id.to_string())
     .ok_or(AppError::InvalidFolderView(format!(
@@ -1689,15 +1685,14 @@ pub async fn publish_page(
 
   let publish_data = match view.layout {
     collab_folder::ViewLayout::Document => {
-      generate_publish_data_for_document(collab_access_control_storage, uid, workspace_id, view_id)
-        .await
+      generate_publish_data_for_document(collab_storage, uid, workspace_id, view_id).await
     },
     collab_folder::ViewLayout::Grid
     | collab_folder::ViewLayout::Board
     | collab_folder::ViewLayout::Calendar => {
       generate_publish_data_for_database(
         pg_pool,
-        collab_access_control_storage,
+        collab_storage,
         uid,
         workspace_id,
         view_id,
@@ -1731,13 +1726,13 @@ pub async fn publish_page(
 }
 
 async fn generate_publish_data_for_document(
-  collab_access_control_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
   view_id: Uuid,
 ) -> Result<Vec<u8>, AppError> {
   let collab = get_latest_collab_encoded(
-    collab_access_control_storage,
+    collab_storage,
     GetCollabOrigin::User { uid },
     workspace_id,
     view_id,
@@ -1749,7 +1744,7 @@ async fn generate_publish_data_for_document(
 
 async fn generate_publish_data_for_database(
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
   view_id: Uuid,
@@ -1845,17 +1840,13 @@ pub async fn unpublish_page(
 
 pub async fn get_page_view_collab(
   pg_pool: &PgPool,
-  collab_access_control_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
   view_id: Uuid,
 ) -> Result<PageCollab, AppError> {
-  let folder = get_latest_collab_folder(
-    collab_access_control_storage,
-    GetCollabOrigin::User { uid },
-    workspace_id,
-  )
-  .await?;
+  let folder =
+    get_latest_collab_folder(collab_storage, GetCollabOrigin::User { uid }, workspace_id).await?;
   let view = folder
     .get_view(&view_id.to_string())
     .ok_or(AppError::InvalidFolderView(format!(
@@ -1906,20 +1897,12 @@ pub async fn get_page_view_collab(
   };
   let page_collab_data = match view.layout {
     collab_folder::ViewLayout::Document => {
-      get_page_collab_data_for_document(collab_access_control_storage, uid, workspace_id, view_id)
-        .await
+      get_page_collab_data_for_document(collab_storage, uid, workspace_id, view_id).await
     },
     collab_folder::ViewLayout::Grid
     | collab_folder::ViewLayout::Board
     | collab_folder::ViewLayout::Calendar => {
-      get_page_collab_data_for_database(
-        pg_pool,
-        collab_access_control_storage,
-        uid,
-        workspace_id,
-        view_id,
-      )
-      .await
+      get_page_collab_data_for_database(pg_pool, collab_storage, uid, workspace_id, view_id).await
     },
     collab_folder::ViewLayout::Chat => Err(AppError::InvalidRequest(
       "Page view for AI chat is not supported at the moment".to_string(),
@@ -1938,7 +1921,7 @@ pub async fn get_page_view_collab(
 
 async fn get_page_collab_data_for_database(
   pg_pool: &PgPool,
-  collab_access_control_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
   view_id: Uuid,
@@ -1953,7 +1936,7 @@ async fn get_page_collab_data_for_database(
       ))
     })?;
   let ws_db = get_latest_collab_encoded(
-    collab_access_control_storage,
+    collab_storage,
     GetCollabOrigin::User { uid },
     workspace_id,
     ws_db_oid,
@@ -1988,7 +1971,7 @@ async fn get_page_collab_data_for_database(
       .database_id
   };
   let db = get_latest_collab_encoded(
-    collab_access_control_storage,
+    collab_storage,
     GetCollabOrigin::User { uid },
     workspace_id,
     Uuid::parse_str(&db_oid)?,
@@ -2042,7 +2025,7 @@ async fn get_page_collab_data_for_database(
       collab_type: CollabType::DatabaseRow,
     })
     .collect();
-  let row_query_collab_results = collab_access_control_storage
+  let row_query_collab_results = collab_storage
     .batch_get_collab(&uid, workspace_id, queries, true)
     .await;
   let row_data = tokio::task::spawn_blocking(move || {
@@ -2083,13 +2066,13 @@ async fn get_page_collab_data_for_database(
 }
 
 async fn get_page_collab_data_for_document(
-  collab_access_control_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   uid: i64,
   workspace_id: Uuid,
   view_id: Uuid,
 ) -> Result<PageCollabData, AppError> {
   let collab = get_latest_collab_encoded(
-    collab_access_control_storage,
+    collab_storage,
     GetCollabOrigin::User { uid },
     workspace_id,
     view_id,
@@ -2115,7 +2098,7 @@ pub async fn create_database_view(
   server: Data<RealtimeServerAddr>,
   user: RealtimeUser,
   pg_pool: &PgPool,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
   database_view_id: &Uuid,
   view_layout: &ViewLayout,

--- a/src/biz/workspace/publish.rs
+++ b/src/biz/workspace/publish.rs
@@ -1,4 +1,4 @@
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use database::{
   collab::GetCollabOrigin,
   publish::{
@@ -203,7 +203,7 @@ pub async fn get_workspace_publish_namespace(
 
 pub async fn list_collab_publish_info(
   publish_collab_store: &dyn PublishedCollabStore,
-  collab_storage: &CollabAccessControlStorage,
+  collab_storage: &CollabStorageWithCache,
   workspace_id: Uuid,
 ) -> Result<Vec<PublishInfoView>, AppError> {
   let folder =

--- a/src/biz/workspace/publish_dup.rs
+++ b/src/biz/workspace/publish_dup.rs
@@ -1,5 +1,5 @@
 use app_error::AppError;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 
 use anyhow::anyhow;
 use bytes::Bytes;
@@ -54,7 +54,7 @@ use super::ops::broadcast_update_with_timeout;
 pub async fn duplicate_published_collab_to_workspace(
   pg_pool: &PgPool,
   bucket_client: AwsS3BucketClientImpl,
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   dest_uid: i64,
   publish_view_id: Uuid,
   dest_workspace_id: Uuid,
@@ -82,7 +82,7 @@ pub async fn duplicate_published_collab_to_workspace(
 pub struct PublishCollabDuplicator {
   /// for fetching and writing folder data
   /// of dest workspace
-  collab_storage: Arc<CollabAccessControlStorage>,
+  collab_storage: Arc<CollabStorageWithCache>,
   /// A map to store the old view_id that was duplicated and new view_id assigned.
   /// If value is none, it means the view_id is not published.
   duplicated_refs: HashMap<Uuid, Option<Uuid>>,
@@ -132,7 +132,7 @@ impl PublishCollabDuplicator {
   pub fn new(
     pg_pool: PgPool,
     bucket_client: AwsS3BucketClientImpl,
-    collab_storage: Arc<CollabAccessControlStorage>,
+    collab_storage: Arc<CollabStorageWithCache>,
     dest_uid: i64,
     dest_workspace_id: Uuid,
     dest_view_id: Uuid,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use access_control::collab::{CollabAccessControl, RealtimeAccessControl};
+use access_control::collab::RealtimeAccessControl;
 use access_control::workspace::WorkspaceAccessControl;
 use anyhow::anyhow;
 use dashmap::DashMap;
@@ -15,7 +15,7 @@ use access_control::metrics::AccessControlMetrics;
 use app_error::AppError;
 use appflowy_ai_client::client::AppFlowyAIClient;
 use appflowy_collaborate::collab::cache::CollabCache;
-use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::storage::CollabStorageWithCache;
 use appflowy_collaborate::metrics::CollabMetrics;
 use appflowy_collaborate::CollabRealtimeMetrics;
 use collab_stream::awareness_gossip::AwarenessGossip;
@@ -46,8 +46,7 @@ pub struct AppState {
   pub awareness_gossip: Arc<AwarenessGossip>,
   pub redis_connection_manager: RedisConnectionManager,
   pub collab_cache: CollabCache,
-  pub collab_access_control_storage: Arc<CollabAccessControlStorage>,
-  pub collab_access_control: Arc<dyn CollabAccessControl>,
+  pub collab_storage: Arc<CollabStorageWithCache>,
   pub workspace_access_control: Arc<dyn WorkspaceAccessControl>,
   pub realtime_access_control: Arc<dyn RealtimeAccessControl>,
   pub bucket_storage: Arc<S3BucketStorage>,


### PR DESCRIPTION
We should replace collab level access control with an Actix middleware instead of having it within the collab storage class.

Casbin is no longer suitable for collab level access control, as we need to check if the parent has access.

For the most part workspace level access control should be sufficient.

## Summary by Sourcery

Remove collab-level access control from the storage layer and shift permission checks to Actix middleware by simplifying and renaming the collab storage implementation, dropping its generic access-control dependency, and updating all API and business logic to use the new caching-only CollabStorageWithCache.

Enhancements:
- Simplify collab storage by removing embedded access-control logic and generic parameterization
- Rename CollabStorageImpl to CollabStorageWithCache and eliminate CollabAccessControlStorage and Casbin integration
- Update all API endpoints and business logic to replace collab_access_control_storage with the new collab_storage

Chores:
- Remove CollabStorageAccessControlImpl, related enforcement methods, and state.collab_access_control fields