### PR TITLE
fix: image urls point to beta.appflowy.cloud after self-hosted import

### DIFF
--- a/external_proxy_config/nginx/appflowy.site.conf
+++ b/external_proxy_config/nginx/appflowy.site.conf
@@ -76,6 +76,7 @@ server {
             # Set headers
             proxy_set_header X-Request-Id $request_id;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Host $scheme://$host;
 
             # Timeouts
             proxy_read_timeout 600s;


### PR DESCRIPTION
I have AppFlowy hosted in EC2 behind an externally-managed nginx proxy, with config based on the [external proxy template](https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/main/external_proxy_config/nginx/appflowy.site.conf). A test import succeeds, but all images fail to load in AppFlowy Web with 404 errors attempting to find the images at beta.appflowy.cloud, when the images are actually located under my domain. The AppFlowy app returns similar errors in logs:
```
  2025-07-07 17:07:12 ERROR dart_ffi: [Flutter]: Unable to load image: HttpException: Invalid statusCode: 404, uri = https://beta.appflowy.cloud/api/file_storage/1855357a-43a5-48c4-9b71-573990c43303/v1/blob/eaa670a1-989a-4e52-8193-cad1e01e66d6/h91Nio0_9WyQ-bUhRYbDQV5GLoQBl-zXxUeXiS0xbYs=.png - retryCount: 0
    at dart-ffi/src/lib.rs:302
```

I believe the `get_host_from_request` function [here](https://github.com/AppFlowy-IO/AppFlowy-Cloud/blob/main/src/api/data_import.rs#L386-L393) checks for the X-Host header, but this header is not set or passed by the external proxy template. Adding this header fixed the issue for me. I did not have the error when hosting using default nginx.conf file used by `docker-compose.yml`, and I'm not sure why or if it should be added there as well.

## Summary by Sourcery

Include X-Host header in the external nginx proxy configuration to ensure image URLs use the self-hosted domain rather than defaulting to beta.appflowy.cloud.

Bug Fixes:
- Add X-Host header to external nginx proxy config to fix image URL resolution for self-hosted imports

Enhancements:
- Update the external proxy nginx template to pass the full scheme and host via X-Host header