### PR TITLE
chore: track pending update count

### DIFF
--- a/services/appflowy-collaborate/src/ws2/actors/workspace.rs
+++ b/services/appflowy-collaborate/src/ws2/actors/workspace.rs
@@ -129,7 +129,7 @@ impl Workspace {
               message: ServerMessage::Manifest {
                 object_id: msg.object_id,
                 collab_type,
-                last_message_id: Rid::default(),
+                last_message_id: state.rid,
                 state_vector: state.state_vector,
               },
             });
@@ -570,8 +570,8 @@ impl Handler<Terminate> for Workspace {
 impl Handler<WsInput> for Workspace {
   type Result = AtomicResponse<Self, ()>;
   fn handle(&mut self, msg: WsInput, _: &mut Self::Context) -> Self::Result {
-    let store = self.manager.clone();
     if let Some(sender) = self.sessions_by_client_id.get(&msg.client_id) {
+      let store = self.manager.clone();
       AtomicResponse::new(Box::pin(
         Self::hande_ws_input(store, sender.clone(), msg).into_actor(self),
       ))


### PR DESCRIPTION
## Summary by Sourcery

Track pending update count per collaboration session to improve synchronization and reduce redundant update messages, and apply minor protocol fixes.

Enhancements:
- Add a `pending_updates` atomic counter and `change_pending_count` method to `CachedCollab`
- Increment and decrement the pending counter on local update dispatch and acknowledgement
- Optimize update dispatch by sending an empty update when the local state and pending count indicate full sync
- Use the actual `last_message_id` in manifest responses instead of the default
- Refactor the `WsInput` handler to clone the manager store in the correct scope