### PR TITLE
fix: update docker compose env for appflowy web image using ws protocol v2

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -4,15 +4,17 @@
 # This file is a template for docker compose deployment
 # Copy this file to .env and change the values as needed
 
-
 # Fully qualified domain name for the deployment. Replace localhost with your domain,
 # such as mydomain.com.
 FQDN=localhost
 
-# Change this to https if you wish to enable TLS.
+# Change this to https if you are using TLS.
 SCHEME=http
+# Change this to wss if you are using TLS
+WS_SCHEME=ws
 
 APPFLOWY_BASE_URL=${SCHEME}://${FQDN}
+APPFLOWY_WEBSOCKET_BASE_URL=${WS_SCHEME}://${FQDN}/ws/v2
 
 # =============================================================================
 # 🗄️ DATABASE & CACHE: Core data infrastructure
@@ -346,3 +348,4 @@ CLOUDFLARE_TUNNEL_TOKEN=
 # Enable AI tests in production environment (usually false)
 # Set to true only if you want to run AI-related tests in production
 AI_TEST_ENABLED=false
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,10 @@ services:
     image: appflowyinc/appflowy_web:${APPFLOWY_WEB_VERSION:-latest}
     depends_on:
       - appflowy_cloud
+    environment:
+      - AF_BASE_URL=${APPFLOWY_BASE_URL}
+      - AF_GOTRUE_URL=${APPFLOWY_BASE_URL}/gotrue
+      - AF_WS_V2_URL=${APPFLOWY_WEBSOCKET_BASE_URL}
 volumes:
   postgres_data:
   minio_data:


### PR DESCRIPTION
Add additional web socket images required for the new appflowy web image using ws/v2

## Summary by Sourcery

Update docker-compose configuration to support WebSocket v2 in the AppFlowy web service

Enhancements:
- Add AF_BASE_URL, AF_GOTRUE_URL, and AF_WS_V2_URL environment variables to the appflowy_web service in docker-compose.yml

Deployment:
- Bump deploy environment for the new web image using ws/v2 protocol