### PR TITLE
feat: add pending invitation status on SharedUser

### DIFF
--- a/libs/shared-entity/src/dto/guest_dto.rs
+++ b/libs/shared-entity/src/dto/guest_dto.rs
@@ -18,6 +18,7 @@ pub struct SharedUser {
   pub access_level: AFAccessLevel,
   pub role: AFRole,
   pub avatar_url: Option<String>,
+  pub pending_invitation: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Add pending invitation status on SharedUser

## Summary by Sourcery

New Features:
- Expose pending_invitation flag on SharedUser DTO to indicate when an invitation is pending.