### PR TITLE
support both ipv4 and ipv6 by default

### DIFF
--- a/services/appflowy-worker/src/main.rs
+++ b/services/appflowy-worker/src/main.rs
@@ -15,7 +15,7 @@ use tokio::net::TcpListener;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
   dotenvy::dotenv().ok();
 
-  let listener = TcpListener::bind("0.0.0.0:4001").await.unwrap();
+  let listener = TcpListener::bind("[::]:4001").await.unwrap();
   let config = Config::from_env()?;
   run_server(listener, config).await
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -207,7 +207,7 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
     },
     application: ApplicationSetting {
       port: get_env_var("APPFLOWY_APPLICATION_PORT", "8000").parse()?,
-      host: get_env_var("APPFLOWY_APPLICATION_HOST", "0.0.0.0"),
+      host: get_env_var("APPFLOWY_APPLICATION_HOST", "[::]"),
     },
     websocket: WebsocketSetting {
       heartbeat_interval: get_env_var("APPFLOWY_WEBSOCKET_HEARTBEAT_INTERVAL", "6").parse()?,


### PR DESCRIPTION
default to both ipv6 and ipv4 in Appflowy deployments.  Solves #1505 