### PR TITLE
feat: add PATCH /database/{db}/fields/{field_id} for updating an existing field

### DIFF
--- a/libs/client-api/src/http_collab.rs
+++ b/libs/client-api/src/http_collab.rs
@@ -231,6 +231,30 @@ impl Client {
     process_response_data::<String>(resp).await
   }
 
+  // Overwrites an existing database field's name, field_type and
+  // type_option_data. field_id is the short collab-internal id (e.g.
+  // "iS5TaT"), not a UUID. There is no merge — the supplied values fully
+  // replace what was on the field.
+  pub async fn update_database_field(
+    &self,
+    workspace_id: &Uuid,
+    database_id: &str,
+    field_id: &str,
+    insert_field: &AFInsertDatabaseField,
+  ) -> Result<(), AppResponseError> {
+    let url = format!(
+      "{}/api/workspace/{}/database/{}/fields/{}",
+      self.base_url, workspace_id, database_id, field_id
+    );
+    let resp = self
+      .http_client_with_auth(Method::PATCH, &url)
+      .await?
+      .json(insert_field)
+      .send()
+      .await?;
+    process_response_error(resp).await
+  }
+
   pub async fn list_database_row_ids_updated(
     &self,
     workspace_id: &Uuid,

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -396,6 +396,10 @@ pub fn workspace_scope() -> Scope {
         .route(web::post().to(post_database_fields_handler)),
     )
     .service(
+      web::resource("/{workspace_id}/database/{database_id}/fields/{field_id}")
+        .route(web::patch().to(patch_database_field_handler)),
+    )
+    .service(
       web::resource("/{workspace_id}/database/{database_id}/row/updated")
         .route(web::get().to(list_database_row_id_updated_handler)),
     )
@@ -2687,6 +2691,36 @@ async fn post_database_fields_handler(
     biz::collab::ops::add_database_field(&state, workspace_id, db_id, field.into_inner()).await?;
 
   Ok(Json(AppResponse::Ok().with_data(field_id)))
+}
+
+// PATCH /api/workspace/{workspace_id}/database/{database_id}/fields/{field_id}
+// Overwrite an existing field's name, field_type and type_option_data. The
+// {field_id} path segment is the short collab-internal id (e.g. "iS5TaT"),
+// not a UUID. The request body uses the same AFInsertDatabaseField shape as
+// POST /fields so the migrator can reuse the DTO.
+async fn patch_database_field_handler(
+  user_uuid: UserUuid,
+  path_param: web::Path<(Uuid, Uuid, String)>,
+  state: Data<AppState>,
+  field: Json<AFInsertDatabaseField>,
+) -> Result<Json<AppResponse<()>>> {
+  let (workspace_id, db_id, field_id) = path_param.into_inner();
+  let uid = state.user_cache.get_user_uid(&user_uuid).await?;
+  state
+    .workspace_access_control
+    .enforce_action(&uid, &workspace_id, Action::Write)
+    .await?;
+
+  biz::collab::ops::update_database_field(
+    &state,
+    workspace_id,
+    db_id,
+    field_id,
+    field.into_inner(),
+  )
+  .await?;
+
+  Ok(Json(AppResponse::Ok()))
 }
 
 async fn list_database_row_id_updated_handler(

--- a/src/biz/collab/ops.rs
+++ b/src/biz/collab/ops.rs
@@ -838,6 +838,72 @@ pub async fn add_database_field(
   Ok(new_id)
 }
 
+// Overwrites an existing database field's name, field_type and type_options.
+// The field is looked up by its short collab-internal id (e.g. "iS5TaT"), not
+// by name. All three properties from `insert_field` replace whatever was
+// previously on the field — there is no merge. If the field_type changes, the
+// old type_option key is dropped so we don't leave a stale payload behind.
+pub async fn update_database_field(
+  state: &AppState,
+  workspace_id: Uuid,
+  database_id: Uuid,
+  field_id: String,
+  insert_field: AFInsertDatabaseField,
+) -> Result<(), AppError> {
+  let (mut db_collab, db_body) =
+    get_latest_collab_database_body(&state.collab_storage, workspace_id, database_id).await?;
+
+  // Parse the new type_option_data up front so we fail with a clean 400
+  // before mutating any collab state.
+  let type_option_data = insert_field
+    .type_option_data
+    .unwrap_or(serde_json::json!({}));
+  let new_tod: collab_database::fields::TypeOptionData =
+    serde_json::from_value(type_option_data).map_err(|err| {
+      AppError::InvalidRequest(format!("Failed to parse type option: {:?}", err))
+    })?;
+
+  let db_collab_update = {
+    let mut yrs_txn = db_collab.transact_mut();
+    let old_field_type = {
+      let existing = db_body.fields.get_field(&yrs_txn, &field_id).ok_or_else(|| {
+        AppError::RecordNotFound(format!("field '{}' not found in database", field_id))
+      })?;
+      existing.field_type
+    };
+    let new_field_type = insert_field.field_type;
+
+    db_body
+      .fields
+      .update_field(&mut yrs_txn, &field_id, |update| {
+        let mut u = update
+          .set_name(insert_field.name)
+          .set_field_type(new_field_type);
+        // Drop the old type_option payload if the field's type changed, so the
+        // collab doesn't carry both keys.
+        if old_field_type != new_field_type {
+          u = u.set_type_option(old_field_type, None);
+        }
+        u.set_type_option(new_field_type, Some(new_tod));
+      });
+
+    yrs_txn.encode_update_v1()
+  };
+
+  state
+    .ws_server
+    .publish_update(
+      workspace_id,
+      database_id,
+      CollabType::Database,
+      &CollabOrigin::Server,
+      db_collab_update,
+    )
+    .await?;
+
+  Ok(())
+}
+
 pub async fn list_database_row_ids_updated(
   collab_storage: &Arc<dyn CollabStore>,
   pg_pool: &PgPool,

--- a/tests/collab/database_crud.rs
+++ b/tests/collab/database_crud.rs
@@ -316,6 +316,86 @@ async fn database_fields_unsupported_field_type() {
 }
 
 #[tokio::test]
+async fn database_field_update_via_patch() {
+  let (c, _user) = generate_unique_registered_user_client().await;
+  let workspace_id = workspace_id_from_client(&c).await;
+  let databases = c.list_databases(&workspace_id).await.unwrap();
+  assert_eq!(databases.len(), 1);
+  let todo_db = &databases[0];
+
+  // Create a SingleSelect field with an initial set of options. The exact
+  // structure of `content` is what the AppFlowy client writes — a serialized
+  // SelectTypeOption JSON string under the "content" key.
+  let initial_content = json!({
+    "options": [
+      { "id": "opt1", "name": "Low",    "color": "Yellow" },
+      { "id": "opt2", "name": "Medium", "color": "Orange" }
+    ],
+    "disable_color": false
+  })
+  .to_string();
+  let field_id = c
+    .add_database_field(
+      &workspace_id,
+      &todo_db.id,
+      &AFInsertDatabaseField {
+        name: "Priority".to_string(),
+        field_type: FieldType::SingleSelect.into(),
+        type_option_data: Some(json!({ "content": initial_content })),
+      },
+    )
+    .await
+    .unwrap();
+
+  // Now PATCH the field with a completely different name and option list —
+  // different option ids, different names, different colours.
+  let new_content = json!({
+    "options": [
+      { "id": "p_lo",  "name": "P3",      "color": "Lime"   },
+      { "id": "p_mid", "name": "P2",      "color": "Aqua"   },
+      { "id": "p_hi",  "name": "P1",      "color": "Pink"   },
+      { "id": "p_now", "name": "Urgent",  "color": "Purple" }
+    ],
+    "disable_color": false
+  })
+  .to_string();
+  c.update_database_field(
+    &workspace_id,
+    &todo_db.id,
+    &field_id,
+    &AFInsertDatabaseField {
+      name: "Severity".to_string(),
+      field_type: FieldType::SingleSelect.into(),
+      type_option_data: Some(json!({ "content": new_content.clone() })),
+    },
+  )
+  .await
+  .unwrap();
+
+  // Read back via GET /fields and confirm the patched values are visible.
+  let fields = c
+    .get_database_fields(&workspace_id, &todo_db.id)
+    .await
+    .unwrap();
+  let patched = fields
+    .iter()
+    .find(|f| f.id == field_id)
+    .expect("patched field is still present after update");
+  assert_eq!(patched.name, "Severity");
+  assert_eq!(patched.field_type, "SingleSelect");
+
+  // The serde representation of a SingleSelect type_option is the parsed
+  // content payload (an object with `options` and `disable_color`).
+  let opts = &patched.type_option["options"];
+  let opts = opts.as_array().expect("options is an array");
+  assert_eq!(opts.len(), 4);
+  let names: Vec<&str> = opts.iter().map(|o| o["name"].as_str().unwrap()).collect();
+  assert_eq!(names, vec!["P3", "P2", "P1", "Urgent"]);
+  let colors: Vec<&str> = opts.iter().map(|o| o["color"].as_str().unwrap()).collect();
+  assert_eq!(colors, vec!["Lime", "Aqua", "Pink", "Purple"]);
+}
+
+#[tokio::test]
 async fn database_insert_row_with_doc() {
   let (c, _user) = generate_unique_registered_user_client().await;
   let workspace_id = workspace_id_from_client(&c).await;

--- a/tests/collab/database_crud.rs
+++ b/tests/collab/database_crud.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use app_error::ErrorCode;
 use client_api_test::{generate_unique_registered_user_client, workspace_id_from_client};
 use collab_database::entity::FieldType;
 use serde_json::json;
@@ -393,6 +394,80 @@ async fn database_field_update_via_patch() {
   assert_eq!(names, vec!["P3", "P2", "P1", "Urgent"]);
   let colors: Vec<&str> = opts.iter().map(|o| o["color"].as_str().unwrap()).collect();
   assert_eq!(colors, vec!["Lime", "Aqua", "Pink", "Purple"]);
+}
+
+// Regression test for the "fail before mutate" contract of PATCH /fields:
+// when the request body's `type_option_data` cannot be parsed as a
+// `TypeOptionData` (HashMap<String, Any> on the collab side), the handler must
+// return 400 and leave the field untouched in storage.
+#[tokio::test]
+async fn database_field_update_via_patch_rejects_invalid_type_option_data() {
+  let (c, _user) = generate_unique_registered_user_client().await;
+  let workspace_id = workspace_id_from_client(&c).await;
+  let databases = c.list_databases(&workspace_id).await.unwrap();
+  assert_eq!(databases.len(), 1);
+  let todo_db = &databases[0];
+
+  // Seed a SingleSelect field with a known payload that we can fingerprint
+  // before and after the failed PATCH.
+  let initial_content = json!({
+    "options": [
+      { "id": "opt1", "name": "Low",    "color": "Yellow" },
+      { "id": "opt2", "name": "Medium", "color": "Orange" }
+    ],
+    "disable_color": false
+  })
+  .to_string();
+  let field_id = c
+    .add_database_field(
+      &workspace_id,
+      &todo_db.id,
+      &AFInsertDatabaseField {
+        name: "Priority".to_string(),
+        field_type: FieldType::SingleSelect.into(),
+        type_option_data: Some(json!({ "content": initial_content })),
+      },
+    )
+    .await
+    .unwrap();
+  let before = c
+    .get_database_fields(&workspace_id, &todo_db.id)
+    .await
+    .unwrap()
+    .into_iter()
+    .find(|f| f.id == field_id)
+    .expect("seeded field is present");
+
+  // Send PATCH with a `type_option_data` that is NOT an object. A JSON array
+  // fails `serde_json::from_value::<HashMap<String, Any>>`, which is the same
+  // path the handler takes before touching collab state.
+  let err = c
+    .update_database_field(
+      &workspace_id,
+      &todo_db.id,
+      &field_id,
+      &AFInsertDatabaseField {
+        name: "ShouldNotApply".to_string(),
+        field_type: FieldType::RichText.into(),
+        type_option_data: Some(json!([])),
+      },
+    )
+    .await
+    .expect_err("PATCH with non-object type_option_data must fail");
+  assert_eq!(err.code, ErrorCode::InvalidRequest);
+
+  // Refetch and assert the field is byte-identical to its pre-PATCH state.
+  let after = c
+    .get_database_fields(&workspace_id, &todo_db.id)
+    .await
+    .unwrap()
+    .into_iter()
+    .find(|f| f.id == field_id)
+    .expect("field is still present after rejected PATCH");
+  assert_eq!(after.name, before.name);
+  assert_eq!(after.field_type, before.field_type);
+  assert_eq!(after.type_option, before.type_option);
+  assert_eq!(after.is_primary, before.is_primary);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/workspace/{workspace_id}/database/{database_id}/fields/{field_id}` so an existing database field's `name`, `field_type`, and `type_option_data` can be updated in place.
- Adds the matching `Client::update_database_field` in `client-api`.

## Motivation
There is currently no REST way to update an existing field's schema. `GET /fields` and `POST /fields` exist; the only update path is to delete and re-add, which loses the field id and breaks every cell that referenced it. PATCH completes the field CRUD surface.

Concrete use cases:
- External migrators (e.g. Notion → AppFlowy) that need to repair a `SingleSelect` / `MultiSelect` / `Status` field whose `type_option_data` was first written with a `SelectOptionColor` variant not in `collab-database`'s enum — those bad colours cause the cell-write path's `unwrap_or_default()` to fall back to an empty options vec, leaving cells silently empty. With PATCH the migrator can fix the palette in place without dropping the database.
- Renaming a field after the fact without rebuilding the database.

## What changed
- `src/biz/collab/ops.rs`: new `update_database_field` op. Mirrors `add_database_field` but targets an existing field by its short collab-internal id (e.g. `"iS5TaT"`). All three properties from `AFInsertDatabaseField` — `name`, `field_type`, `type_option_data` — fully replace the existing values (no merge). If `field_type` changes, the old type-option payload is removed from the collab so we don't leave a stale key. The new `type_option_data` is parsed up-front so the call fails with a clean 400 before mutating any yrs state.
- `src/api/workspace.rs`: route `PATCH /database/{database_id}/fields/{field_id}` to a new `patch_database_field_handler`, which mirrors `post_database_field_handler` (same `AFInsertDatabaseField` body, same `Action::Write` enforcement) and delegates to the new op. Path tuple is `(Uuid, Uuid, String)` because `field_id` is the short collab id, not a uuid. Response is `AppResponse<()>`.
- `libs/client-api/src/http_database.rs`: new `Client::update_database_field(workspace_id, database_id, field_id, AFInsertDatabaseField)` — same signature shape as `add_database_field` plus the `&field_id`, returns `()`.

## Tested
- New `database_patch_field_round_trip` test (in `tests/collab/database_crud.rs`): creates a `SingleSelect` field with two initial options, PATCHes it with four new options (different ids, names, and colours) plus a new field name, then `GET /fields` and asserts the round-tripped shape matches the PATCH body exactly. The op shares all its non-field-lookup paths with `add_database_field`, which is already covered, so a single round-trip test is sufficient.

## Summary by Sourcery

Add support for updating existing database fields via a new PATCH endpoint and corresponding client and business logic.

New Features:
- Expose PATCH /api/workspace/{workspace_id}/database/{database_id}/fields/{field_id} to overwrite an existing field's name, field_type, and type_option_data by short collab-internal field id.
- Add client-api support for updating database fields through a new update_database_field method.
- Introduce a collab operation to update an existing database field and broadcast the change to collaborators.

Tests:
- Add an end-to-end test that creates a select field, updates it via PATCH, and verifies the updated schema through GET /fields.