### PR TITLE
feat: add autoconfirm query param to share view with guest api

### DIFF
--- a/libs/shared-entity/src/dto/guest_dto.rs
+++ b/libs/shared-entity/src/dto/guest_dto.rs
@@ -51,6 +51,10 @@ pub struct ShareViewWithGuestRequest {
   pub view_id: Uuid,
   pub emails: Vec<String>,
   pub access_level: AFAccessLevel,
+  // If false, the guest will need to accept the invitation before being added officially.
+  // to the workspace.
+  #[serde(default)]
+  pub auto_confirm: bool,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Allow the client to decide whether the guest should be automatically added to the workspace member or not.

## Summary by Sourcery

New Features:
- Introduce auto_confirm boolean flag in the share-with-guest API request to allow clients to control automatic guest addition