### PR TITLE
chore: when encoded collab failed to deserialize log object id

### DIFF
--- a/services/appflowy-collaborate/src/collab/cache/mem_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/mem_cache.rs
@@ -1,4 +1,4 @@
-use crate::collab::cache::encode_collab_from_bytes;
+use crate::collab::cache::decode_encoded_collab;
 use crate::CollabMetrics;
 use anyhow::anyhow;
 use app_error::AppError;
@@ -109,9 +109,7 @@ impl CollabMemCache {
   pub async fn get_encode_collab(&self, object_id: &Uuid) -> Option<(Rid, EncodedCollab)> {
     match self.get_data_with_timestamp(object_id).await {
       Ok(Some((timestamp, bytes))) => {
-        let encoded_collab = encode_collab_from_bytes(&self.thread_pool, bytes)
-          .await
-          .ok()?;
+        let encoded_collab = decode_encoded_collab(&self.thread_pool, bytes).await.ok()?;
         let rid = Rid::new(timestamp, 0);
         Some((rid, encoded_collab))
       },

--- a/services/appflowy-collaborate/src/collab/cache/mod.rs
+++ b/services/appflowy-collaborate/src/collab/cache/mod.rs
@@ -10,10 +10,10 @@ use std::sync::Arc;
 /// Threshold for spawning blocking tasks for decoding operations.
 /// Data smaller than this will be processed on the current thread for efficiency.
 /// Data larger than this will be spawned to avoid blocking the current thread.
-pub const DECODE_SPAWN_THRESHOLD: usize = 4096; // 4KB
+pub const DECODE_SPAWN_THRESHOLD: usize = 64 * 1024; // 64KiB
 
 #[inline]
-pub(crate) async fn encode_collab_from_bytes(
+pub(crate) async fn decode_encoded_collab(
   thread_pool: &Arc<ThreadPoolNoAbort>,
   bytes: Vec<u8>,
 ) -> Result<EncodedCollab, AppError> {


### PR DESCRIPTION
## Summary by Sourcery

Replace the legacy encoder function with a dedicated decoder for collab data, enhance error handling for deserialization failures, and adjust threading thresholds for heavier payloads

Bug Fixes:
- Map deserialization failures to internal errors with descriptive messages when reading collab data from Postgres

Enhancements:
- Rename encode_collab_from_bytes to decode_encoded_collab and update corresponding cache calls
- Increase DECODE_SPAWN_THRESHOLD from 4 KB to 64 KiB to defer larger decoding tasks to the thread pool