### PR TITLE
chore: Write update to redis stream directly

### DIFF
--- a/services/appflowy-collaborate/src/collab/mod.rs
+++ b/services/appflowy-collaborate/src/collab/mod.rs
@@ -1,4 +1,5 @@
 pub mod access_control;
 pub mod cache;
 pub mod storage;
+pub mod update_publish;
 pub mod validator;

--- a/services/appflowy-collaborate/src/collab/update_publish.rs
+++ b/services/appflowy-collaborate/src/collab/update_publish.rs
@@ -1,0 +1,66 @@
+use crate::collab::cache::CollabCache;
+use anyhow::anyhow;
+use appflowy_proto::{ObjectId, Rid, UpdateFlags, WorkspaceId};
+use collab::core::origin::CollabOrigin;
+use collab_entity::CollabType;
+use collab_stream::model::UpdateStreamMessage;
+use redis::aio::ConnectionManager;
+use redis::streams::{StreamTrimOptions, StreamTrimmingMode};
+use redis::AsyncCommands;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::trace;
+
+pub struct CollabUpdateWriter {
+  connection_manager: ConnectionManager,
+  collab_cache: Arc<CollabCache>,
+}
+
+impl CollabUpdateWriter {
+  pub fn new(connection_manager: ConnectionManager, collab_cache: Arc<CollabCache>) -> Self {
+    Self {
+      connection_manager,
+      collab_cache,
+    }
+  }
+  pub async fn publish_update(
+    &self,
+    workspace_id: WorkspaceId,
+    object_id: ObjectId,
+    collab_type: CollabType,
+    sender: &CollabOrigin,
+    update: Vec<u8>,
+  ) -> anyhow::Result<Rid> {
+    let key = UpdateStreamMessage::stream_key(&workspace_id);
+    let mut conn = self.connection_manager.clone();
+    let items: String = UpdateStreamMessage::prepare_command(
+      &key,
+      &object_id,
+      collab_type,
+      sender,
+      update,
+      UpdateFlags::Lib0v1.into(),
+    )
+    .query_async(&mut conn)
+    .await?;
+    self.collab_cache.mark_as_dirty(object_id);
+
+    let rid = Rid::from_str(&items).map_err(|err| anyhow!("failed to parse rid: {}", err))?;
+    trace!(
+      "publishing update to '{}' (object id: {}), rid:{}",
+      key,
+      object_id,
+      rid
+    );
+    Ok(rid)
+  }
+
+  pub async fn prune_updates(&self, workspace_id: WorkspaceId, up_to: Rid) -> anyhow::Result<()> {
+    let key = UpdateStreamMessage::stream_key(&workspace_id);
+    let mut conn = self.connection_manager.clone();
+    let options = StreamTrimOptions::minid(StreamTrimmingMode::Exact, up_to.to_string());
+    let _: redis::Value = conn.xtrim_options(key, &options).await?;
+    tracing::info!("pruned updates from workspace {}", workspace_id);
+    Ok(())
+  }
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -38,6 +38,7 @@ use appflowy_ai_client::client::AppFlowyAIClient;
 use appflowy_collaborate::actix_ws::server::RealtimeServerActor;
 use appflowy_collaborate::collab::cache::CollabCache;
 use appflowy_collaborate::collab::storage::CollabStorageImpl;
+use appflowy_collaborate::collab::update_publish::CollabUpdateWriter;
 use appflowy_collaborate::command::{CLCommandReceiver, CLCommandSender};
 use appflowy_collaborate::snapshot::SnapshotControl;
 use appflowy_collaborate::ws2::{CollabStore, WsServer};
@@ -327,6 +328,11 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     metrics.collab_metrics.clone(),
   )
   .await;
+
+  let collab_update_writer = Arc::new(CollabUpdateWriter::new(
+    redis_conn_manager.clone(),
+    collab_cache.clone(),
+  ));
   let collab_access_control_storage = Arc::new(CollabStorageImpl::new(
     collab_cache.clone(),
     collab_storage_access_control.clone(),
@@ -367,6 +373,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     redis_stream_router.clone(),
     awareness_gossip.clone(),
     indexer_scheduler.clone(),
+    collab_update_writer.clone(),
   );
   let ws_server = WsServer::new(collab_store).start();
 
@@ -395,6 +402,7 @@ pub async fn init_state(config: &Config, rt_cmd_tx: CLCommandSender) -> Result<A
     ai_client: appflowy_ai_client,
     indexer_scheduler,
     ws_server,
+    collab_update_writer,
   })
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,6 +16,7 @@ use app_error::AppError;
 use appflowy_ai_client::client::AppFlowyAIClient;
 use appflowy_collaborate::collab::cache::CollabCache;
 use appflowy_collaborate::collab::storage::CollabAccessControlStorage;
+use appflowy_collaborate::collab::update_publish::CollabUpdateWriter;
 use appflowy_collaborate::metrics::CollabMetrics;
 use appflowy_collaborate::ws2::WsServer;
 use appflowy_collaborate::CollabRealtimeMetrics;
@@ -61,6 +62,7 @@ pub struct AppState {
   pub ai_client: AppFlowyAIClient,
   pub indexer_scheduler: Arc<IndexerScheduler>,
   pub ws_server: Addr<WsServer>,
+  pub collab_update_writer: Arc<CollabUpdateWriter>,
 }
 
 impl AppState {


### PR DESCRIPTION
Use CollabUpdateWriter  to write update to redis stream directly.

## Summary by Sourcery

Use a dedicated CollabUpdateWriter to perform all Redis stream writes for collaboration updates, refactor functions to consume AppState, and consolidate update logic across business, API, and collaborative store layers.

Enhancements:
- Introduce CollabUpdateWriter to centralize Redis stream updates and trimming logic
- Refactor workspace/business logic to accept AppState and use CollabUpdateWriter instead of raw server and storage dependencies
- Unify update functions (page, folder, database) via update_collab_data_with_timeout for consistent timeout and error handling
- Extract update publishing and pruning into a new services/appflowy-collaborate/src/collab/update_publish module
- Simplify HTTP API handlers to use AppState only and remove Data<RealtimeServerAddr> and explicit storage arguments
- Initialize and propagate CollabUpdateWriter through application startup and CollabStore
- Offload Folder decoding to a blocking task to avoid blocking async runtime