### PR TITLE
chore: bump yrs to 0.25.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9051,8 +9051,9 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.23.4"
-source = "git+https://github.com/appflowy/y-crdt.git?rev=9cb217fc9a11c4a6cce99455cc6e977bd9c9b6fc#9cb217fc9a11c4a6cce99455cc6e977bd9c9b6fc"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197c2b4b298f35c3ba4d549884ac872a961112095b29f173ab45e3d5cf609018"
 dependencies = [
  "arc-swap",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,7 +277,7 @@ tokio-tungstenite = "0.20"
 secrecy = { version = "0.8.0", features = ["serde"] }
 thiserror = "2.0"
 # collaboration
-yrs = { version = "0.23.4", features = ["sync"] }
+yrs = { version = "0.23.5", features = ["sync"] }
 collab = { version = "0.2.0" }
 collab-entity = { version = "0.2.0" }
 collab-folder = { version = "0.2.0" }
@@ -305,7 +305,6 @@ lto = false
 
 
 [patch.crates-io]
-yrs = { git = "https://github.com/appflowy/y-crdt.git", rev = "9cb217fc9a11c4a6cce99455cc6e977bd9c9b6fc" }
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
 collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -41,7 +41,7 @@ use uuid::Uuid;
 use yrs::sync::AwarenessUpdate;
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
-use yrs::{ReadTxn, StateVector, Update};
+use yrs::{DeleteSet, ReadTxn, StateVector, Update};
 
 /// A group used to manage a single [Collab] object
 pub struct CollabGroup {
@@ -213,20 +213,26 @@ impl CollabGroup {
     let sender = update.sender.clone();
     match update.into_update() {
       Ok(update) => {
+        let mut update_sv = StateVector::default();
+        let insertions = update.insertions(true);
+        let del_set = DeleteSet::from(insertions);
+        for (&client, blocks) in del_set.iter() {
+          if blocks.is_empty() {
+            continue;
+          }
+          let upper = blocks.iter().map(|b| b.end).max().unwrap();
+          update_sv.set_max(client, upper);
+        }
+
         trace!(
           "receive inbound {}/{} update {:#?}, state vector: {:#?}, server state vector: {:#?}",
           state.object_id,
           state.collab_type,
           update,
-          update.state_vector_higher(),
+          update_sv,
           state.state_vector.read().await,
         );
-
-        state
-          .state_vector
-          .write()
-          .await
-          .merge(update.state_vector_higher());
+        state.state_vector.write().await.merge(update_sv);
 
         let seq_num = state.seq_no.fetch_add(1, Ordering::SeqCst) + 1;
         let payload = Message::Sync(SyncMessage::Update(update.encode_v1())).encode_v1();


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the yrs CRDT dependency and refactor CollabGroups state vector handling to derive it from actual update insertions via DeleteSet instead of using state_vector_higher().

Enhancements:
- Compute a custom StateVector from update insertions using DeleteSet for precise state merging and logging
- Replace calls to state_vector_higher() with the new computed StateVector in trace output and state merging

Build:
- Bump yrs crate version to 0.23.5 with sync feature and remove the previous patch override