### PR TITLE
feat: return view id with no access in shared views api

### DIFF
--- a/libs/client-api/src/http_guest.rs
+++ b/libs/client-api/src/http_guest.rs
@@ -1,6 +1,6 @@
 use client_api_entity::guest_dto::{
-  ListSharedViewResponse, RevokeSharedViewAccessRequest, ShareViewWithGuestRequest,
-  SharedViewDetails, SharedViewDetailsRequest,
+  RevokeSharedViewAccessRequest, ShareViewWithGuestRequest, SharedViewDetails,
+  SharedViewDetailsRequest, SharedViews,
 };
 use reqwest::Method;
 use shared_entity::response::AppResponseError;
@@ -49,7 +49,7 @@ impl Client {
   pub async fn get_shared_views(
     &self,
     workspace_id: &Uuid,
-  ) -> Result<ListSharedViewResponse, AppResponseError> {
+  ) -> Result<SharedViews, AppResponseError> {
     let url = format!(
       "{}/api/sharing/workspace/{}/view",
       self.base_url, workspace_id,

--- a/libs/shared-entity/src/dto/guest_dto.rs
+++ b/libs/shared-entity/src/dto/guest_dto.rs
@@ -32,8 +32,9 @@ pub struct SharedViewDetailsRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ListSharedViewResponse {
+pub struct SharedViews {
   pub shared_views: Vec<SharedView>,
+  pub view_id_with_no_access: Vec<Uuid>,
 }
 
 pub struct SharedFolderView {

--- a/src/api/guest.rs
+++ b/src/api/guest.rs
@@ -5,8 +5,8 @@ use actix_web::{
 use app_error::ErrorCode;
 use shared_entity::{
   dto::guest_dto::{
-    ListSharedViewResponse, RevokeSharedViewAccessRequest, ShareViewWithGuestRequest,
-    SharedViewDetails, SharedViewDetailsRequest,
+    RevokeSharedViewAccessRequest, ShareViewWithGuestRequest, SharedViewDetails,
+    SharedViewDetailsRequest, SharedViews,
   },
   response::{AppResponseError, JsonAppResponse},
 };
@@ -41,7 +41,7 @@ async fn list_shared_views_handler(
   _user_uuid: UserUuid,
   _state: Data<AppState>,
   _path: web::Path<Uuid>,
-) -> Result<JsonAppResponse<ListSharedViewResponse>> {
+) -> Result<JsonAppResponse<SharedViews>> {
   Err(
     AppResponseError::new(
       ErrorCode::FeatureNotAvailable,


### PR DESCRIPTION
## Summary by Sourcery

Return a list of view IDs with no access in the shared views API response and propagate the updated DTO name across the codebase

New Features:
- Add view_id_with_no_access list to the shared views API response

Enhancements:
- Rename ListSharedViewResponse to SharedViews across client and server code
- Update get_shared_views client method and list_shared_views_handler return types to use the renamed SharedViews DTO