### PR TITLE
chore: use ResponseActFuture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "collab-importer"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc#b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e59260e524f33104b0ddcd6bb8f6218cad0f7e18#e59260e524f33104b0ddcd6bb8f6218cad0f7e18"
 dependencies = [
  "anyhow",
  "collab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,14 +307,14 @@ lto = false
 [patch.crates-io]
 # It's diffcult to resovle different version with the same crate used in AppFlowy Frontend and the Client-API crate.
 # So using patch to workaround this issue.
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "b309bbaf5657ab72f3fb8fd40a2bdfcd0237defc" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-importer = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e59260e524f33104b0ddcd6bb8f6218cad0f7e18" }
 
 [features]
 history = []

--- a/services/appflowy-collaborate/src/collab/collab_manager.rs
+++ b/services/appflowy-collaborate/src/collab/collab_manager.rs
@@ -89,7 +89,7 @@ impl CollabManager {
     Ok(())
   }
 
-  pub async fn get_folder(&self, workspace_id: WorkspaceId) -> AppResult<Folder> {
+  pub async fn build_folder(&self, workspace_id: WorkspaceId) -> AppResult<Folder> {
     let query = QueryCollab::new(workspace_id, CollabType::Folder);
     let encoded_collab = self
       .collab_cache


### PR DESCRIPTION
## Summary by Sourcery

Use ResponseActFuture in place of AtomicResponse for handling WorkspaceFolder messages and rename get_folder to build_folder in CollabManager

Enhancements:
- Replace AtomicResponse with ResponseActFuture for WorkspaceFolder handler
- Rename async get_folder instance method to get_folder and align CollabManager’s get_folder to build_folder
- Update handler to directly return the pinned actor future without AtomicResponse wrapper