### PR TITLE
feat: disable provider token

### DIFF
--- a/docker/gotrue/Dockerfile
+++ b/docker/gotrue/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM golang as base
 WORKDIR /go/src/supabase
-RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch 0.8.0
+RUN git clone https://github.com/AppFlowy-IO/auth.git --depth 1 --branch disable-provider-token
 WORKDIR /go/src/supabase/auth
 RUN CGO_ENABLED=0 go build -o /auth .
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update docker/gotrue/Dockerfile to clone the disable-provider-token branch instead of the 0.8.0 tag