### PR TITLE
feat: add update and get endpoints for mentionable person

### DIFF
--- a/.sqlx/query-76879756963f1861a0d2c2dfbfd8fdd1316699bfc231f567ea02740079fcecae.json
+++ b/.sqlx/query-76879756963f1861a0d2c2dfbfd8fdd1316699bfc231f567ea02740079fcecae.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT\n        au.uuid,\n        COALESCE(awmp.name, au.name) AS \"name!\",\n        au.email,\n        awm.role_id AS \"role!\",\n        COALESCE(awmp.avatar_url, au.metadata ->> 'icon_url') AS \"avatar_url\",\n        awmp.cover_image_url,\n        awmp.description\n      FROM af_workspace_member awm\n      JOIN af_user au ON awm.uid = au.uid\n      LEFT JOIN af_workspace_member_profile awmp ON (awm.uid = awmp.uid AND awm.workspace_id = awmp.workspace_id)\n      WHERE awm.workspace_id = $1\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "role!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "cover_image_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "description",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      false,
+      false,
+      null,
+      true,
+      true
+    ]
+  },
+  "hash": "76879756963f1861a0d2c2dfbfd8fdd1316699bfc231f567ea02740079fcecae"
+}

--- a/.sqlx/query-bf6b17d3d656d14e2350c1606aa836ee15842aac5453d1b6dc9e4f286cb9e04d.json
+++ b/.sqlx/query-bf6b17d3d656d14e2350c1606aa836ee15842aac5453d1b6dc9e4f286cb9e04d.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      INSERT INTO af_workspace_member_profile (workspace_id, uid, name, avatar_url, cover_image_url, description)\n      VALUES ($1, $2, $3, $4, $5, $6)\n      ON CONFLICT (workspace_id, uid) DO UPDATE\n      SET name = EXCLUDED.name,\n          avatar_url = EXCLUDED.avatar_url,\n          cover_image_url = EXCLUDED.cover_image_url,\n          description = EXCLUDED.description\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bf6b17d3d656d14e2350c1606aa836ee15842aac5453d1b6dc9e4f286cb9e04d"
+}

--- a/libs/client-api/src/http_person.rs
+++ b/libs/client-api/src/http_person.rs
@@ -1,0 +1,44 @@
+use client_api_entity::{MentionablePersons, WorkspaceMemberProfile};
+use reqwest::Method;
+use shared_entity::response::AppResponseError;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{process_response_data, process_response_error, Client};
+
+impl Client {
+  #[instrument(level = "info", skip_all, err)]
+  pub async fn get_workspace_mentionable_persons(
+    &self,
+    workspace_id: &Uuid,
+  ) -> Result<MentionablePersons, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/mentionable-person",
+      self.base_url, workspace_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    process_response_data::<MentionablePersons>(resp).await
+  }
+
+  pub async fn update_workspace_member_profile(
+    &self,
+    workspace_id: &Uuid,
+    updated_profile: &WorkspaceMemberProfile,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/update-member-profile",
+      self.base_url, workspace_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::PUT, &url)
+      .await?
+      .json(updated_profile)
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+}

--- a/libs/client-api/src/lib.rs
+++ b/libs/client-api/src/lib.rs
@@ -7,6 +7,7 @@ mod http_blob;
 mod http_collab;
 mod http_guest;
 mod http_member;
+mod http_person;
 mod http_publish;
 mod http_quick_note;
 mod http_search;

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -1313,6 +1313,68 @@ pub struct JoinWorkspaceByInviteCodeParams {
   pub code: String,
 }
 
+pub struct MentionableWorkspaceMemberOrGuest {
+  pub uuid: Uuid,
+  pub name: String,
+  pub email: String,
+  pub role: AFRole,
+  pub avatar_url: Option<String>,
+  pub cover_image_url: Option<String>,
+  pub description: Option<String>,
+}
+
+impl From<MentionableWorkspaceMemberOrGuest> for MentionablePerson {
+  fn from(val: MentionableWorkspaceMemberOrGuest) -> Self {
+    MentionablePerson {
+      uuid: val.uuid,
+      name: val.name,
+      email: val.email,
+      role: match val.role {
+        AFRole::Owner => MentionablePersonType::WorkspaceMember,
+        AFRole::Member => MentionablePersonType::WorkspaceMember,
+        AFRole::Guest => MentionablePersonType::WorkspaceGuest,
+      },
+      avatar_url: val.avatar_url,
+      cover_image_url: val.cover_image_url,
+      description: val.description,
+      invited: false,
+    }
+  }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WorkspaceMemberProfile {
+  pub name: String,
+  pub avatar_url: Option<String>,
+  pub cover_image_url: Option<String>,
+  pub description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MentionablePerson {
+  pub uuid: Uuid,
+  pub name: String,
+  pub email: String,
+  pub role: MentionablePersonType,
+  pub avatar_url: Option<String>,
+  pub cover_image_url: Option<String>,
+  pub description: Option<String>,
+  pub invited: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MentionablePersons {
+  pub persons: Vec<MentionablePerson>,
+}
+
+#[derive(Serialize_repr, Deserialize_repr, Debug)]
+#[repr(u8)]
+pub enum MentionablePersonType {
+  WorkspaceMember = 1,
+  WorkspaceGuest = 2,
+  Contact = 3,
+}
+
 #[cfg(test)]
 mod test {
   use crate::dto::{CreateCollabData, CreateCollabDataV0};

--- a/migrations/20250703030740_workspace_member_profile.sql
+++ b/migrations/20250703030740_workspace_member_profile.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS af_workspace_member_profile (
+  uid BIGINT NOT NULL,
+  workspace_id UUID NOT NULL,
+  name TEXT,
+  avatar_url TEXT,
+  cover_image_url TEXT,
+  description TEXT,
+  PRIMARY KEY (uid, workspace_id),
+  FOREIGN KEY (uid, workspace_id) REFERENCES af_workspace_member(uid, workspace_id) ON DELETE CASCADE
+);

--- a/tests/workspace/mod.rs
+++ b/tests/workspace/mod.rs
@@ -6,6 +6,7 @@ mod invitation_crud;
 mod join_workspace;
 mod member_crud;
 mod page_view;
+mod person;
 mod publish;
 mod published_data;
 mod quick_note;

--- a/tests/workspace/person.rs
+++ b/tests/workspace/person.rs
@@ -1,0 +1,30 @@
+use client_api::entity::WorkspaceMemberProfile;
+use client_api_test::generate_unique_registered_user_client;
+
+#[tokio::test]
+async fn workspace_mentionable_persons_crud() {
+  let (c, user) = generate_unique_registered_user_client().await;
+  let workspaces = c.get_workspaces().await.unwrap();
+  assert_eq!(workspaces.len(), 1);
+  let workspace_id = workspaces[0].workspace_id;
+  c.update_workspace_member_profile(
+    &workspace_id,
+    &WorkspaceMemberProfile {
+      name: "name override".to_string(),
+      avatar_url: Some("avatar url override".to_string()),
+      cover_image_url: Some("cover image url".to_string()),
+      description: Some("description override".to_string()),
+    },
+  )
+  .await
+  .unwrap();
+
+  let mentionable_persons = c
+    .get_workspace_mentionable_persons(&workspace_id)
+    .await
+    .unwrap()
+    .persons;
+  assert_eq!(mentionable_persons.len(), 1);
+  assert_eq!(mentionable_persons[0].email, user.email);
+  assert_eq!(mentionable_persons[0].name, "name override");
+}


### PR DESCRIPTION
1. Endpoint to update the user's own workspace member profile, which allow them to customize display name, avatar url, background url etc.
2. Endpoint to list all possible person that can be mentioned in a workspace.