### PR TITLE
feat: add PATCH /database/{db}/row/{row_id} for id-stable row upsert

### DIFF
--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -404,6 +404,10 @@ pub fn workspace_scope() -> Scope {
         .route(web::get().to(list_database_row_details_handler)),
     )
     .service(
+      web::resource("/{workspace_id}/database/{database_id}/row/{row_id}")
+        .route(web::patch().to(patch_database_row_handler)),
+    )
+    .service(
       web::resource("/{workspace_id}/quick-note")
         .route(web::get().to(list_quick_notes_handler))
         .route(web::post().to(post_quick_note_handler)),
@@ -2613,6 +2617,34 @@ async fn post_database_row_handler(
     biz::collab::ops::insert_database_row(&state, workspace_id, db_id, uid, None, cells, document)
       .await?;
   Ok(Json(AppResponse::Ok().with_data(new_db_row_id)))
+}
+
+async fn patch_database_row_handler(
+  user_uuid: UserUuid,
+  path_param: web::Path<(Uuid, Uuid, Uuid)>,
+  state: Data<AppState>,
+  add_database_row: Json<AddDatatabaseRow>,
+) -> Result<Json<AppResponse<()>>> {
+  let (workspace_id, db_id, row_id) = path_param.into_inner();
+  let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  state
+    .workspace_access_control
+    .enforce_action(&uid, &workspace_id, Action::Write)
+    .await?;
+
+  let AddDatatabaseRow { cells, document } = add_database_row.into_inner();
+
+  biz::collab::ops::upsert_database_row(
+    &state,
+    workspace_id,
+    db_id,
+    uid,
+    row_id,
+    cells,
+    document,
+  )
+  .await?;
+  Ok(Json(AppResponse::Ok()))
 }
 
 async fn put_database_row_handler(


### PR DESCRIPTION
## Summary
- Exposes the existing `biz::collab::ops::upsert_database_row` op over HTTP at `PATCH /api/workspace/{workspace_id}/database/{database_id}/row/{row_id}`.
- Semantics: if the row exists, the cells passed in the body (and document body, if any) are updated in place, preserving cells the caller didn't touch; if the row is missing, it is created with the given id.

## Motivation
The existing surface on `/row` has two shapes that don't cover one common case:
- `POST /row` mints a server-side row id — loses idempotency for external syncers.
- `PUT /row` is the hash-based upsert — forces the caller to know the right `pre_hash`.

External sync tools (Notion / Linear / Airtable importers) typically keep a stable mapping from a source-side id to an AppFlowy row uuid and want "upsert with the id I already chose, preserving cells I don't touch". `PATCH /row/{row_id}` fills that gap. The op already implements the right semantics — this only wires it to a route.

## What changed
`src/api/workspace.rs`:
- Add the `PATCH /{workspace_id}/database/{database_id}/row/{row_id}` route to `workspace_scope()`.
- Add `patch_database_row_handler`. Mirrors `post_database_row_handler`: same `AddDatatabaseRow { cells, document }` body, same `workspace_access_control.enforce_action(uid, ws, Action::Write)` check. Delegates to `biz::collab::ops::upsert_database_row`. Response is `AppResponse<()>` since the id is already in the path.

## Tested
- The underlying op `upsert_database_row` already has coverage in the existing database CRUD tests (used by the desktop client write path).
- Manual smoke test: PATCH with a known row id on an empty database creates the row; a follow-up PATCH on the same id updates only the supplied cells and leaves untouched cells intact.

## Summary by Sourcery

New Features:
- Add PATCH /{workspace_id}/database/{database_id}/row/{row_id} API endpoint to upsert a database row by a client-provided row id while preserving untouched cells.