### PR TITLE
fix: fix guest details endpoint

### DIFF
--- a/libs/client-api/src/http_guest.rs
+++ b/libs/client-api/src/http_guest.rs
@@ -69,7 +69,7 @@ impl Client {
     ancestor_view_ids: &[Uuid],
   ) -> Result<SharedViewDetails, AppResponseError> {
     let url = format!(
-      "{}/api/sharing/workspace/{}/view/{}",
+      "{}/api/sharing/workspace/{}/view/{}/access-details",
       self.base_url, workspace_id, view_id,
     );
     let resp = self


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include the '/access-details' suffix in the workspace view guest details endpoint path