### PR TITLE
chore: remove workspace redis stream on workspace deletion

### DIFF
--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -77,6 +77,7 @@ async fn delete_user_handler(
   } = query.into_inner();
   delete_user(
     &state.pg_pool,
+    &state.redis_connection_manager,
     &state.bucket_storage,
     &state.gotrue_client,
     &state.gotrue_admin,

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -471,6 +471,7 @@ async fn delete_workspace_handler(
     .await?;
   workspace::ops::delete_workspace_for_user(
     state.pg_pool.clone(),
+    state.redis_connection_manager.clone(),
     workspace_id,
     state.bucket_storage.clone(),
   )


### PR DESCRIPTION
## Summary by Sourcery

Clean up Redis streams for workspaces upon deletion by passing the Redis connection manager through the user and workspace deletion flows and issuing a DEL command for the workspace stream key.

Enhancements:
- Forward the Redis connection manager through delete_user and delete_workspace_for_user functions
- Delete the Redis stream key for a workspace in delete_workspace_for_user