### PR TITLE
refactor: remove unnecessary CollaParams

### DIFF
--- a/libs/collab-stream/src/client.rs
+++ b/libs/collab-stream/src/client.rs
@@ -13,6 +13,7 @@ use redis::{AsyncCommands, FromRedisValue};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tracing::trace;
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -175,6 +176,15 @@ impl CollabRedisStream {
     stream_key: &str,
     message_ids: &[MessageId],
   ) -> Result<(), StreamError> {
+    trace!(
+      "deleting messages from stream `{}`: {}",
+      stream_key,
+      message_ids
+        .iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<String>>()
+        .join(", ")
+    );
     let mut conn = self.connection_manager.clone();
     let _: redis::Value = conn.xdel(stream_key, message_ids).await?;
     Ok(())

--- a/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/collab_cache.rs
@@ -130,6 +130,7 @@ impl CollabCache {
     &self.metrics
   }
 
+  #[instrument(level = "trace", skip_all)]
   pub async fn bulk_insert_collab(
     &self,
     workspace_id: Uuid,
@@ -261,6 +262,12 @@ impl CollabCache {
       .unwrap_or(0)
       + updates.iter().map(|u| u.update.len()).sum::<usize>();
 
+    trace!(
+      "found {} pending updates for collab: {}/{}",
+      updates.len(),
+      object_id,
+      collab_type
+    );
     if !updates.is_empty() {
       encoded_collab = if size <= self.small_collab_size {
         // For small collab, replaying updates on the current thread
@@ -463,6 +470,7 @@ impl CollabCache {
 
   /// Insert the encoded collab data into the cache.
   /// The data is inserted into both the memory and disk cache.
+  #[instrument(level = "trace", skip_all)]
   pub async fn insert_encode_collab_data(
     &self,
     workspace_id: &Uuid,
@@ -496,6 +504,7 @@ impl CollabCache {
     Ok(())
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn cache_collab(
     &self,
     object_id: Uuid,
@@ -518,6 +527,7 @@ impl CollabCache {
     }
   }
 
+  #[instrument(level = "trace", skip_all)]
   pub async fn insert_encode_collab_to_disk(
     &self,
     workspace_id: &Uuid,
@@ -669,7 +679,8 @@ fn replaying_updates(
         .map_err(|err| AppError::DecodeUpdateError(err.to_string()))?;
 
         tracing::trace!(
-          "replaying update for {}/{}: {:#?}",
+          "replaying {} update for {}/{}: {:#?}",
+          msg.last_message_id,
           object_id,
           collab_type,
           update,

--- a/services/appflowy-collaborate/src/collab/cache/mem_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/mem_cache.rs
@@ -265,6 +265,7 @@ impl CollabMemCache {
   ///
   /// # Returns
   /// A Redis result indicating the success or failure of the operation.
+  #[instrument(level = "trace", skip_all)]
   async fn insert_data_with_timestamp(
     &self,
     object_id: &Uuid,

--- a/services/appflowy-collaborate/src/collab/collab_store.rs
+++ b/services/appflowy-collaborate/src/collab/collab_store.rs
@@ -261,6 +261,7 @@ impl CollabStore {
     Ok(())
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn save_snapshot(
     collab_cache: Arc<CollabCache>,
     workspace_id: WorkspaceId,
@@ -284,6 +285,7 @@ impl CollabStore {
     Ok(())
   }
 
+  #[instrument(level = "trace", skip_all)]
   pub async fn snapshot_workspace(
     &self,
     workspace_id: WorkspaceId,

--- a/services/appflowy-collaborate/src/group/manager.rs
+++ b/services/appflowy-collaborate/src/group/manager.rs
@@ -2,18 +2,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use access_control::collab::RealtimeAccessControl;
-use app_error::AppError;
 use collab::core::collab::{default_client_id, CollabOptions, DataSource};
 use collab::core::origin::CollabOrigin;
-use collab::entity::EncodedCollab;
 use collab::preclude::Collab;
 use collab_entity::CollabType;
 use collab_rt_entity::user::RealtimeUser;
 use collab_rt_entity::CollabMessage;
 use collab_stream::client::CollabRedisStream;
 use database::collab::{CollabStorage, GetCollabOrigin};
-use database_entity::dto::QueryCollabParams;
-use tracing::{instrument, trace};
+use tracing::trace;
 use uuid::Uuid;
 use yrs::{ReadTxn, StateVector};
 
@@ -116,10 +113,14 @@ where
     object_id: Uuid,
     collab_type: CollabType,
   ) -> Result<(), RealtimeError> {
-    let params = QueryCollabParams::new(object_id, collab_type, workspace_id);
     let res = self
       .storage
-      .get_full_encode_collab(GetCollabOrigin::Server, params, false)
+      .get_full_encode_collab(
+        GetCollabOrigin::Server,
+        &workspace_id,
+        &object_id,
+        collab_type,
+      )
       .await;
     let state_vector = match res {
       Ok(collab) => {
@@ -157,83 +158,4 @@ where
     self.state.insert_group(object_id, group);
     Ok(())
   }
-}
-
-#[allow(dead_code)]
-#[instrument(level = "trace", skip_all)]
-async fn load_collab<S>(
-  uid: i64,
-  object_id: &Uuid,
-  params: QueryCollabParams,
-  storage: Arc<S>,
-) -> Result<(Collab, EncodedCollab), AppError>
-where
-  S: CollabStorage,
-{
-  let encode_collab = storage
-    .get_full_encode_collab(GetCollabOrigin::User { uid }, params.clone(), false)
-    .await?;
-  let options = CollabOptions::new(object_id.to_string(), default_client_id())
-    .with_data_source(DataSource::DocStateV1(encode_collab.doc_state.to_vec()));
-  let result = Collab::new_with_options(CollabOrigin::Server, options);
-  match result {
-    Ok(collab) => Ok((collab, encode_collab)),
-    Err(err) => load_collab_from_snapshot(object_id, params, storage)
-      .await
-      .ok_or_else(|| AppError::Internal(err.into())),
-  }
-}
-
-async fn load_collab_from_snapshot<S>(
-  object_id: &Uuid,
-  params: QueryCollabParams,
-  storage: Arc<S>,
-) -> Option<(Collab, EncodedCollab)>
-where
-  S: CollabStorage,
-{
-  let encode_collab = get_latest_snapshot(
-    &params.workspace_id,
-    object_id,
-    &*storage,
-    &params.collab_type,
-  )
-  .await?;
-  let options = CollabOptions::new(object_id.to_string(), default_client_id())
-    .with_data_source(DataSource::DocStateV1(encode_collab.doc_state.to_vec()));
-  let collab = Collab::new_with_options(CollabOrigin::Empty, options).ok()?;
-  Some((collab, encode_collab))
-}
-
-async fn get_latest_snapshot<S>(
-  workspace_id: &Uuid,
-  object_id: &Uuid,
-  storage: &S,
-  collab_type: &CollabType,
-) -> Option<EncodedCollab>
-where
-  S: CollabStorage,
-{
-  let metas = storage
-    .get_collab_snapshot_list(workspace_id, object_id)
-    .await
-    .ok()?
-    .0;
-  for meta in metas {
-    let object_id = Uuid::parse_str(&meta.object_id).ok()?;
-    let snapshot_data = storage
-      .get_collab_snapshot(*workspace_id, object_id, &meta.snapshot_id)
-      .await
-      .ok()?;
-    if let Ok(encoded_collab) = EncodedCollab::decode_from_bytes(&snapshot_data.encoded_collab_v1) {
-      let options = CollabOptions::new(object_id.to_string(), default_client_id())
-        .with_data_source(DataSource::DocStateV1(encoded_collab.doc_state.to_vec()));
-      if let Ok(collab) = Collab::new_with_options(CollabOrigin::Empty, options) {
-        // TODO(nathan): this check is not necessary, can be removed in the future.
-        collab_type.validate_require_data(&collab).ok()?;
-        return Some(encoded_collab);
-      }
-    }
-  }
-  None
 }

--- a/src/biz/collab/utils.rs
+++ b/src/biz/collab/utils.rs
@@ -30,7 +30,6 @@ use database::collab::select_workspace_database_oid;
 use database::collab::CollabStorage;
 use database::collab::GetCollabOrigin;
 use database_entity::dto::QueryCollab;
-use database_entity::dto::QueryCollabParams;
 use database_entity::dto::QueryCollabResult;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
@@ -261,6 +260,7 @@ pub async fn get_latest_collab_database_body(
   .await?
 }
 
+#[instrument(level = "trace", skip_all)]
 pub async fn get_latest_collab_encoded(
   collab_storage: &CollabAccessControlStorage,
   collab_origin: GetCollabOrigin,
@@ -269,17 +269,7 @@ pub async fn get_latest_collab_encoded(
   collab_type: CollabType,
 ) -> Result<EncodedCollab, AppError> {
   collab_storage
-    .get_full_encode_collab(
-      collab_origin,
-      QueryCollabParams {
-        workspace_id,
-        inner: QueryCollab {
-          object_id,
-          collab_type,
-        },
-      },
-      true,
-    )
+    .get_full_encode_collab(collab_origin, &workspace_id, &object_id, collab_type)
     .await
 }
 

--- a/tests/collab/single_device_edit.rs
+++ b/tests/collab/single_device_edit.rs
@@ -646,7 +646,7 @@ async fn offline_and_then_sync_through_http_request() {
   .unwrap();
 
   // Second insertion - medium text
-  let medium_text = generate_random_string(512);
+  let medium_text = generate_random_string(200);
   test_client
     .insert_into(&object_id, "2", medium_text.clone())
     .await;
@@ -684,7 +684,7 @@ async fn offline_and_then_sync_through_http_request() {
     &mut test_client.api_client,
     object_id,
     &CollabType::Unknown,
-    30,
+    10,
     json!({"1": small_text, "2": medium_text}),
   )
   .await


### PR DESCRIPTION
## Summary by Sourcery

Simplify the collaboration storage and retrieval APIs, remove obsolete helpers, and add extensive tracing for better observability.

Enhancements:
- Rename storage methods (queue_insert_or_update_collab → upsert_collab and batch_insert_new_collab → upsert_collab_background) and remove unneeded flags and parameter wrappers
- Simplify get_full_encode_collab signature by eliminating QueryCollabParams and boolean flags in favor of explicit workspace_id, object_id, and collab_type arguments
- Introduce a centralized permission-check helper (check_or_update_permission) and integrate permission enforcement into upsert operations
- Add #[instrument] annotations and trace logs across storage, cache, API handlers, and client code to improve debugging and monitoring
- Remove deprecated helper functions and dead code related to snapshot loading and QueryCollabParams

Tests:
- Reduce random test payload sizes and expected sync message counts in single_device_edit tests