### PR TITLE
Batch dirty collab

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,5 +2,4 @@
 ignore = [
   "RUSTSEC-2024-0384",
   "RUSTSEC-2025-0012",
-  "RUSTSEC-2024-0436",
 ]

--- a/services/appflowy-collaborate/src/collab/cache/disk_cache.rs
+++ b/services/appflowy-collaborate/src/collab/cache/disk_cache.rs
@@ -1,4 +1,4 @@
-use crate::collab::cache::encode_collab_from_bytes;
+use crate::collab::cache::encode_collab_from_bytes_with_thread_pool;
 use crate::CollabMetrics;
 use anyhow::{anyhow, Context};
 use app_error::AppError;
@@ -297,7 +297,8 @@ impl CollabDiskCache {
         Ok((updated_at, data)) => {
           self.metrics.pg_read_collab_count.inc();
           let rid = Rid::new(updated_at.timestamp_millis() as u64, 0);
-          let encoded_collab = encode_collab_from_bytes(&self.thread_pool, data).await?;
+          let encoded_collab =
+            encode_collab_from_bytes_with_thread_pool(&self.thread_pool, data).await?;
           return Ok((rid, encoded_collab));
         },
         Err(e) => {

--- a/services/appflowy-collaborate/src/collab/cache/mod.rs
+++ b/services/appflowy-collaborate/src/collab/cache/mod.rs
@@ -13,7 +13,18 @@ use std::sync::Arc;
 pub const DECODE_SPAWN_THRESHOLD: usize = 4096; // 4KB
 
 #[inline]
-pub(crate) async fn encode_collab_from_bytes(
+pub(crate) fn encode_collab_from_bytes(bytes: Vec<u8>) -> Result<EncodedCollab, AppError> {
+  match EncodedCollab::decode_from_bytes(&bytes) {
+    Ok(encoded_collab) => Ok(encoded_collab),
+    Err(err) => Err(AppError::Internal(anyhow::anyhow!(
+      "Failed to decode collab from bytes: {:?}",
+      err
+    ))),
+  }
+}
+
+#[inline]
+pub(crate) async fn encode_collab_from_bytes_with_thread_pool(
   thread_pool: &Arc<ThreadPoolNoAbort>,
   bytes: Vec<u8>,
 ) -> Result<EncodedCollab, AppError> {

--- a/tests/collab/storage_test.rs
+++ b/tests/collab/storage_test.rs
@@ -6,7 +6,6 @@ use collab::core::transaction::DocTransactionExtension;
 use collab::entity::EncodedCollab;
 use collab::preclude::{Doc, Transact};
 use collab_entity::CollabType;
-use database::collab::CollabMetadata;
 use database_entity::dto::{
   CreateCollabParams, DeleteCollabParams, QueryCollab, QueryCollabParams, QueryCollabResult,
 };
@@ -413,27 +412,6 @@ async fn collab_mem_cache_insert_override_test() {
   let (_, encode_collab_from_cache) = mem_cache.get_encode_collab(&object_id).await.unwrap();
   assert_eq!(encode_collab_from_cache.doc_state, vec![15, 16, 17]);
   assert_eq!(encode_collab_from_cache.state_vector, vec![12, 13, 14]);
-}
-
-#[tokio::test]
-async fn collab_meta_redis_cache_test() {
-  let conn = redis_connection_manager().await;
-  let mem_cache = CollabMemCache::new(pool(), conn, CollabMetrics::default().into());
-  mem_cache
-    .get_collab_meta(&Uuid::new_v4())
-    .await
-    .unwrap_err();
-
-  let object_id = Uuid::new_v4();
-  let workspace_id = Uuid::new_v4();
-  let meta = CollabMetadata {
-    object_id,
-    workspace_id,
-  };
-  mem_cache.insert_collab_meta(meta.clone()).await.unwrap();
-  let meta_from_cache = mem_cache.get_collab_meta(&object_id).await.unwrap();
-  assert_eq!(meta.workspace_id, meta_from_cache.workspace_id);
-  assert_eq!(meta.object_id, meta_from_cache.object_id);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary by Sourcery

Enable efficient batch retrieval of collaboration data with Redis pipelining and parallel decoding, refactor cache implementations for better error handling and metrics, remove deprecated metadata caching, and enhance logging and instrumentation.

New Features:
- Add batch_get_data and batch_get_encode_collab for efficient batch retrieval of raw and encoded collaboration data using Redis pipelining and parallel decoding.

Enhancements:
- Refactor batch_get_snapshot_collab to chunk queries by collab type with error-resilient batched processing.
- Unify collab decoding into synchronous and thread-pool-backed variants and centralize timestamp extraction with metrics and error logging.
- Rename and simplify internal data insertion method (_insert_data_with_timestamp) with improved timestamped payload handling.
- Add tracing instrumentation and metrics increments to key cache operations.
- Remove deprecated batch_get_encode_collab alias.

Tests:
- Remove collab_meta Redis caching test.

Chores:
- Remove deprecated collab metadata caching methods and associated tests.
- Update deny.toml to drop an obsolete RustSec ignore entry.