### PR TITLE
fix: use invalid folder view error code when view not found

### DIFF
--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -2308,10 +2308,9 @@ async fn get_page_collab_data_for_document(
   )
   .await
   .map_err(|err| {
-    AppError::Internal(anyhow::anyhow!(
-      "Unable to get page collab data for {}: {}",
-      view_id,
-      err
+    AppError::InvalidFolderView(format!(
+      "Unable to get latest collab for view {}: {}",
+      view_id, err
     ))
   })?;
   Ok(PageCollabData {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Return AppError::InvalidFolderView instead of Internal when failing to retrieve collaboration data for a non-existent view and update the error message