### PR TITLE
fix: hide ungrouped column by default when using the web api endpoint

### DIFF
--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -1307,7 +1307,6 @@ async fn post_page_view_handler(
   path: web::Path<Uuid>,
   payload: Json<CreatePageParams>,
   state: Data<AppState>,
-
   req: HttpRequest,
 ) -> Result<Json<AppResponse<Page>>> {
   let uid = state.user_cache.get_user_uid(&user_uuid).await?;

--- a/src/biz/workspace/page_view.rs
+++ b/src/biz/workspace/page_view.rs
@@ -521,7 +521,10 @@ async fn prepare_default_board_encoded_database(
     rows.push(row);
   }
   let fields = vec![card_title_field, card_status_field];
-  let layout_setting = BoardLayoutSetting::new();
+  let layout_setting = BoardLayoutSetting {
+    hide_ungrouped_column: true,
+    collapse_hidden_groups: true,
+  };
 
   prepare_new_encoded_database(
     view_id,


### PR DESCRIPTION
The current default board layout settings for board is incorrect. `hide_ungrouped_column` and `collapse_hidden_groups` should have been set to true.

## Summary by Sourcery

Set `hide_ungrouped_column` and `collapse_hidden_groups` to true in the default board layout settings and remove an extraneous blank line in the API handler signature.

Bug Fixes:
- Enable hiding the ungrouped column by default in new board layouts
- Enable collapsing of hidden groups by default in new board layouts

Chores:
- Remove an unnecessary blank line in the web API handler signature