### PR TITLE
fix: make pre_hash optional and add row_id to UpsertDatatabaseRow

### DIFF
--- a/libs/shared-entity/src/dto/workspace_dto.rs
+++ b/libs/shared-entity/src/dto/workspace_dto.rs
@@ -550,7 +550,12 @@ pub struct AddDatatabaseRow {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct UpsertDatatabaseRow {
-  pub pre_hash: String, // input which will be hashed into database row id
+  /// Optional. Input hashed into a database row id (SHA256 of workspace_id + db_id + pre_hash).
+  /// If omitted, a random UUID is generated (useful for creating new rows without dedup).
+  pub pre_hash: Option<String>,
+  /// Optional. If provided, directly use this UUID as the row id for upsert.
+  /// Useful when you already know the row id (e.g. from a previous create or from list).
+  pub row_id: Option<String>,
   pub cells: HashMap<String, serde_json::Value>,
   pub document: Option<String>,
 }

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -2630,21 +2630,30 @@ async fn put_database_row_handler(
 
   let UpsertDatatabaseRow {
     pre_hash,
+    row_id,
     cells,
     document,
   } = upsert_db_row.into_inner();
 
-  let row_id = {
-    let mut hasher = Sha256::new();
-    hasher.update(workspace_id);
-    hasher.update(db_id);
-    hasher.update(pre_hash);
-    let hash = hasher.finalize();
-    Uuid::from_bytes([
-      // take 16 out of 32 bytes
-      hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7], hash[8], hash[9],
-      hash[10], hash[11], hash[12], hash[13], hash[14], hash[15],
-    ])
+  let row_id = match row_id {
+    Some(id) => Uuid::parse_str(&id).map_err(|_| AppError::InvalidRequest("Invalid row_id format".into()))?,
+    None => {
+      match pre_hash {
+        Some(hash) => {
+          let mut hasher = Sha256::new();
+          hasher.update(workspace_id);
+          hasher.update(db_id);
+          hasher.update(hash);
+          let hash = hasher.finalize();
+          Uuid::from_bytes([
+            // take 16 out of 32 bytes
+            hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7], hash[8], hash[9],
+            hash[10], hash[11], hash[12], hash[13], hash[14], hash[15],
+          ])
+        },
+        None => Uuid::new_v4(),
+      }
+    },
   };
 
   biz::collab::ops::upsert_database_row(&state, workspace_id, db_id, uid, row_id, cells, document)


### PR DESCRIPTION
## Summary

The  endpoint currently requires a  field which is used to derive the row's UUID via SHA256. This makes it impossible to update existing rows because:

1. The  is computed client-side as  — no API exposes this for existing rows
2. The  endpoint returns 404

This PR fixes the issue by:

### Changes

**libs/shared-entity/src/dto/workspace_dto.rs**
- Changed  from  to  (backward compatible)
- Added optional  field
- Added documentation explaining the precedence logic

**src/api/workspace.rs** ( handler)
- If  is provided → use it directly as the row UUID
- If  is provided → compute UUID via SHA256 (existing behavior)
- If neither → generate a random UUID (new behavior)

This allows both creating new rows without a , and updating existing rows by passing the known .

## Testing

- Existing tests should pass (backward compatible —  still works when provided)
- New behavior verified by the AppFlowy MCP server

## Summary by Sourcery

Make database row upserts support optional pre-hash values and direct row ID specification to enable both new row creation and updates of existing rows.

New Features:
- Allow clients to specify an explicit row_id when upserting a database row, using it directly as the row UUID.
- Support creating database rows without providing a pre_hash by generating a random UUID when neither row_id nor pre_hash is supplied.

Enhancements:
- Make the pre_hash field in UpsertDatatabaseRow optional and document the precedence logic between row_id, pre_hash, and random UUID generation.