### PR TITLE
chore: bump collab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "collab-importer"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a#21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb#d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb"
 dependencies = [
  "anyhow",
  "collab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,14 +307,14 @@ lto = false
 [patch.crates-io]
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "21cda3bd0da5dcaaa8abea377c4dafc6bba3b04a" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "d6209e07c2e160a1f5fdfd5b2bcef5edc1b190bb" }
 
 [features]
 history = []

--- a/libs/workspace-template/src/document/util.rs
+++ b/libs/workspace-template/src/document/util.rs
@@ -64,7 +64,7 @@ pub async fn create_database_from_params(
       .encoded_row_collabs
       .into_iter()
       .map(|encoded_row_collab| TemplateData {
-        template_id: TemplateObjectId::DatabaseRow(encoded_row_collab.object_id),
+        template_id: TemplateObjectId::DatabaseRow(encoded_row_collab.object_id.to_string()),
         collab_type: CollabType::DatabaseRow,
         encoded_collab: encoded_row_collab.encoded_collab,
       });

--- a/src/biz/workspace/duplicate.rs
+++ b/src/biz/workspace/duplicate.rs
@@ -238,7 +238,7 @@ async fn duplicate_database(
     let database = Database::open(database_id, database_context.clone())
       .await
       .map_err(|err| AppError::Internal(anyhow::anyhow!("Failed to open database: {}", err)))?;
-    let database_data = database.get_database_data().await;
+    let database_data = database.get_database_data(20, true).await;
     let params = duplicate_database_data_with_context(duplicate_context, &database_data);
     let duplicated_database = Database::create_with_view(params, database_context.clone())
       .await
@@ -272,9 +272,8 @@ async fn duplicate_database(
       updated_at: None,
     });
     for row in encoded_database.encoded_row_collabs {
-      let row_id = Uuid::parse_str(&row.object_id.clone())?;
       collab_params_list.push(CollabParams {
-        object_id: row_id,
+        object_id: row.object_id,
         encoded_collab_v1: row.encoded_collab.encode_to_bytes()?.into(),
         collab_type: CollabType::DatabaseRow,
         updated_at: None,

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -1193,7 +1193,7 @@ async fn create_database_page(
     workspace_id,
   )
   .await?;
-  let database_id: Uuid = encoded_database.encoded_database_collab.object_id.parse()?;
+  let database_id = encoded_database.encoded_database_collab.object_id;
   let workspace_database_update =
     add_new_database_to_workspace(&mut workspace_database, &database_id, view_id).await?;
   let database_collab_params = CollabParams {
@@ -1211,7 +1211,7 @@ async fn create_database_page(
     .iter()
     .flat_map(|row_collab| {
       Some(CollabParams {
-        object_id: Uuid::parse_str(&row_collab.object_id).ok()?,
+        object_id: row_collab.object_id,
         encoded_collab_v1: row_collab.encoded_collab.encode_to_bytes().unwrap().into(),
         collab_type: CollabType::DatabaseRow,
         updated_at: None,

--- a/tests/workspace/import_test.rs
+++ b/tests/workspace/import_test.rs
@@ -125,7 +125,7 @@ async fn import_project_and_task_zip_test() {
         .await;
       let inline_views = get_inline_view_id(&database).unwrap();
       let fields = database.get_fields_in_view(&inline_views, None);
-      let rows = database.collect_all_rows().await;
+      let rows = database.collect_all_rows(false).await;
       assert_eq!(rows.len(), 4);
       assert_eq!(fields.len(), 13);
 
@@ -146,7 +146,7 @@ async fn import_project_and_task_zip_test() {
         .await;
       let inline_views = get_inline_view_id(&database).unwrap();
       let fields = database.get_fields_in_view(&inline_views, None);
-      let rows = database.collect_all_rows().await;
+      let rows = database.collect_all_rows(false).await;
       assert_eq!(rows.len(), 17);
       assert_eq!(fields.len(), 13);
       continue;


### PR DESCRIPTION
## Summary by Sourcery

Bump AppFlowy-Collab subcrate to the latest commit and update code to match its revised API

Enhancements:
- Adjust get_database_data and collect_all_rows calls to include new parameters
- Remove manual UUID parsing by using raw object_id values for collab params
- Convert object_id to string in workspace-template util to align with updated API

Build:
- Update Cargo.toml to use new AppFlowy-Collab git revision across all patched collab crates

Tests:
- Update import tests to pass the new flag to collect_all_rows