### PR TITLE
feat: add ancestor view ids as request parameter

### DIFF
--- a/libs/client-api/src/http_guest.rs
+++ b/libs/client-api/src/http_guest.rs
@@ -1,9 +1,8 @@
 use client_api_entity::guest_dto::{
-  ListSharedViewResponse, RevokeSharedViewAccessRequest, ShareViewWithGuestRequest,
-  SharedViewDetails,
+  ListSharedViewResponse, QuerySharedViewDetailsParams, RevokeSharedViewAccessRequest,
+  ShareViewWithGuestRequest, SharedViewDetails,
 };
 use reqwest::Method;
-use serde_json::json;
 use shared_entity::response::AppResponseError;
 use uuid::Uuid;
 
@@ -58,7 +57,6 @@ impl Client {
     let resp = self
       .http_client_with_auth(Method::GET, &url)
       .await?
-      .json(&json!({}))
       .send()
       .await?;
     process_response_data(resp).await
@@ -68,6 +66,7 @@ impl Client {
     &self,
     workspace_id: &Uuid,
     view_id: &Uuid,
+    ancestor_view_ids: &[Uuid],
   ) -> Result<SharedViewDetails, AppResponseError> {
     let url = format!(
       "{}/api/sharing/workspace/{}/view/{}",
@@ -76,7 +75,9 @@ impl Client {
     let resp = self
       .http_client_with_auth(Method::GET, &url)
       .await?
-      .json(&json!({}))
+      .query(&QuerySharedViewDetailsParams {
+        ancestor_view_ids: ancestor_view_ids.to_vec(),
+      })
       .send()
       .await?;
     process_response_data(resp).await

--- a/libs/shared-entity/src/dto/guest_dto.rs
+++ b/libs/shared-entity/src/dto/guest_dto.rs
@@ -27,6 +27,11 @@ pub struct SharedViewDetails {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuerySharedViewDetailsParams {
+  pub ancestor_view_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListSharedViewResponse {
   pub shared_views: Vec<SharedView>,
 }

--- a/src/api/guest.rs
+++ b/src/api/guest.rs
@@ -2,8 +2,8 @@ use actix_web::{web::Data, Result};
 use app_error::ErrorCode;
 use shared_entity::{
   dto::guest_dto::{
-    ListSharedViewResponse, RevokeSharedViewAccessRequest, ShareViewWithGuestRequest,
-    SharedViewDetails,
+    ListSharedViewResponse, QuerySharedViewDetailsParams, RevokeSharedViewAccessRequest,
+    ShareViewWithGuestRequest, SharedViewDetails,
   },
   response::{AppResponseError, JsonAppResponse},
 };
@@ -65,6 +65,7 @@ async fn put_shared_view_handler(
 async fn get_shared_view_handler(
   _user_uuid: UserUuid,
   _state: Data<AppState>,
+  _query: web::Query<QuerySharedViewDetailsParams>,
   _path: web::Path<(Uuid, Uuid)>,
 ) -> Result<JsonAppResponse<SharedViewDetails>> {
   Err(


### PR DESCRIPTION
Add ancestor id as request parameters so that we don't have to query the folder collab to check permission.

## Summary by Sourcery

Accept ancestor_view_ids as a query parameter in shared view endpoints to eliminate extra folder collaboration permission lookups.

New Features:
- Introduce QuerySharedViewsParams and QuerySharedViewDetailsParams structs with ancestor_view_ids field.
- Update client get_shared_views and get_shared_view methods to include ancestor_view_ids in query parameters.
- Extend server list_shared_views_handler and get_shared_view_handler to accept and process ancestor_view_ids query parameter.