### PR TITLE
fix: use base url environment variable for health check gotrue

### DIFF
--- a/script/lib/check_config.sh
+++ b/script/lib/check_config.sh
@@ -1083,7 +1083,7 @@ check_user_auth_flow() {
     fi
 
     # Verify GoTrue is accessible
-    local gotrue_health=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost/gotrue/health" --max-time 3 2>/dev/null)
+    local gotrue_health=$(curl -s -o /dev/null -w "%{http_code}" "${APPFLOWY_BASE_URL:-http://localhost}/gotrue/health" --max-time 3 2>/dev/null)
 
     if [[ "$gotrue_health" == "200" ]]; then
         print_success "User Auth: GoTrue service healthy"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix GoTrue health check failing when the service is not hosted on localhost by using the APPFLOWY_BASE_URL environment variable as the base URL.