### PR TITLE
fix: batch fetch collab from redis stream

### DIFF
--- a/libs/database/src/collab/collab_storage.rs
+++ b/libs/database/src/collab/collab_storage.rs
@@ -132,7 +132,6 @@ pub trait CollabStorage: Send + Sync + 'static {
     uid: &i64,
     workspace_id: Uuid,
     queries: Vec<QueryCollab>,
-    from_editing_collab: bool,
   ) -> HashMap<Uuid, QueryCollabResult>;
 
   /// Deletes a collaboration from the storage.

--- a/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
@@ -158,7 +158,8 @@ impl CollabCache {
     Ok(())
   }
 
-  pub async fn get_encode_collab(
+  #[instrument(level = "trace", skip_all)]
+  pub async fn get_snapshot_collab(
     &self,
     workspace_id: &Uuid,
     query: QueryCollab,
@@ -221,7 +222,7 @@ impl CollabCache {
     encoding: EncoderVersion,
   ) -> Result<(Rid, EncodedCollab), AppError> {
     let object_id = query.object_id;
-    let (rid, mut encoded_collab) = match self.get_encode_collab(workspace_id, query).await {
+    let (rid, mut encoded_collab) = match self.get_snapshot_collab(workspace_id, query).await {
       Ok((rid, encoded_collab)) => (rid, Some(encoded_collab)),
       Err(AppError::RecordNotFound(_)) => (Rid::default(), None),
       Err(err) => return Err(err),
@@ -231,41 +232,20 @@ impl CollabCache {
     if !self.dirty_collabs.contains(&object_id) {
       // there are no pending updates for this collab, so we can return the cached value directly
       tracing::trace!("no pending updates for collab: {}", object_id);
-      match encoded_collab {
+      return match encoded_collab {
         Some(encoded_collab) if encoded_collab.doc_state.len() <= self.small_collab_size => {
-          return Ok((rid, encoded_collab));
+          Ok((rid, encoded_collab))
         },
         Some(encoded_collab) => {
           // If the collab is large, we do not replay updates and return the snapshot only.
-          let options = CollabOptions::new(object_id.to_string(), default_client_id())
-            .with_data_source(match encoded_collab.version {
-              EncoderVersion::V1 => DataSource::DocStateV1(encoded_collab.doc_state.into()),
-              EncoderVersion::V2 => DataSource::DocStateV2(encoded_collab.doc_state.into()),
-            });
-          let collab = Collab::new_with_options(CollabOrigin::Server, options)
-            .map_err(|err| AppError::Internal(err.into()))?;
-          let tx = collab.transact();
-          let doc_state: Bytes = match encoded_collab.version {
-            EncoderVersion::V1 => tx.encode_diff_v1(&from),
-            EncoderVersion::V2 => tx.encode_diff_v2(&from),
-          }
-          .into();
-          return Ok((
-            rid,
-            EncodedCollab {
-              version: encoded_collab.version,
-              state_vector: encoded_collab.state_vector,
-              doc_state,
-            },
-          ));
+          let diff_encoded = self.encode_diff_for_large_collab(object_id, encoded_collab, &from)?;
+          Ok((rid, diff_encoded))
         },
-        None => {
-          return Err(AppError::RecordNotFound(format!(
-            "Collab not found for object_id: {}",
-            object_id
-          )));
-        },
-      }
+        None => Err(AppError::RecordNotFound(format!(
+          "Collab not found for object_id: {}",
+          object_id
+        ))),
+      };
     }
 
     let updates = self
@@ -324,9 +304,11 @@ impl CollabCache {
       .await
   }
 
-  /// Batch get the encoded collab data from the cache.
-  /// returns a hashmap of the object_id to the encoded collab data.
-  pub async fn batch_get_encode_collab<T: Into<QueryCollab>>(
+  /// Batch get the encoded collab **SNAPSHOT** data from the cache.
+  /// This function only returns cached/stored data and does NOT apply pending updates.
+  /// Use batch_get_full_collab() if you need current state with updates applied.
+  /// Returns a hashmap of the object_id to the encoded collab data.
+  pub async fn batch_get_snapshot_collab<T: Into<QueryCollab>>(
     &self,
     workspace_id: &Uuid,
     queries: Vec<T>,
@@ -364,6 +346,72 @@ impl CollabCache {
       .batch_get_collab(workspace_id, disk_queries)
       .await;
     results.extend(values_from_disk_cache);
+    results
+  }
+
+  /// Batch get the encoded collab data from the cache (DEPRECATED).
+  /// This function is deprecated - use batch_get_snapshot_collab() or batch_get_full_collab() instead.
+  /// Returns a hashmap of the object_id to the encoded collab data.
+  #[deprecated(
+    note = "Use batch_get_snapshot_collab() for snapshots or batch_get_full_collab() for current state"
+  )]
+  pub async fn batch_get_encode_collab<T: Into<QueryCollab>>(
+    &self,
+    workspace_id: &Uuid,
+    queries: Vec<T>,
+  ) -> HashMap<Uuid, QueryCollabResult> {
+    self.batch_get_snapshot_collab(workspace_id, queries).await
+  }
+
+  /// Batch get the FULL/CURRENT collab data (applying pending updates for dirty collabs).
+  /// This function is consistent with get_full_collab - it applies pending updates.
+  /// Returns a hashmap of the object_id to the encoded collab data.
+  pub async fn batch_get_full_collab<T: Into<QueryCollab>>(
+    &self,
+    workspace_id: &Uuid,
+    queries: Vec<T>,
+    from: Option<StateVector>,
+    encoding: EncoderVersion,
+  ) -> HashMap<Uuid, QueryCollabResult> {
+    let queries = queries.into_iter().map(Into::into).collect::<Vec<_>>();
+    let mut results = HashMap::new();
+
+    // For batch efficiency, separate dirty and clean collabs
+    let mut clean_queries = Vec::new();
+    let mut dirty_queries = Vec::new();
+
+    for query in queries {
+      if self.dirty_collabs.contains(&query.object_id) {
+        dirty_queries.push(query);
+      } else {
+        clean_queries.push(query);
+      }
+    }
+
+    // Process clean collabs in batch (more efficient)
+    if !clean_queries.is_empty() {
+      let clean_results = self
+        .batch_get_snapshot_collab(workspace_id, clean_queries)
+        .await;
+      results.extend(clean_results);
+    }
+
+    // Process dirty collabs individually (need to apply updates)
+    for query in dirty_queries {
+      let object_id = query.object_id;
+      if let Ok((_, encoded_collab)) = self
+        .get_full_collab(workspace_id, query, from.clone(), encoding.clone())
+        .await
+      {
+        results.insert(
+          object_id,
+          QueryCollabResult::Success {
+            encode_collab_v1: encoded_collab.doc_state.to_vec(),
+          },
+        );
+      }
+    }
+
     results
   }
 
@@ -538,6 +586,37 @@ impl CollabCache {
     }
 
     Ok(())
+  }
+
+  /// Encode diff for a large collab without full replay (optimization for clean large collabs)
+  fn encode_diff_for_large_collab(
+    &self,
+    object_id: Uuid,
+    encoded_collab: EncodedCollab,
+    from: &StateVector,
+  ) -> Result<EncodedCollab, AppError> {
+    let options = CollabOptions::new(object_id.to_string(), default_client_id()).with_data_source(
+      match encoded_collab.version {
+        EncoderVersion::V1 => DataSource::DocStateV1(encoded_collab.doc_state.into()),
+        EncoderVersion::V2 => DataSource::DocStateV2(encoded_collab.doc_state.into()),
+      },
+    );
+
+    let collab = Collab::new_with_options(CollabOrigin::Server, options)
+      .map_err(|err| AppError::Internal(err.into()))?;
+
+    let tx = collab.transact();
+    let doc_state: Bytes = match encoded_collab.version {
+      EncoderVersion::V1 => tx.encode_diff_v1(from),
+      EncoderVersion::V2 => tx.encode_diff_v2(from),
+    }
+    .into();
+
+    Ok(EncodedCollab {
+      version: encoded_collab.version,
+      state_vector: encoded_collab.state_vector,
+      doc_state,
+    })
   }
 }
 

--- a/services/appflowy-collaborate/src/ws2/collab_store.rs
+++ b/services/appflowy-collaborate/src/ws2/collab_store.rs
@@ -81,7 +81,7 @@ impl CollabStore {
   ) -> AppResult<(Rid, Bytes)> {
     match self
       .collab_cache
-      .get_encode_collab(&workspace_id, QueryCollab::new(object_id, collab_type))
+      .get_snapshot_collab(&workspace_id, QueryCollab::new(object_id, collab_type))
       .await
     {
       Ok((rid, collab)) => Ok((rid, collab.doc_state)),

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1963,7 +1963,7 @@ async fn batch_get_collab_handler(
   let result = BatchQueryCollabResult(
     state
       .collab_access_control_storage
-      .batch_get_collab(&uid, workspace_id, payload.into_inner().0, false)
+      .batch_get_collab(&uid, workspace_id, payload.into_inner().0)
       .await,
   );
   Ok(Json(AppResponse::Ok().with_data(result)))

--- a/src/biz/collab/ops.rs
+++ b/src/biz/collab/ops.rs
@@ -924,7 +924,7 @@ pub async fn list_database_row_details(
     })
     .collect();
   let mut db_row_details = collab_storage
-    .batch_get_collab(&uid, workspace_uuid, query_collabs, true)
+    .batch_get_collab(&uid, workspace_uuid, query_collabs)
     .await
     .into_iter()
     .flat_map(|(id, result)| match result {
@@ -994,7 +994,7 @@ pub async fn list_database_row_details(
       })
       .collect::<Vec<_>>();
     let mut query_res = collab_storage
-      .batch_get_collab(&uid, workspace_uuid, query_db_docs, true)
+      .batch_get_collab(&uid, workspace_uuid, query_db_docs)
       .await;
     for row_detail in &mut db_row_details {
       if let Err(err) = fill_in_db_row_doc(client_id, row_detail, &doc_id_by_row_id, &mut query_res)

--- a/src/biz/collab/utils.rs
+++ b/src/biz/collab/utils.rs
@@ -289,7 +289,7 @@ pub async fn batch_get_latest_collab_encoded(
     })
     .collect();
   let query_collab_results = collab_storage
-    .batch_get_collab(&uid, workspace_id, queries, true)
+    .batch_get_collab(&uid, workspace_id, queries)
     .await;
   let encoded_collabs = tokio::task::spawn_blocking(move || {
     let collabs: HashMap<_, EncodedCollab> = query_collab_results

--- a/src/biz/workspace/duplicate.rs
+++ b/src/biz/workspace/duplicate.rs
@@ -323,7 +323,7 @@ async fn duplicate_document(
     })
     .collect();
   let query_results = collab_storage
-    .batch_get_collab(&uid, workspace_id, queries, true)
+    .batch_get_collab(&uid, workspace_id, queries)
     .await;
   let mut collab_params_list = vec![];
   for (collab_id, query_result) in query_results {

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -2254,7 +2254,7 @@ async fn get_page_collab_data_for_database(
     })
     .collect();
   let row_query_collab_results = collab_access_control_storage
-    .batch_get_collab(&uid, *workspace_id, queries, true)
+    .batch_get_collab(&uid, *workspace_id, queries)
     .await;
   let row_data = tokio::task::spawn_blocking(move || {
     let row_collabs: HashMap<_, _> = row_query_collab_results


### PR DESCRIPTION
## Summary by Sourcery

Improve the xtask harness with flexible build profiles and parallel server orchestration, refactor collab caching to cleanly separate snapshot vs. full state retrieval in batch, and streamline storage and API by removing legacy boolean flags.

New Features:
- Add new CLI flags (--no-worker, --ci, --release, --profiling) to xtask for controlling worker inclusion and build profiles

Enhancements:
- Automatically configure sccache and CARGO_INCREMENTAL in xtask and parallelize server startup with improved process monitoring
- Rename get_encode_collab to get_snapshot_collab, introduce batch_get_snapshot_collab and batch_get_full_collab, and deprecate batch_get_encode_collab in the collab cache
- Add encode_diff_for_large_collab helper to optimize diff encoding for large clean collabs
- Streamline storage layer batch fetching by delegating to batch_get_full_collab and remove complex legacy partition logic
- Remove deprecated boolean flag from batch_get_collab signature and update all related call sites accordingly