### PR TITLE
Fix:  web websocket connect issue

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -77,12 +77,34 @@ http {
 
         # WebSocket
         location /ws {
+            # Handle preflight OPTIONS requests
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' $http_origin always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
+                add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, X-Requested-With' always;
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+                add_header 'Access-Control-Max-Age' 1728000 always;
+                add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+                add_header 'Content-Length' 0 always;
+                return 204;
+            }
+
+            # Add CORS headers to all responses
+            add_header 'Access-Control-Allow-Origin' $http_origin always;
+            add_header 'Access-Control-Allow-Credentials' 'true' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, X-Requested-With' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+
+            # Existing proxy configuration
             proxy_pass $appflowy_cloud_backend;
 
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_read_timeout 86400s;
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Enable CORS for WebSocket connections in Nginx by handling preflight OPTIONS requests and adding requisite headers, and propagate client forwarding headers to the backend.

Enhancements:
- Handle preflight OPTIONS requests on the /ws endpoint with appropriate CORS headers and a 204 response
- Add Access-Control-Allow-* headers to all responses on the /ws location

Deployment:
- Set X-Real-IP, X-Forwarded-For, and X-Forwarded-Proto headers when proxying WebSocket traffic