### PR TITLE
feat: endpoint to check whether row document collab exists

### DIFF
--- a/.sqlx/query-6fbcd1c32c638530461c74f8c8195a5b1e1e6f7a389a6a60d889c88c5f47302a.json
+++ b/.sqlx/query-6fbcd1c32c638530461c74f8c8195a5b1e1e6f7a389a6a60d889c88c5f47302a.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT EXISTS (\n            SELECT 1 FROM af_collab\n            WHERE oid = $1 AND deleted_at IS NULL\n        )\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6fbcd1c32c638530461c74f8c8195a5b1e1e6f7a389a6a60d889c88c5f47302a"
+}

--- a/libs/client-api/src/http_collab.rs
+++ b/libs/client-api/src/http_collab.rs
@@ -12,9 +12,10 @@ use client_api_entity::workspace_dto::{
   ListDatabaseRowUpdatedParam, UpsertDatatabaseRow,
 };
 use client_api_entity::{
-  AFCollabEmbedInfo, BatchQueryCollabParams, BatchQueryCollabResult, CollabParams,
-  CreateCollabData, CreateCollabParams, DeleteCollabParams, PublishCollabItem, QueryCollab,
-  QueryCollabParams, RepeatedAFCollabEmbedInfo, UpdateCollabWebParams,
+  AFCollabEmbedInfo, AFDatabaseRowDocumentCollabExistenceInfo, BatchQueryCollabParams,
+  BatchQueryCollabResult, CollabParams, CreateCollabData, CreateCollabParams, DeleteCollabParams,
+  PublishCollabItem, QueryCollab, QueryCollabParams, RepeatedAFCollabEmbedInfo,
+  UpdateCollabWebParams,
 };
 use collab_rt_entity::collab_proto::{CollabDocStateParams, PayloadCompressionType};
 use collab_rt_entity::HttpRealtimeMessage;
@@ -428,6 +429,24 @@ impl Client {
       .send()
       .await?;
     process_response_error(resp).await
+  }
+
+  pub async fn check_if_row_document_collab_exists(
+    &self,
+    workspace_id: &Uuid,
+    object_id: &Uuid,
+  ) -> Result<bool, AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{workspace_id}/collab/{object_id}/row-document-collab-exists",
+      self.base_url
+    );
+    let resp = self
+      .http_client_with_auth(Method::GET, &url)
+      .await?
+      .send()
+      .await?;
+    let info = process_response_data::<AFDatabaseRowDocumentCollabExistenceInfo>(resp).await?;
+    Ok(info.exists)
   }
 
   pub async fn get_collab_embed_info(

--- a/libs/database-entity/src/dto.rs
+++ b/libs/database-entity/src/dto.rs
@@ -453,6 +453,11 @@ pub struct QueryWorkspaceMember {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct AFDatabaseRowDocumentCollabExistenceInfo {
+  pub exists: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AFCollabEmbedInfo {
   pub object_id: Uuid,
   /// The timestamp when the object's embeddings updated

--- a/libs/database/src/collab/collab_db_ops.rs
+++ b/libs/database/src/collab/collab_db_ops.rs
@@ -230,6 +230,24 @@ where
   Ok(records)
 }
 
+pub async fn select_collab_id_exists<'a, E>(conn: E, object_id: &Uuid) -> Result<bool, sqlx::Error>
+where
+  E: Executor<'a, Database = Postgres>,
+{
+  let exists = sqlx::query_scalar!(
+    r#"
+        SELECT EXISTS (
+            SELECT 1 FROM af_collab
+            WHERE oid = $1 AND deleted_at IS NULL
+        )
+        "#,
+    object_id,
+  )
+  .fetch_one(conn)
+  .await?;
+  Ok(exists.unwrap_or(false))
+}
+
 #[inline]
 pub async fn select_blob_from_af_collab<'a, E>(
   conn: E,

--- a/tests/collab/database_crud.rs
+++ b/tests/collab/database_crud.rs
@@ -37,6 +37,12 @@ async fn database_row_upsert_with_doc() {
       row_detail.doc,
       Some(String::from("This is a document of a database row"))
     );
+    let row_uuid = uuid::Uuid::parse_str(&row_id).unwrap();
+    let row_collab_doc_exists = &c
+      .check_if_row_document_collab_exists(&workspace_id, &row_uuid)
+      .await
+      .unwrap();
+    assert!(row_collab_doc_exists)
   }
   // Upsert row with another doc
   let _ = c


### PR DESCRIPTION
AppFlowy Web require this endpoint to properly decide how to open a database row's document.

## Summary by Sourcery

Introduce a new endpoint and supporting logic to check whether a database row’s document collaboration exists.

New Features:
- Add GET /v1/{workspace_id}/collab/{object_id}/row-document-collab-exists endpoint and handler returning an existence flag
- Implement client API method check_if_row_document_collab_exists to query the new endpoint
- Add business logic and SQL function to derive and check row document collab existence in the database

Enhancements:
- Introduce AFDatabaseRowDocumentCollabExistenceInfo DTO for standardizing the existence response

Tests:
- Add integration test to verify row document collab existence after creation