### PR TITLE
chore: bump collab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "collab-importer"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=af4222c8148950f8d0154c3cd32e0872af3f33f0#af4222c8148950f8d0154c3cd32e0872af3f33f0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
 dependencies = [
  "anyhow",
  "collab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,14 +307,14 @@ lto = false
 [patch.crates-io]
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "af4222c8148950f8d0154c3cd32e0872af3f33f0" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
 
 [features]
 history = []

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -166,8 +166,8 @@ impl CreateCollabData {
     }
   }
 
-  pub fn to_proto(&self) -> proto::collab::CollabParams {
-    proto::collab::CollabParams {
+  pub fn to_proto(&self) -> proto::CollabParams {
+    proto::CollabParams {
       object_id: self.object_id.to_string(),
       encoded_collab: self.encoded_collab_v1.to_vec(),
       collab_type: self.collab_type.to_proto() as i32,
@@ -180,7 +180,7 @@ impl CreateCollabData {
   }
 
   pub fn from_protobuf_bytes(bytes: &[u8]) -> Result<Self, EntityError> {
-    match proto::collab::CollabParams::decode(bytes) {
+    match proto::CollabParams::decode(bytes) {
       Ok(proto) => Self::try_from(proto),
       Err(err) => Err(DeserializationError(err.to_string())),
     }
@@ -208,11 +208,11 @@ impl From<CreateCollabData> for CollabParams {
   }
 }
 
-impl TryFrom<proto::collab::CollabParams> for CreateCollabData {
+impl TryFrom<proto::CollabParams> for CreateCollabData {
   type Error = EntityError;
 
-  fn try_from(proto: proto::collab::CollabParams) -> Result<Self, Self::Error> {
-    let collab_type_proto = proto::collab::CollabType::try_from(proto.collab_type).unwrap();
+  fn try_from(proto: proto::CollabParams) -> Result<Self, Self::Error> {
+    let collab_type_proto = proto::CollabType::try_from(proto.collab_type).unwrap();
     let collab_type = CollabType::from_proto(&collab_type_proto);
     Ok(Self {
       object_id: Uuid::from_str(&proto.object_id)
@@ -826,19 +826,19 @@ pub enum EmbeddingContentType {
 }
 
 impl EmbeddingContentType {
-  pub fn from_proto(proto: proto::collab::EmbeddingContentType) -> Result<Self, EntityError> {
+  pub fn from_proto(proto: proto::EmbeddingContentType) -> Result<Self, EntityError> {
     match proto {
-      proto::collab::EmbeddingContentType::PlainText => Ok(EmbeddingContentType::PlainText),
-      proto::collab::EmbeddingContentType::Unknown => Err(InvalidData(format!(
+      proto::EmbeddingContentType::PlainText => Ok(EmbeddingContentType::PlainText),
+      proto::EmbeddingContentType::Unknown => Err(InvalidData(format!(
         "{} is not a supported embedding type",
         proto.as_str_name()
       ))),
     }
   }
 
-  pub fn to_proto(&self) -> proto::collab::EmbeddingContentType {
+  pub fn to_proto(&self) -> proto::EmbeddingContentType {
     match self {
-      EmbeddingContentType::PlainText => proto::collab::EmbeddingContentType::PlainText,
+      EmbeddingContentType::PlainText => proto::EmbeddingContentType::PlainText,
     }
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Bump the AppFlowy-Collab dependencies to a new revision and adapt the database-entity code to the updated protobuf API

Enhancements:
- Update protobuf type references and conversions to use `proto::CollabParams` and `proto::EmbeddingContentType` instead of the old `proto::collab` module paths

Build:
- Update Cargo.toml to pin all collab-related crates to revision `21cda3b0da5dcaaa8abea377c4dafc6bba3b04a` and refresh Cargo.lock