### PR TITLE
fix: infinite init_sync loop from old client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9052,8 +9052,7 @@ dependencies = [
 [[package]]
 name = "yrs"
 version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1d740a98b12112352f05ddfc06c1505b66fca116601f9388b84be45d21f84d"
+source = "git+https://github.com/appflowy/y-crdt.git?rev=c0be216997197ab774894be0f9aca996138ab8c8#c0be216997197ab774894be0f9aca996138ab8c8"
 dependencies = [
  "arc-swap",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9052,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "yrs"
 version = "0.23.4"
-source = "git+https://github.com/appflowy/y-crdt.git?rev=c0be216997197ab774894be0f9aca996138ab8c8#c0be216997197ab774894be0f9aca996138ab8c8"
+source = "git+https://github.com/appflowy/y-crdt.git?rev=9cb217fc9a11c4a6cce99455cc6e977bd9c9b6fc#9cb217fc9a11c4a6cce99455cc6e977bd9c9b6fc"
 dependencies = [
  "arc-swap",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,7 @@ lto = false
 
 
 [patch.crates-io]
+yrs = { git = "https://github.com/appflowy/y-crdt.git", rev = "c0be216997197ab774894be0f9aca996138ab8c8" }
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
 collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,7 @@ lto = false
 
 
 [patch.crates-io]
-yrs = { git = "https://github.com/appflowy/y-crdt.git", rev = "c0be216997197ab774894be0f9aca996138ab8c8" }
+yrs = { git = "https://github.com/appflowy/y-crdt.git", rev = "9cb217fc9a11c4a6cce99455cc6e977bd9c9b6fc" }
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
 collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }

--- a/services/appflowy-collaborate/src/client/client_msg_router.rs
+++ b/services/appflowy-collaborate/src/client/client_msg_router.rs
@@ -112,7 +112,7 @@ impl ClientMessageRouter {
           // before applying user messages, we need to check if the user has the permission
           // valid_messages contains the messages that the user is allowed to apply
           // invalid_message contains the messages that the user is not allowed to apply
-          let (valid_messages, invalid_message) = Self::access_control(
+          let (valid_messages, _) = Self::access_control(
             &workspace_id,
             &user.uid,
             &object_id,
@@ -120,15 +120,6 @@ impl ClientMessageRouter {
             original_messages,
           )
           .await;
-          trace!(
-            "{} receive client:{}, device:{}, message: valid:{} invalid:{}",
-            message_object_id,
-            user.uid,
-            user.device_id,
-            valid_messages.len(),
-            invalid_message.len()
-          );
-
           if valid_messages.is_empty() {
             continue;
           }

--- a/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
@@ -636,10 +636,11 @@ fn replaying_updates(
   from: &StateVector,
 ) -> Result<Option<EncodedCollab>, AppError> {
   tracing::trace!(
-    "replaying {} updates for {}/{}",
+    "replaying {} updates for {}/{}, from: {:#?}",
     updates.len(),
     object_id,
-    collab_type
+    collab_type,
+    from,
   );
   let mut collab = match encoded_collab {
     Some(encoded_collab) => {

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, instrument, trace, warn};
 use uuid::Uuid;
 use yrs::sync::AwarenessUpdate;
 use yrs::updates::decoder::{Decode, DecoderV1};
@@ -208,10 +208,20 @@ impl CollabGroup {
     Ok(())
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn handle_inbound_update(state: &CollabGroupState, update: CollabStreamUpdate) {
     let sender = update.sender.clone();
     match update.into_update() {
       Ok(update) => {
+        trace!(
+          "receive inbound {}/{} update {:#?}, current state vector: {:#?}, update state vector: {:#?}",
+          state.object_id,
+          state.collab_type,
+          update,
+          state.state_vector.read().await,
+          update.state_vector(),
+        );
+
         state
           .state_vector
           .write()
@@ -219,11 +229,6 @@ impl CollabGroup {
           .merge(update.state_vector());
 
         let seq_num = state.seq_no.fetch_add(1, Ordering::SeqCst) + 1;
-        tracing::trace!(
-          "broadcasting collab update from {} - seq_num: {}",
-          sender,
-          seq_num
-        );
         let payload = Message::Sync(SyncMessage::Update(update.encode_v1())).encode_v1();
         let message = BroadcastSync::new(sender, state.object_id.to_string(), payload, seq_num);
         for mut e in state.subscribers.iter_mut() {
@@ -283,11 +288,7 @@ impl CollabGroup {
   }
 
   async fn handle_inbound_awareness(state: &CollabGroupState, update: &AwarenessStreamUpdate) {
-    tracing::trace!(
-      "broadcasting awareness update from {} (contains {} clients)",
-      update.sender,
-      update.data.clients.len()
-    );
+    tracing::trace!("broadcast awareness {:#?}", update.data,);
     let sender = &update.sender;
     let message = AwarenessSync::new(
       state.object_id.to_string(),
@@ -366,26 +367,6 @@ impl CollabGroup {
       .indexer_scheduler
       .index_collab_immediately(workspace_id, object_id, &collab, collab_type)
       .await
-  }
-
-  pub async fn calculate_missing_update(
-    &self,
-    state_vector: StateVector,
-  ) -> Result<Vec<u8>, RealtimeError> {
-    {
-      // first check if we need to send any updates
-      let collab_sv = self.state.state_vector.read().await;
-      if *collab_sv <= state_vector {
-        return Ok(vec![]);
-      }
-    }
-
-    let encoded_collab = self.encode_collab().await?;
-    let options = CollabOptions::new(self.object_id().to_string(), default_client_id())
-      .with_data_source(DataSource::DocStateV1(encoded_collab.doc_state.into()));
-    let collab = Collab::new_with_options(CollabOrigin::Server, options)?;
-    let update = collab.transact().encode_state_as_update_v1(&state_vector);
-    Ok(update)
   }
 
   pub async fn encode_collab(&self) -> Result<EncodedCollab, RealtimeError> {
@@ -522,15 +503,12 @@ impl CollabGroup {
       }
       for message in messages {
         match Self::handle_client_message(state, message).await {
-          Ok(response) => {
-            trace!("[realtime]: sending response: {}", response);
-            match sink.send(response.into()).await {
-              Ok(()) => {},
-              Err(err) => {
-                trace!("[realtime]: send failed: {}", err);
-                break;
-              },
-            }
+          Ok(response) => match sink.send(response.into()).await {
+            Ok(()) => {},
+            Err(err) => {
+              trace!("[realtime]: send failed: {}", err);
+              break;
+            },
           },
           Err(err) => {
             error!(
@@ -566,12 +544,6 @@ impl CollabGroup {
         state.seq_no.load(Ordering::SeqCst),
       ));
     }
-
-    trace!(
-      "Applying client updates: {}, origin:{}",
-      collab_msg,
-      message_origin
-    );
 
     let payload = collab_msg.payload();
 
@@ -675,19 +647,45 @@ impl CollabGroup {
 
   async fn handle_sync_step1(
     state: &CollabGroupState,
-    remote_sv: &StateVector,
+    client_sv: &StateVector,
   ) -> Result<Option<Vec<u8>>, RTProtocolError> {
     if let Ok(sv) = state.state_vector.try_read() {
+      trace!(
+        "Sync step1: {}/{} current state vector: {:#?}, client state vector: {:#?}",
+        state.object_id,
+        state.collab_type,
+        sv,
+        client_sv
+      );
       // we optimistically try to obtain state vector lock for a fast track:
       // if we remote sv is up-to-date with current one, we don't need to do anything
-      match sv.partial_cmp(remote_sv) {
-        Some(std::cmp::Ordering::Equal) => return Ok(None), // client and server are in sync
+      match sv.partial_cmp(client_sv) {
+        Some(std::cmp::Ordering::Equal) => {
+          trace!(
+            "Sync step1: {}/{} client and server are in sync, no need to send anything",
+            state.object_id,
+            state.collab_type
+          );
+          return Ok(None);
+        }, // client and server are in sync
         Some(std::cmp::Ordering::Less) => {
           // server is behind client
+          trace!(
+            "Sync step1: server {}/{} is behind client, sending sync step 1 with state vector: {:#?}",
+            state.object_id, state.collab_type,
+            sv
+          );
           let msg = Message::Sync(SyncMessage::SyncStep1(sv.clone()));
           return Ok(Some(msg.encode_v1()));
         },
-        Some(std::cmp::Ordering::Greater) | None => { /* server has some new updates */ },
+        Some(std::cmp::Ordering::Greater) | None => {
+          // server has some new updates
+          trace!(
+            "Sync step1: server has some new updates for {}/{}",
+            state.object_id,
+            state.collab_type
+          );
+        },
       }
     }
 
@@ -701,7 +699,7 @@ impl CollabGroup {
 
     // prepare document state update and state vector
     let tx = snapshot.collab.transact();
-    let doc_state = tx.encode_diff_v1(remote_sv);
+    let doc_state = tx.encode_diff_v1(client_sv);
     let local_sv = tx.state_vector();
     drop(tx);
 
@@ -735,19 +733,39 @@ impl CollabGroup {
       .await
       .map_err(|err| RTProtocolError::Internal(err.into()))??
     };
+
     state
       .metrics
       .load_collab_time
       .observe(start.elapsed().as_millis() as f64);
-    let missing_updates = {
+
+    let (should_apply_update, missing_updates) = {
       let current_sv = state.state_vector.read().await;
       let update_sv = decoded_update.state_vector();
+      trace!(
+        "Sync step2: {}/{} current state vector: {:#?}, update state vector: {:#?}, new update: {:#?}",
+        state.object_id,
+        state.collab_type,
+        current_sv,
+        update_sv,
+        decoded_update,
+      );
       match current_sv.partial_cmp(&update_sv) {
         None => {
-          // None marks concurrent state vectors, meaning that current collab group
-          // has some of the updates that the client didn't see and vice versa
-          tracing::trace!("missing updates found for {}", state.object_id);
-          Some(Message::Sync(SyncMessage::SyncStep1(current_sv.clone())).encode_v1())
+          // Concurrent state vectors: both server and client have updates the other hasn't seen
+          // We should apply the update to merge the states, then inform the client of our state
+          trace!(
+            "Sync step2: {}/{} concurrent state vectors, current: {:#?}, update: {:#?}",
+            state.object_id,
+            state.collab_type,
+            current_sv,
+            update_sv
+          );
+          // Apply the update first, then send our state vector so client can sync back
+          (
+            true,
+            Some(Message::Sync(SyncMessage::SyncStep1(current_sv.clone())).encode_v1()),
+          )
         },
         Some(std::cmp::Ordering::Greater) if decoded_update.delete_set().is_empty() => {
           // This update has no new data. In fact server is more up to date, that this
@@ -757,15 +775,24 @@ impl CollabGroup {
             Message::Sync(SyncMessage::SyncStep1(current_sv.clone())).encode_v1(),
           ));
         },
-        _ => None,
+        Some(std::cmp::Ordering::Equal) | Some(std::cmp::Ordering::Greater) => {
+          trace!(
+            "Sync step2: {}/{} server is ahead of client",
+            state.object_id,
+            state.collab_type,
+          );
+          (true, None)
+        },
       }
     };
 
-    state
-      .persister
-      .send_update(origin.clone(), update)
-      .await
-      .map_err(|err| RTProtocolError::Internal(err.into()))?;
+    if should_apply_update {
+      state
+        .persister
+        .send_update(origin.clone(), update)
+        .await
+        .map_err(|err| RTProtocolError::Internal(err.into()))?;
+    }
 
     Ok(missing_updates)
   }
@@ -784,6 +811,7 @@ impl CollabGroup {
     update: Vec<u8>,
   ) -> Result<Option<Vec<u8>>, RTProtocolError> {
     let awareness_update = AwarenessUpdate::decode_v1(&update)?;
+    trace!("awareness updates: {:#?}", awareness_update);
     state
       .persister
       .send_awareness(origin, awareness_update)
@@ -940,7 +968,7 @@ impl CollabPersister {
       sender: sender_session.clone(),
     };
     self.awareness_sink.send(&update).await?;
-    tracing::trace!("broadcasted awareness from {}", update.sender);
+    trace!("broadcast awareness {:#?}", update);
     Ok(())
   }
 

--- a/services/appflowy-collaborate/src/rt_server.rs
+++ b/services/appflowy-collaborate/src/rt_server.rs
@@ -20,12 +20,9 @@ use database::collab::CollabStorage;
 use indexer::scheduler::IndexerScheduler;
 use redis::aio::ConnectionManager;
 use tokio::sync::mpsc::Sender;
-use tokio::task::yield_now;
 use tokio::time::interval;
 use tracing::{error, trace, warn};
 use uuid::Uuid;
-use yrs::updates::decoder::Decode;
-use yrs::StateVector;
 
 use crate::actix_ws::entities::{ClientGenerateEmbeddingMessage, ClientHttpUpdateMessage};
 use crate::{CollabRealtimeMetrics, RealtimeClientWebsocketSink};
@@ -184,7 +181,6 @@ where
     Ok(())
   }
 
-  #[inline]
   pub fn handle_client_http_update(
     &self,
     message: ClientHttpUpdateMessage,
@@ -192,6 +188,20 @@ where
     let group_cmd_sender = self.create_group_if_not_exist(message.object_id);
     tokio::spawn(async move {
       let object_id = message.object_id;
+      let return_tx = message.return_tx;
+
+      // Helper closure to handle error responses and logging
+      let handle_result = |app_error: AppError,
+                           return_tx: Option<
+        tokio::sync::oneshot::Sender<Result<Option<Vec<u8>>, AppError>>,
+      >| {
+        if let Some(tx) = return_tx {
+          let _ = tx.send(Err(app_error));
+        } else {
+          error!("{}", app_error);
+        }
+      };
+
       let (tx, rx) = tokio::sync::oneshot::channel();
       let result = group_cmd_sender
         .send(GroupCommand::HandleClientHttpUpdate {
@@ -204,17 +214,12 @@ where
         })
         .await;
 
-      let return_tx = message.return_tx;
       if let Err(err) = result {
-        if let Some(return_rx) = return_tx {
-          let _ = return_rx.send(Err(AppError::Internal(anyhow!(
-            "send update to group fail: {}",
-            err
-          ))));
-          return;
-        } else {
-          error!("send http update to group fail: {}", err);
-        }
+        handle_result(
+          AppError::Internal(anyhow!("send update to group fail: {}", err)),
+          return_tx,
+        );
+        return;
       }
 
       match rx.await {
@@ -226,67 +231,21 @@ where
             );
           }
 
-          if let Some(return_rx) = return_tx {
-            if let Some(state_vector) = message
-              .state_vector
-              .and_then(|data| StateVector::decode_v1(&data).ok())
-            {
-              // yield
-              yield_now().await;
-
-              // Calculate missing update
-              let (tx, rx) = tokio::sync::oneshot::channel();
-              let _ = group_cmd_sender
-                .send(GroupCommand::CalculateMissingUpdate {
-                  object_id,
-                  state_vector,
-                  ret: tx,
-                })
-                .await;
-              match rx.await {
-                Ok(missing_update_result) => {
-                  let _ = group_cmd_sender
-                    .send(GroupCommand::GenerateCollabEmbedding { object_id })
-                    .await;
-
-                  let result = missing_update_result
-                    .map_err(|err| {
-                      AppError::Internal(anyhow!("fail to calculate missing update: {}", err))
-                    })
-                    .map(Some);
-                  let _ = return_rx.send(result);
-                },
-                Err(err) => {
-                  let _ = return_rx.send(Err(AppError::Internal(anyhow!(
-                    "fail to calculate missing update: {}",
-                    err
-                  ))));
-                },
-              }
-            } else {
-              let _ = return_rx.send(Ok(None));
-            }
+          if let Some(tx) = return_tx {
+            let _ = tx.send(Ok(None));
           }
         },
         Ok(Err(err)) => {
-          if let Some(return_rx) = return_tx {
-            let _ = return_rx.send(Err(AppError::Internal(anyhow!(
-              "apply http update to group fail: {}",
-              err
-            ))));
-          } else {
-            error!("apply http update to group fail: {}", err);
-          }
+          handle_result(
+            AppError::Internal(anyhow!("apply http update to group fail: {}", err)),
+            return_tx,
+          );
         },
         Err(err) => {
-          if let Some(return_rx) = return_tx {
-            let _ = return_rx.send(Err(AppError::Internal(anyhow!(
-              "fail to receive applied result: {}",
-              err
-            ))));
-          } else {
-            error!("fail to receive applied result: {}", err);
-          }
+          handle_result(
+            AppError::Internal(anyhow!("fail to receive applied result: {}", err)),
+            return_tx,
+          );
         },
       }
     });

--- a/tests/collab/single_device_edit.rs
+++ b/tests/collab/single_device_edit.rs
@@ -670,6 +670,14 @@ async fn offline_and_then_sync_through_http_request() {
     .await
     .unwrap();
 
+  assert_client_collab_value(
+    &mut test_client,
+    &object_id,
+    json!({"1": small_text, "2": medium_text}),
+  )
+  .await
+  .unwrap();
+
   // Verify medium text was synced
   assert_server_collab(
     workspace_id,

--- a/tests/collab/single_device_edit.rs
+++ b/tests/collab/single_device_edit.rs
@@ -676,7 +676,7 @@ async fn offline_and_then_sync_through_http_request() {
     &mut test_client.api_client,
     object_id,
     &CollabType::Unknown,
-    10,
+    30,
     json!({"1": small_text, "2": medium_text}),
   )
   .await


### PR DESCRIPTION
## Summary by Sourcery

Instrument collaboration server code with detailed trace logging, streamline HTTP update handling, and remove legacy missing update logic to fix infinite server sync loop.

Bug Fixes:
- Fix infinite server sync loop by correcting state vector comparisons and update application in sync steps.

Enhancements:
- Add trace-level logs in inbound update, awareness, and sync handlers for improved debugging.
- Simplify client HTTP update flow with a unified error-handling closure and consistent return behavior.

Chores:
- Remove deprecated calculate_missing_update method and related GroupCommand variants.
- Clean up redundant code and tracing statements throughout the collab and router modules.