### PR TITLE
fix: Add postgres envvar to dev.env

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -14,6 +14,14 @@ DATABASE_URL=postgres://postgres:password@localhost:5432/postgres
 # .sqlx files must be pregenerated
 # SQLX_OFFLINE=true
 
+# PostgreSQL Settings
+POSTGRES_HOST=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_PORT=5432
+POSTGRES_DB=postgres
+
+
 # =============================================================================
 # ☁️ APPFLOWY SERVICES: Application service configuration
 # =============================================================================


### PR DESCRIPTION
The postgres envvar is missing in the dev.env, and this results in postgres' health check failing as it uses these envvars. this makes the health check default envvar like `POSTGRES_USER` to blank string. For some reason it is not enough just to specify them in the environment section of the docker compose file so add these to dev.env just like deploy.env