### PR TITLE
chore: fix minor typo in nginx.conf comment

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -166,7 +166,7 @@ http {
 
         # Minio Web UI
         # Derive from: https://min.io/docs/minio/linux/integrations/setup-nginx-proxy-with-minio.html
-        # Optional Module, comment this section if you are did not deploy minio in docker-compose.yml
+        # Optional Module, comment this section if you did not deploy minio in docker-compose.yml
         # This endpoint is meant to be used for the MinIO Web UI, accessible via the admin portal
         location /minio/ {
             proxy_pass $minio_backend;
@@ -194,7 +194,7 @@ http {
             chunked_transfer_encoding off;
         }
 
-        # Optional Module, comment this section if you are did not deploy minio in docker-compose.yml
+        # Optional Module, comment this section if you did not deploy minio in docker-compose.yml
         # This is used for presigned url, which is needs to be exposed to the AppFlowy client application.
         location /minio-api/ {
             proxy_pass $minio_api_backend;
@@ -215,7 +215,7 @@ http {
         }
 
         # PgAdmin
-        # Optional Module, comment this section if you are did not deploy pgadmin in docker-compose.yml
+        # Optional Module, comment this section if you did not deploy pgadmin in docker-compose.yml
         location /pgadmin/ {
             set $pgadmin pgadmin;
             proxy_pass $pgadmin_backend;
@@ -227,7 +227,7 @@ http {
         }
 
         # Admin Frontend
-        # Optional Module, comment this section if you are did not deploy admin_frontend in docker-compose.yml
+        # Optional Module, comment this section if you did not deploy admin_frontend in docker-compose.yml
         location /console {
             proxy_pass $admin_frontend_backend;
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Fix "did not deploy" typo to "did not deploy" in nginx.conf comments for MinIO, pgAdmin, and admin frontend