### PR TITLE
fix: filter out guests from list members

### DIFF
--- a/.sqlx/query-8cd79c307813a509119230c7673f86471463a06ad9a84764da8d5bb1e6168e1c.json
+++ b/.sqlx/query-8cd79c307813a509119230c7673f86471463a06ad9a84764da8d5bb1e6168e1c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n    SELECT\n      af_user.uid,\n      af_user.name,\n      af_user.email,\n      af_user.metadata ->> 'icon_url' AS avatar_url,\n      af_workspace_member.role_id AS role,\n      af_workspace_member.created_at\n    FROM public.af_workspace_member\n        JOIN public.af_user ON af_workspace_member.uid = af_user.uid\n    WHERE af_workspace_member.workspace_id = $1\n    ORDER BY af_workspace_member.created_at ASC;\n    ",
+  "query": "\n    SELECT\n      af_user.uid,\n      af_user.name,\n      af_user.email,\n      af_user.metadata ->> 'icon_url' AS avatar_url,\n      af_workspace_member.role_id AS role,\n      af_workspace_member.created_at\n    FROM public.af_workspace_member\n        JOIN public.af_user ON af_workspace_member.uid = af_user.uid\n    WHERE af_workspace_member.workspace_id = $1\n    AND role_id != $2\n    ORDER BY af_workspace_member.created_at ASC;\n    ",
   "describe": {
     "columns": [
       {
@@ -36,7 +36,8 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Int4"
       ]
     },
     "nullable": [
@@ -48,5 +49,5 @@
       true
     ]
   },
-  "hash": "5a138792392ddd8f7572b6fe08b6d52bd8deef885337099ab9b62d6b5f997efc"
+  "hash": "8cd79c307813a509119230c7673f86471463a06ad9a84764da8d5bb1e6168e1c"
 }

--- a/libs/database/src/workspace.rs
+++ b/libs/database/src/workspace.rs
@@ -528,9 +528,11 @@ pub async fn select_workspace_member_list(
     FROM public.af_workspace_member
         JOIN public.af_user ON af_workspace_member.uid = af_user.uid
     WHERE af_workspace_member.workspace_id = $1
+    AND role_id != $2
     ORDER BY af_workspace_member.created_at ASC;
     "#,
-    workspace_id
+    workspace_id,
+    AFRole::Guest as i32,
   )
   .fetch_all(pg_pool)
   .await?;

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -634,6 +634,8 @@ async fn post_workspace_settings_handler(
   Ok(AppResponse::Ok().with_data(settings).into())
 }
 
+/// A workspace member/owner can view all members of the workspace, except for guests.
+/// A guest can only view their own information.
 #[instrument(skip_all, err)]
 async fn get_workspace_members_handler(
   user_uuid: UserUuid,

--- a/tests/workspace/member_crud.rs
+++ b/tests/workspace/member_crud.rs
@@ -175,10 +175,9 @@ async fn update_workspace_member_role_from_guest_to_member() {
     .get_workspace_members(&workspace_id)
     .await
     .unwrap();
+  assert_eq!(members.len(), 1);
   assert_eq!(members[0].email, owner.email().await);
   assert_eq!(members[0].role, AFRole::Owner);
-  assert_eq!(members[1].email, guest.email().await);
-  assert_eq!(members[1].role, AFRole::Guest);
 
   owner
     .try_update_workspace_member(&workspace_id, &guest, AFRole::Member)
@@ -225,7 +224,7 @@ async fn workspace_add_member() {
     .get_workspace_members(&workspace_id)
     .await
     .unwrap();
-  assert_eq!(members.len(), 4);
+  assert_eq!(members.len(), 3);
   assert_eq!(members[0].email, owner.email().await);
   assert_eq!(members[0].role, AFRole::Owner);
 
@@ -234,9 +233,6 @@ async fn workspace_add_member() {
 
   assert_eq!(members[2].email, member.email().await);
   assert_eq!(members[2].role, AFRole::Member);
-
-  assert_eq!(members[3].email, guest.email().await);
-  assert_eq!(members[3].role, AFRole::Guest);
 }
 
 #[tokio::test]
@@ -403,11 +399,11 @@ async fn add_workspace_member_and_then_member_get_member_list() {
     .await
     .unwrap();
 
-  // member should be able to get the member list of the workspace
+  // member should be able to get the member list of the workspace, guest should be excluded
   let members = member.get_workspace_members(&workspace_id).await;
-  assert_eq!(members.len(), 3);
+  assert_eq!(members.len(), 2);
 
-  // guest should not be able to get the member list of the workspace
+  // guest should not be able to get the member list of the workspace, only their own info
   let members = guest
     .try_get_workspace_members(&workspace_id)
     .await


### PR DESCRIPTION
Exclude guests from workspace member list.

## Summary by Sourcery

Bug Fixes:
- Filter out members with the guest role when selecting workspace members