### PR TITLE
fix: workspace controller actor runloop

### DIFF
--- a/libs/client-api/src/v2/controller.rs
+++ b/libs/client-api/src/v2/controller.rs
@@ -190,6 +190,7 @@ pub enum DisconnectedReason {
   UserDisconnect(Arc<str>),
   ServerForceClose,
   Unauthorized(Arc<str>),
+  PingTimeout,
 }
 
 impl Display for DisconnectedReason {
@@ -208,6 +209,7 @@ impl Display for DisconnectedReason {
       DisconnectedReason::UserDisconnect(reason) => write!(f, "user disconnect: {}", reason),
       DisconnectedReason::Unauthorized(reason) => write!(f, "unauthorized: {}", reason),
       DisconnectedReason::ServerForceClose => write!(f, "server force close"),
+      DisconnectedReason::PingTimeout => write!(f, "ping timeout"),
     }
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve WorkspaceControllerActor’s ping runloop by tracking consecutive ping failures and disconnecting after a threshold with a new PingTimeout reason, reset failure counters on successful pings or incoming messages, extend reconnect delay, and enhance logging throughout the connection lifecycle.

Enhancements:
- Add atomic ping_failures counter and MAX_PING_FAILURES to track and limit consecutive ping failures
- Disconnect actor with a PingTimeout reason when ping failures reach the threshold and reset the counter
- Reset ping failure counter on every successful ping or on receiving any server message
- Increase reconnect retry sleep interval from 5 to 10 seconds
- Improve logging by elevating key events to info level, adding context (workspace_id, ping counts), and tracing ping failures