### PR TITLE
feat: add block id to page mention notification email url link

### DIFF
--- a/src/biz/notification/email.rs
+++ b/src/biz/notification/email.rs
@@ -65,6 +65,14 @@ impl EmailNotificationWorker {
           .collect();
 
         for mention in page_mentions {
+          let mut page_url = format!(
+            "{}/app/{}/{}",
+            self.appflowy_web_url, mention.workspace_id, mention.view_id
+          );
+          if let Some(block_id) = mention.block_id {
+            page_url.push_str(&format!("?blockId={}", block_id));
+          }
+
           let param = PageMentionNotificationMailerParam {
             workspace_name: mention.workspace_name,
             mentioned_page_name: mention.view_name,


### PR DESCRIPTION
Add block id to the page url in page mention notification email.

## Summary by Sourcery

Conditionally start the email notification worker based on configuration and include block IDs in page mention notification email URLs

Enhancements:
- Only spawn the email notification worker when enable_email_notification is set in config
- Append blockId query parameter to page mention notification email links when available