### PR TITLE
chore: use rid as dirty timestamp

### DIFF
--- a/services/appflowy-collaborate/src/collab/storage.rs
+++ b/services/appflowy-collaborate/src/collab/storage.rs
@@ -369,6 +369,7 @@ where
       .await
   }
 
+  #[instrument(level = "trace", skip_all)]
   fn mark_as_editing(&self, oid: Uuid) {
     self.cache.mark_as_dirty(oid, MillisSeconds::now());
   }

--- a/services/appflowy-collaborate/src/group/group_init.rs
+++ b/services/appflowy-collaborate/src/group/group_init.rs
@@ -982,6 +982,7 @@ impl CollabPersister {
     })
   }
 
+  #[instrument(level = "trace", skip_all)]
   async fn send_update(
     &self,
     sender: CollabOrigin,

--- a/services/appflowy-collaborate/src/ws2/actors/workspace.rs
+++ b/services/appflowy-collaborate/src/ws2/actors/workspace.rs
@@ -406,7 +406,7 @@ impl StreamHandler<anyhow::Result<UpdateStreamMessage>> for Workspace {
     let collab_type = msg.collab_type;
     let last_message_id = msg.last_message_id;
     let update = msg.update.clone();
-    store.mark_as_dirty(object_id);
+    store.mark_as_dirty(object_id, msg.last_message_id.timestamp);
 
     let sessions: Vec<WorkspaceSessionHandle> = self
       .sessions_by_client_id


### PR DESCRIPTION
## Summary by Sourcery

Switch dirty tracking to use Rid-derived timestamps and add trace-level instrumentation across collaboration flow

Enhancements:
- Use Rid.timestamp instead of current time when marking objects as dirty in CollabStore and workspace handler
- Update mark_as_dirty signature to accept an explicit timestamp parameter
- Log a trace message when no updates are available for a workspace snapshot up to a given rid

Chores:
- Add trace-level instrumentation to mark_as_editing in storage and send_update in group initialization