### PR TITLE
fix: database_fields_crud flaky test

### DIFF
--- a/libs/database/src/collab/collab_storage.rs
+++ b/libs/database/src/collab/collab_storage.rs
@@ -120,7 +120,7 @@ pub trait CollabStorage: Send + Sync + 'static {
   /// # Returns
   ///
   /// * `Result<RawData>` - Returns the data of the collaboration if found, `Err` otherwise.
-  async fn get_encode_collab(
+  async fn get_full_encode_collab(
     &self,
     origin: GetCollabOrigin,
     params: QueryCollabParams,

--- a/libs/indexer/src/unindexed_workspace.rs
+++ b/libs/indexer/src/unindexed_workspace.rs
@@ -138,7 +138,7 @@ async fn stream_unindexed_collabs(
           Ok(cid) => match cid.collab_type {
             CollabType::Document => {
               let collab = storage
-                .get_encode_collab(GetCollabOrigin::Server, cid.clone().into(), false)
+                .get_full_encode_collab(GetCollabOrigin::Server, cid.clone().into(), false)
                 .await?;
 
               Ok(Some(UnindexedCollab {

--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 
 use crate::collab::access_control::CollabStorageAccessControlImpl;
+use crate::collab::cache::mem_cache::MillisSeconds;
 use crate::collab::cache::CollabCache;
 use crate::collab::update_publish::CollabUpdateWriter;
 use crate::collab::validator::CollabValidator;
@@ -12,6 +13,7 @@ use anyhow::{anyhow, Context};
 use app_error::AppError;
 use appflowy_proto::UpdateFlags;
 use async_trait::async_trait;
+use chrono::Timelike;
 use collab::entity::{EncodedCollab, EncoderVersion};
 use collab_entity::CollabType;
 use collab_rt_entity::ClientCollabMessage;
@@ -309,7 +311,7 @@ where
       .await?;
 
     match tokio::time::timeout(
-      Duration::from_secs(120),
+      Duration::from_secs(30),
       self
         .cache
         .insert_encode_collab_data(&workspace_id, uid, params, transaction),
@@ -329,7 +331,7 @@ where
   }
 
   #[instrument(level = "trace", skip_all, fields(oid = %params.object_id))]
-  async fn get_encode_collab(
+  async fn get_full_encode_collab(
     &self,
     origin: GetCollabOrigin,
     params: QueryCollabParams,
@@ -442,6 +444,6 @@ where
   }
 
   fn mark_as_editing(&self, oid: Uuid) {
-    self.cache.mark_as_dirty(oid);
+    self.cache.mark_as_dirty(oid, MillisSeconds::now());
   }
 }

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -1177,7 +1177,7 @@ impl CollabPersister {
     let params = QueryCollabParams::new(self.object_id, self.collab_type, self.workspace_id);
     let result = self
       .storage
-      .get_encode_collab(GetCollabOrigin::Server, params, false)
+      .get_full_encode_collab(GetCollabOrigin::Server, params, false)
       .await;
     let doc_state = match result {
       Ok(encoded_collab) => encoded_collab.doc_state,

--- a/services/appflowy-collaborate/src/group/manager.rs
+++ b/services/appflowy-collaborate/src/group/manager.rs
@@ -119,7 +119,7 @@ where
     let params = QueryCollabParams::new(object_id, collab_type, workspace_id);
     let res = self
       .storage
-      .get_encode_collab(GetCollabOrigin::Server, params, false)
+      .get_full_encode_collab(GetCollabOrigin::Server, params, false)
       .await;
     let state_vector = match res {
       Ok(collab) => {
@@ -171,7 +171,7 @@ where
   S: CollabStorage,
 {
   let encode_collab = storage
-    .get_encode_collab(GetCollabOrigin::User { uid }, params.clone(), false)
+    .get_full_encode_collab(GetCollabOrigin::User { uid }, params.clone(), false)
     .await?;
   let options = CollabOptions::new(object_id.to_string(), default_client_id())
     .with_data_source(DataSource::DocStateV1(encode_collab.doc_state.to_vec()));

--- a/services/appflowy-collaborate/src/ws2/collab_store.rs
+++ b/services/appflowy-collaborate/src/ws2/collab_store.rs
@@ -1,3 +1,4 @@
+use crate::collab::cache::mem_cache::MillisSeconds;
 use crate::collab::cache::CollabCache;
 use crate::collab::update_publish::CollabUpdateWriter;
 use anyhow::anyhow;
@@ -188,7 +189,9 @@ impl CollabStore {
   }
 
   pub fn mark_as_dirty(&self, object_id: ObjectId) {
-    self.collab_cache.mark_as_dirty(object_id);
+    self
+      .collab_cache
+      .mark_as_dirty(object_id, MillisSeconds::now());
   }
 
   #[instrument(level = "trace", skip_all, err)]

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -338,12 +338,12 @@ async fn collab_mem_cache_read_write_test() {
   let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
 
   let object_id = Uuid::new_v4();
-  let timestamp = chrono::Utc::now().timestamp();
+  let timestamp = chrono::Utc::now().timestamp_millis() as u64;
   mem_cache
     .insert_encode_collab_data(
       &object_id,
       &encode_collab.encode_to_bytes().unwrap(),
-      timestamp,
+      timestamp.into(),
       None,
     )
     .await
@@ -360,12 +360,12 @@ async fn collab_mem_cache_insert_override_test() {
   let mem_cache = CollabMemCache::new(pool(), conn, CollabMetrics::default().into());
   let object_id = Uuid::new_v4();
   let encode_collab = EncodedCollab::new_v1(vec![1, 2, 3], vec![4, 5, 6]);
-  let mut timestamp = chrono::Utc::now().timestamp();
+  let mut timestamp = chrono::Utc::now().timestamp_millis() as u64;
   mem_cache
     .insert_encode_collab_data(
       &object_id,
       &encode_collab.encode_to_bytes().unwrap(),
-      timestamp,
+      timestamp.into(),
       None,
     )
     .await
@@ -380,7 +380,7 @@ async fn collab_mem_cache_insert_override_test() {
       &EncodedCollab::new_v1(vec![6, 7, 8], vec![9, 10, 11])
         .encode_to_bytes()
         .unwrap(),
-      timestamp,
+      timestamp.into(),
       None,
     )
     .await
@@ -400,7 +400,7 @@ async fn collab_mem_cache_insert_override_test() {
       &EncodedCollab::new_v1(vec![12, 13, 14], vec![15, 16, 17])
         .encode_to_bytes()
         .unwrap(),
-      timestamp,
+      timestamp.into(),
       None,
     )
     .await


### PR DESCRIPTION
1.Race Condition Between mark_as_dirty and mark_as_clean:
These operations are not atomic, which can lead to inconsistent states. To avoid this, use is_dirty_since to check the state safely.
2.Move spawn_insert_collab Logic into CollabMemCache:
Centralize this logic within CollabMemCache to ensure consistency across the codebase.
3.Fix Incorrect Timestamp When Inserting Encoded Collab into Redis Cache:
Previously, an incorrect timestamp could be set, leading to potential retrieval of stale or invalid collab states.

## Summary by Sourcery

Improve collab caching reliability and consistency by replacing non‐atomic dirty state tracking with timestamped checks, centralizing spawn logic, standardizing timestamp handling, and updating related storage, API, and test code.

Bug Fixes:
- Replace DashSet dirty_collabs with timestamped DashMap and is_dirty_since API to eliminate race conditions in collab dirty/clean evaluation.
- Fix incorrect timestamp assignments when caching collabs to prevent stale state retrieval.

Enhancements:
- Introduce MillisSeconds for uniform millisecond‐precision timestamps across caching and streaming.
- Centralize large collab insert spawning in CollabMemCache and remove scattered thread/task logic.
- Rename get_encode_collab to get_full_encode_collab and update all callers in storage, group management, ws2, and API layers.
- Simplify biz collab ops by passing AppState instead of separate collab_storage and pg_pool parameters.
- Add tracing instrumentation on key collab operations for improved observability.

Tests:
- Update mem_cache tests to use millisecond‐precision timestamps.