### PR TITLE
feat: expose Relation field in row detail response

### DIFF
--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -2735,6 +2735,10 @@ async fn list_database_row_details_handler(
     .enforce_action(&uid, &workspace_id, Action::Read)
     .await?;
 
+  // No filtered-out field types: every FieldType (including Relation) is
+  // surfaced through this endpoint. The `unsupported_field_types` parameter
+  // is kept on the ops API so callers that need to mask specific field types
+  // can opt in without a signature change.
   let db_rows = biz::collab::ops::list_database_row_details(
     &state.collab_storage,
     uid,

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -52,7 +52,6 @@ use collab::core::collab::{default_client_id, CollabOptions, DataSource};
 use collab::core::origin::CollabOrigin;
 use collab::entity::EncodedCollab;
 use collab::preclude::Collab;
-use collab_database::entity::FieldType;
 use collab_document::document::Document;
 use collab_entity::CollabType;
 use collab_folder::timestamp;
@@ -2736,15 +2735,13 @@ async fn list_database_row_details_handler(
     .enforce_action(&uid, &workspace_id, Action::Read)
     .await?;
 
-  static UNSUPPORTED_FIELD_TYPES: &[FieldType] = &[FieldType::Relation];
-
   let db_rows = biz::collab::ops::list_database_row_details(
     &state.collab_storage,
     uid,
     workspace_id,
     db_id,
     &row_ids,
-    UNSUPPORTED_FIELD_TYPES,
+    &[],
     with_doc,
   )
   .await?;

--- a/tests/collab/database_crud.rs
+++ b/tests/collab/database_crud.rs
@@ -267,52 +267,58 @@ async fn database_fields_crud() {
 }
 
 #[tokio::test]
-async fn database_fields_unsupported_field_type() {
+async fn database_row_with_relation_field() {
   let (c, _user) = generate_unique_registered_user_client().await;
   let workspace_id = workspace_id_from_client(&c).await;
   let databases = c.list_databases(&workspace_id).await.unwrap();
   assert_eq!(databases.len(), 1);
   let todo_db = &databases[0];
 
-  let my_rel_field_id = {
-    c.add_database_field(
+  // A Relation field points at another database via `database_id` in its
+  // type-option payload. For the purposes of this test we point it at the
+  // same database — the read path only cares that the field deserializes
+  // as a Relation, not that the target rows resolve.
+  let my_rel_field_id = c
+    .add_database_field(
       &workspace_id,
       &todo_db.id,
       &AFInsertDatabaseField {
         name: "MyRelationCol".to_string(),
         field_type: FieldType::Relation.into(),
-        ..Default::default()
+        type_option_data: Some(json!({ "database_id": todo_db.id.to_string() })),
       },
     )
     .await
-    .unwrap()
-  };
-  {
-    let my_description = "my task 123";
-    let my_status = "To Do";
-    let new_row_id = c
-      .add_database_item(
-        &workspace_id,
-        &todo_db.id,
-        HashMap::from([
-          (String::from("Description"), json!(my_description)),
-          (String::from("Status"), json!(my_status)),
-          (String::from("Multiselect"), json!(["social", "news"])),
-          (my_rel_field_id, json!("relation_data")),
-        ]),
-        None,
-      )
-      .await
-      .unwrap();
+    .unwrap();
 
-    let row_details = c
-      .list_database_row_details(&workspace_id, &todo_db.id, &[&new_row_id], false)
-      .await
-      .unwrap();
-    assert_eq!(row_details.len(), 1);
-    let new_row_detail = &row_details[0];
-    assert!(!new_row_detail.cells.contains_key("MyRelationCol"));
-  }
+  let related_row_id = "11111111-1111-1111-1111-111111111111";
+  let new_row_id = c
+    .add_database_item(
+      &workspace_id,
+      &todo_db.id,
+      HashMap::from([
+        (String::from("Description"), json!("my task 123")),
+        (String::from("Status"), json!("To Do")),
+        (
+          my_rel_field_id.clone(),
+          json!({ "row_ids": [related_row_id] }),
+        ),
+      ]),
+      None,
+    )
+    .await
+    .unwrap();
+
+  let row_details = c
+    .list_database_row_details(&workspace_id, &todo_db.id, &[&new_row_id], false)
+    .await
+    .unwrap();
+  assert_eq!(row_details.len(), 1);
+  let new_row_detail = &row_details[0];
+  assert_eq!(
+    new_row_detail.cells["MyRelationCol"],
+    json!({ "row_ids": [related_row_id] })
+  );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Resolves #1531.

## Summary
- `GET /workspace/{wsid}/database/{dbid}/row/detail` now returns Relation cells instead of dropping them via the hardcoded `UNSUPPORTED_FIELD_TYPES` filter.
- The cell is serialized as `{"row_ids": ["<uuid>", ...]}` — the same shape `convert_json_to_cell` already accepts on the write side.

## Motivation
`collab-database` already implements both `TypeOptionCellReader` and `TypeOptionCellWriter` for `RelationTypeOption`, the cell is stored end-to-end, and the desktop / mobile clients already render it. The server-side filter was the only thing hiding it from REST consumers — this is a read-side completion of an already-supported round-trip.

## What changed
- `src/api/workspace.rs`: drop `FieldType::Relation` from `UNSUPPORTED_FIELD_TYPES` so the existing `TypeOptionCellReader` for relations is exercised.
- `tests/collab/database_crud.rs`: rename `database_fields_unsupported_field_type` to `database_row_with_relation_field`. The renamed test creates a Relation field with a populated `database_id`, writes a row whose relation cell points at a synthetic UUID, and asserts the row-detail endpoint returns the same `{"row_ids": [...]}` payload.

## Tested
- `database_row_with_relation_field` exercises the full write/read round-trip through the public API (replaces the old "assert that relation is filtered out" test).

## Summary by Sourcery

Expose relation field data in database row detail responses and update tests to assert the new behavior.

New Features:
- Include Relation field cells in workspace database row detail API responses, returning their stored relation payloads instead of filtering them out.

Tests:
- Replace the previous "relation field is filtered out" test with a new end-to-end test that creates a relation field, writes a related row, and asserts the row detail response returns the expected relation payload.