### PR TITLE
fix: get page view should support orphaned view

### DIFF
--- a/.sqlx/query-2902fd3a9faa9481754d38b29abb543640c0b5564dca8f0141c7de2b8aab9551.json
+++ b/.sqlx/query-2902fd3a9faa9481754d38b29abb543640c0b5564dca8f0141c7de2b8aab9551.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT oid,workspace_id,deleted_at,created_at,updated_at\n        FROM af_collab\n        WHERE oid = $1 AND partition_key = $2 AND deleted_at IS NULL;\n        ",
+  "query": "\n        SELECT oid,workspace_id,owner_uid,deleted_at,created_at,updated_at\n        FROM af_collab\n        WHERE oid = $1 AND partition_key = $2 AND deleted_at IS NULL;\n        ",
   "describe": {
     "columns": [
       {
@@ -15,16 +15,21 @@
       },
       {
         "ordinal": 2,
+        "name": "owner_uid",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
         "name": "deleted_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "updated_at",
         "type_info": "Timestamptz"
       }
@@ -38,10 +43,11 @@
     "nullable": [
       false,
       false,
+      false,
       true,
       true,
       false
     ]
   },
-  "hash": "7cf981763c361bd1d3bd3a04488419820baca4e44b81753cf632ec6a55ee26d8"
+  "hash": "2902fd3a9faa9481754d38b29abb543640c0b5564dca8f0141c7de2b8aab9551"
 }

--- a/libs/collab-rt-entity/build.rs
+++ b/libs/collab-rt-entity/build.rs
@@ -19,20 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .out_dir("src/")
     .compile_protos(&proto_files, &["proto/"])?;
 
-  // Run rustfmt on the generated files.
-  let files = std::fs::read_dir("src/")?
-    .filter_map(Result::ok)
-    .filter(|entry| {
-      entry
-        .path()
-        .extension()
-        .map(|ext| ext == "rs")
-        .unwrap_or(false)
-    })
-    .map(|entry| entry.path().display().to_string());
-
-  for file in files {
-    Command::new("rustfmt").arg(file).status()?;
-  }
+  // Run cargo fmt to format the code
+  Command::new("cargo").arg("fmt").status()?;
   Ok(())
 }

--- a/libs/database/src/collab/collab_db_ops.rs
+++ b/libs/database/src/collab/collab_db_ops.rs
@@ -266,7 +266,7 @@ where
   sqlx::query_as!(
     AFCollabRowMeta,
     r#"
-        SELECT oid,workspace_id,deleted_at,created_at,updated_at
+        SELECT oid,workspace_id,owner_uid,deleted_at,created_at,updated_at
         FROM af_collab
         WHERE oid = $1 AND partition_key = $2 AND deleted_at IS NULL;
         "#,

--- a/libs/database/src/pg_row.rs
+++ b/libs/database/src/pg_row.rs
@@ -303,7 +303,7 @@ pub struct AFWorkspaceInvitationMinimal {
 pub struct AFCollabRowMeta {
   pub oid: String,
   pub workspace_id: Uuid,
-
+  pub owner_uid: i64,
   pub deleted_at: Option<DateTime<Utc>>,
   pub created_at: Option<DateTime<Utc>>,
   pub updated_at: DateTime<Utc>,


### PR DESCRIPTION
Allow get page view endpoint to retrieve orphaned view.

## Summary by Sourcery

Enable the get page view endpoint to return orphaned document views when they aren’t found in a folder, while refactoring and adjusting collab helper signatures and metadata.

New Features:
- Support retrieving orphaned page views in the get page view endpoint by falling back to a document-based view when no folder view exists.

Enhancements:
- Refactor get_page_view_collab into separate helper functions for views with parents and orphaned views.
- Change internal collab data retrieval functions to accept references for workspace_id and view_id.
- Include owner_uid in AFCollabRowMeta and update the corresponding SQL query.