### PR TITLE
feat: api to get mentionable person by id

### DIFF
--- a/.sqlx/query-6530216abfca09cfa97a9ac23f555c31a74c3c38af24660abca9542c5eb5abc9.json
+++ b/.sqlx/query-6530216abfca09cfa97a9ac23f555c31a74c3c38af24660abca9542c5eb5abc9.json
@@ -1,0 +1,59 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      SELECT\n        au.uuid,\n        COALESCE(awmp.name, au.name) AS \"name!\",\n        au.email,\n        awm.role_id AS \"role!\",\n        COALESCE(awmp.avatar_url, au.metadata ->> 'icon_url') AS \"avatar_url\",\n        awmp.cover_image_url,\n        awmp.description\n      FROM af_workspace_member awm\n      JOIN af_user au ON awm.uid = au.uid\n      LEFT JOIN af_workspace_member_profile awmp ON (awm.uid = awmp.uid AND awm.workspace_id = awmp.workspace_id)\n      WHERE awm.workspace_id = $1\n      AND au.uuid = $2\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "role!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "cover_image_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "description",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      false,
+      false,
+      null,
+      true,
+      true
+    ]
+  },
+  "hash": "6530216abfca09cfa97a9ac23f555c31a74c3c38af24660abca9542c5eb5abc9"
+}

--- a/libs/client-api/src/http_person.rs
+++ b/libs/client-api/src/http_person.rs
@@ -1,4 +1,4 @@
-use client_api_entity::{MentionablePersons, WorkspaceMemberProfile};
+use client_api_entity::{MentionablePerson, MentionablePersons, WorkspaceMemberProfile};
 use reqwest::Method;
 use shared_entity::response::AppResponseError;
 use tracing::instrument;
@@ -8,7 +8,7 @@ use crate::{process_response_data, process_response_error, Client};
 
 impl Client {
   #[instrument(level = "info", skip_all, err)]
-  pub async fn get_workspace_mentionable_persons(
+  pub async fn list_workspace_mentionable_persons(
     &self,
     workspace_id: &Uuid,
   ) -> Result<MentionablePersons, AppResponseError> {
@@ -22,6 +22,24 @@ impl Client {
       .send()
       .await?;
     process_response_data::<MentionablePersons>(resp).await
+  }
+
+  #[instrument(level = "info", skip_all, err)]
+  pub async fn get_workspace_mentionable_person(
+    &self,
+    workspace_id: &Uuid,
+    person_id: &Uuid,
+  ) -> Result<MentionablePerson, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/mentionable-person/{}",
+      self.base_url, workspace_id, person_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    process_response_data::<MentionablePerson>(resp).await
   }
 
   pub async fn update_workspace_member_profile(

--- a/src/biz/workspace/ops.rs
+++ b/src/biz/workspace/ops.rs
@@ -738,7 +738,7 @@ pub async fn num_pending_task(uid: i64, pg_pool: &PgPool) -> Result<i64, AppErro
   Ok(count)
 }
 
-pub async fn get_workspace_mentionable_persons(
+pub async fn list_workspace_mentionable_persons(
   pg_pool: &PgPool,
   workspace_id: &Uuid,
   uid: i64,
@@ -767,6 +767,23 @@ pub async fn get_workspace_mentionable_persons(
     );
   }
   Ok(persons)
+}
+
+pub async fn get_workspace_mentionable_person(
+  pg_pool: &PgPool,
+  workspace_id: &Uuid,
+  person_id: &Uuid,
+) -> Result<MentionablePerson, AppError> {
+  let mentionable_workspace_members_or_guests =
+    select_workspace_mentionable_member_or_guest_by_uuid(pg_pool, workspace_id, person_id).await?;
+  if let Some(mentionable) = mentionable_workspace_members_or_guests {
+    Ok(mentionable.into())
+  } else {
+    Err(AppError::RecordNotFound(format!(
+      "person with ID {} is neither a workspace member nor contact",
+      person_id
+    )))
+  }
 }
 
 pub async fn update_workspace_member_profile(

--- a/tests/workspace/person.rs
+++ b/tests/workspace/person.rs
@@ -20,11 +20,17 @@ async fn workspace_mentionable_persons_crud() {
   .unwrap();
 
   let mentionable_persons = c
-    .get_workspace_mentionable_persons(&workspace_id)
+    .list_workspace_mentionable_persons(&workspace_id)
     .await
     .unwrap()
     .persons;
   assert_eq!(mentionable_persons.len(), 1);
   assert_eq!(mentionable_persons[0].email, user.email);
   assert_eq!(mentionable_persons[0].name, "name override");
+  let person_id = mentionable_persons[0].uuid;
+  let mentionable_person = c
+    .get_workspace_mentionable_person(&workspace_id, &person_id)
+    .await
+    .unwrap();
+  assert_eq!(mentionable_person.email, user.email)
 }


### PR DESCRIPTION
API endpoint to get mentionable person by id.

## Summary by Sourcery

Enable retrieval of a specific mentionable workspace user or guest by UUID

New Features:
- Add GET /workspace/{workspace_id}/mentionable-person/{contact_id} endpoint to fetch a single mentionable person
- Expose client API method get_workspace_mentionable_person for individual retrieval

Enhancements:
- Rename get_workspace_mentionable_persons to list_workspace_mentionable_persons for consistency
- Implement select_workspace_mentionable_member_or_guest_by_uuid database query and corresponding business logic get_workspace_mentionable_person
- Add API handler get_workspace_mentionable_person_handler and wire it into workspace routing

Tests:
- Update integration test to call list_workspace_mentionable_persons and validate fetching an individual mentionable person by ID