### PR TITLE
chore: commit transaction before send redis update

### DIFF
--- a/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
@@ -25,7 +25,7 @@ use rayon::prelude::*;
 use sqlx::{PgPool, Transaction};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, trace};
 use uuid::Uuid;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
@@ -229,7 +229,7 @@ impl CollabCache {
     let from = from.unwrap_or_default();
     if !self.is_dirty_since(&object_id, MillisSeconds::from(&rid)) {
       // there are no pending updates for this collab, so we can return the cached value directly
-      tracing::trace!("no pending updates for collab: {}", object_id);
+      trace!("no pending updates for collab: {}", object_id);
       return match encoded_collab {
         Some(encoded_collab) if encoded_collab.doc_state.len() <= self.small_collab_size => {
           Ok((rid, encoded_collab))


### PR DESCRIPTION
## Summary by Sourcery

Convert collab parameter preparation to async blocking tasks and ensure database transactions are committed before sending Redis updates

Enhancements:
- Offload default and initial document collab parameter assembly into tokio::task::spawn_blocking and mark the helper functions async
- Update all invocations of prepare_default_document_collab_param and prepare_document_collab_param_with_initial_data to await the new async implementations

Chores:
- Move the transaction.commit() in create_database_page to occur before publishing Redis stream updates