### PR TITLE
feat(admin): advertise MCP capability for non-commercial deployments

### DIFF
--- a/doc/ADMIN_TAGS.md
+++ b/doc/ADMIN_TAGS.md
@@ -1,0 +1,15 @@
+# Admin capability tags
+
+`GET /api/admin/tags` returns read-only capability metadata used by AppFlowy Admin to decide
+which navigation entries and pages to show. The endpoint intentionally mirrors the public
+capability endpoint in AppFlowy Cloud Premium: it does not expose user, workspace, license, or
+other administrative data, and it does not authorize any operation.
+
+The non-commercial server always advertises `MCP`. AppFlowy Admin may therefore expose its MCP
+tool console for this deployment. `UserManagement` and `UpgradePlan` are also returned to preserve
+the Admin client's existing fetch-failure baseline. Other tags are deliberately omitted because
+this server does not provide their corresponding Admin APIs.
+
+Tags are a UI-discoverability contract, not a security boundary. Any API or MCP operation exposed
+by the server must continue to enforce authentication, authorization, and workspace permissions
+independently.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,5 @@
 # Docs
 - Directory to contain information about usage and development.
+- [Admin capability tags](./ADMIN_TAGS.md)
 - [Appflowy Cloud Deployment](./DEPLOYMENT.md)
 - [Appflowy with Cloud](https://docs.appflowy.io/docs/guides/appflowy/self-hosting-appflowy)

--- a/libs/shared-entity/src/dto/server_info_dto.rs
+++ b/libs/shared-entity/src/dto/server_info_dto.rs
@@ -12,3 +12,35 @@ pub struct ServerInfoResponseItem {
   pub minimum_supported_client_version: Option<String>,
   pub appflowy_web_url: String,
 }
+
+/// Admin console capabilities advertised by the server.
+///
+/// Variant names are part of the JSON contract shared with AppFlowy Admin.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SuperAdminTags {
+  UserManagement,
+  UpgradePlan,
+  PublishPageManagement,
+  CommercialLicenseSubscription,
+  CollabDocument,
+  SearchDiagnostics,
+  Permission,
+  AI,
+  MCP,
+  ServerHealth,
+}
+
+#[cfg(test)]
+mod tests {
+  use serde_json::Value;
+
+  use super::SuperAdminTags;
+
+  #[test]
+  fn mcp_admin_tag_serializes_stably() {
+    assert_eq!(
+      serde_json::to_value(SuperAdminTags::MCP).unwrap(),
+      Value::String("MCP".to_string())
+    );
+  }
+}

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -1,0 +1,53 @@
+use actix_web::{web, Scope};
+use shared_entity::dto::server_info_dto::SuperAdminTags;
+use shared_entity::response::{AppResponse, JsonAppResponse};
+
+/// Returns the read-only capability metadata consumed by AppFlowy Admin.
+pub fn admin_scope() -> Scope {
+  web::scope("/api/admin").service(web::resource("/tags").route(web::get().to(admin_tags_handler)))
+}
+
+async fn admin_tags_handler() -> JsonAppResponse<Vec<SuperAdminTags>> {
+  AppResponse::Ok()
+    .with_data(noncommercial_admin_tags())
+    .into()
+}
+
+fn noncommercial_admin_tags() -> Vec<SuperAdminTags> {
+  vec![
+    SuperAdminTags::UserManagement,
+    SuperAdminTags::UpgradePlan,
+    SuperAdminTags::MCP,
+  ]
+}
+
+#[cfg(test)]
+mod tests {
+  use actix_web::{http::StatusCode, test, App};
+  use serde_json::json;
+
+  use super::admin_scope;
+
+  #[actix_web::test]
+  async fn admin_tags_endpoint_returns_exact_noncommercial_capabilities() {
+    let app = test::init_service(App::new().service(admin_scope())).await;
+    let request = test::TestRequest::get().uri("/api/admin/tags").to_request();
+
+    let response = test::call_service(&app, request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(
+      body,
+      json!({
+        "data": [
+          "UserManagement",
+          "UpgradePlan",
+          "MCP"
+        ],
+        "code": 0,
+        "message": "Operation completed successfully."
+      })
+    );
+  }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod access_request;
+pub mod admin;
 pub mod ai;
 pub mod chat;
 pub mod data_import;

--- a/src/application.rs
+++ b/src/application.rs
@@ -52,6 +52,7 @@ use mailer::sender::Mailer;
 use snowflake::Snowflake;
 
 use crate::api::access_request::access_request_scope;
+use crate::api::admin::admin_scope;
 use crate::api::ai::ai_completion_scope;
 use crate::api::chat::chat_scope;
 use crate::api::data_import::data_import_scope;
@@ -151,6 +152,7 @@ pub async fn run_actix_server(
     let app = app.wrap(actix_cors_scope());
 
     app
+      .service(admin_scope())
       .service(server_info_scope())
       .service(user_scope())
       .service(workspace_scope())


### PR DESCRIPTION
## Summary

- add the read-only `GET /api/admin/tags` capability endpoint expected by AppFlowy Admin
- advertise `MCP` unconditionally for the non-commercial deployment
- preserve the existing Admin fallback baseline with `UserManagement` and `UpgradePlan`
- deliberately omit tags for Admin APIs that this server does not implement
- add an exact `MCP` serialization test and a strict full-response endpoint test

The endpoint mirrors the Premium server's public capability-metadata contract. It does not expose administrative data or authorize any operation; MCP authentication, scopes, and workspace permissions remain server-enforced.

Companion changes:

- Admin UI: AppFlowy-IO/AppFlowy-Admin#65
- Premium Team entitlement: AppFlowy-IO/AppFlowy-Cloud-Premium#881

## Required configuration

The tag enables UI discovery only. Operators still need to configure the Admin frontend and standalone MCP service, including `APPFLOWY_MCP_BASE_URL`, allowed browser origins/redirect hosts, and the required MCP request/response headers documented in the Admin PR.

## Validation

- `cargo test -p shared-entity mcp_admin_tag_serializes_stably`
- `PROTOC=<temporary-protoc> cargo test -p appflowy-cloud admin_tags_endpoint_returns_exact_noncommercial_capabilities --lib`
- `cargo fmt --all -- --check`
- `git diff --check`

Clippy was not run because `cargo-clippy` is unavailable in the repository's pinned Rust 1.86 toolchain.
