### PR TITLE
fix: drain remaining snapshot tasks

### DIFF
--- a/services/appflowy-collaborate/src/collab/snapshot_scheduler.rs
+++ b/services/appflowy-collaborate/src/collab/snapshot_scheduler.rs
@@ -48,6 +48,14 @@ impl SnapshotScheduler {
     Some(workspaces)
   }
 
+  async fn drain_snapshot_tasks(tasks: &mut JoinSet<()>) {
+    while let Some(result) = tasks.join_next().await {
+      if let Err(err) = result {
+        tracing::error!("Snapshot task failed: {}", err);
+      }
+    }
+  }
+
   async fn snapshot_task(
     mut receiver: UnboundedReceiver<(Uuid, Rid)>,
     collab_store: Arc<CollabManager>,
@@ -73,13 +81,13 @@ impl SnapshotScheduler {
         });
         i += 1;
         if i >= Self::CONCURRENCY_LIMIT {
-          while let Some(result) = tasks.join_next().await {
-            if let Err(err) = result {
-              tracing::error!("Snapshot task failed: {}", err);
-            }
-          }
+          Self::drain_snapshot_tasks(&mut tasks).await;
           i = 0;
         }
+      }
+
+      if i > 0 {
+        Self::drain_snapshot_tasks(&mut tasks).await;
       }
     }
   }


### PR DESCRIPTION
## Summary
- drain snapshot `JoinSet` tasks through a shared helper
- wait for the final partial batch so pending snapshot tasks are not aborted when `JoinSet` is dropped

## Testing
- Not run locally: current Codex sandbox fails to start commands with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`.

## Summary by Sourcery

Ensure snapshot scheduler drains all pending snapshot tasks before dropping the task set to avoid aborting in-flight work.

Bug Fixes:
- Prevent snapshot tasks from being aborted by draining remaining tasks, including the final partial batch, before the JoinSet is dropped.

Enhancements:
- Introduce a shared helper to drain snapshot task JoinSet instances and centralize error logging for failed snapshot tasks.