### PR TITLE
feat: add optional SCIM compose routing

### DIFF
--- a/.github/workflows/rustlint.yml
+++ b/.github/workflows/rustlint.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Validate optional SCIM deployment
+        run: ./script/check_optional_scim_compose.sh
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}

--- a/README.md
+++ b/README.md
@@ -66,4 +66,6 @@ We also have a few other open source repos, such as
 ## 🚀Deployment
 
 - See [deployment guide](https://appflowy.com/docs/Step-by-step-Self-Hosting-Guide---From-Zero-to-Production)
-
+- SCIM provisioning is disabled at the public proxy by default. Enterprise
+  deployments can enable the provider-neutral route with the
+  [optional SCIM Compose override](doc/SCIM.md).

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,5 @@
 # Docs
 - Directory to contain information about usage and development.
 - [Appflowy Cloud Deployment](./DEPLOYMENT.md)
+- [Optional SCIM endpoint](./SCIM.md)
 - [Appflowy with Cloud](https://docs.appflowy.io/docs/guides/appflowy/self-hosting-appflowy)

--- a/doc/SCIM.md
+++ b/doc/SCIM.md
@@ -1,0 +1,71 @@
+# Optional SCIM endpoint
+
+AppFlowy Self-hosted Cloud can act as a SCIM 2.0 server. Your identity provider
+pushes Users and Groups to AppFlowy; SCIM is provisioning, not login.
+
+The public SCIM route is disabled by default. A normal deployment remains:
+
+```bash
+docker compose up -d
+```
+
+## Enable SCIM
+
+SCIM bearer tokens grant permission to provision and deactivate accounts, so
+the endpoint is available only over HTTPS. Configure `SCHEME=https`, install a
+valid certificate in `nginx/ssl`, then start the stack with the SCIM override:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.scim.yml \
+  up -d
+```
+
+The override adds no services and does not deploy an identity provider. It only
+mounts the `/scim/` reverse-proxy route into the existing Nginx service, so it
+works with any compatible provider, including Microsoft Entra ID, Okta, and
+Authentik.
+
+In the AppFlowy Admin Console:
+
+1. Open **SCIM Provisioning**.
+2. Create a directory-sync connection for the target workspace.
+3. Copy the returned bearer token immediately and store it securely.
+4. Configure the identity provider with:
+   - **Tenant URL:** `https://<your-domain>/scim/v2`
+   - **Token:** the connection's bearer token
+
+Each directory-sync connection targets one AppFlowy workspace. SCIM Groups are
+directory groups inside that connection; they are not separate workspaces.
+
+Plain HTTP requests receive `403 Forbidden` rather than a redirect. The
+SCIM-enabled virtual server also omits query strings from access logs and
+retains only critical Nginx error messages because SCIM filters can contain
+email addresses and external IDs.
+
+## External reverse proxies
+
+The override assumes TLS terminates at the bundled Nginx container. If a load
+balancer or external proxy terminates TLS and forwards plaintext HTTP to the
+container, configure `/scim/` on that HTTPS edge instead of using this override:
+
+- forward the original `/scim/v2/*` URI to `appflowy_cloud:8000`;
+- preserve the `Authorization` header;
+- do not redirect plaintext SCIM requests to HTTPS;
+- omit query strings from access and error logs.
+
+The `appflowy_cloud` hostname is available only inside the Compose network. An
+external proxy must either join that network or use another private, reachable
+address for the AppFlowy Cloud service; port 8000 is not published by default.
+
+## Disable SCIM
+
+Remove the override from subsequent Compose commands and recreate Nginx:
+
+```bash
+docker compose -f docker-compose.yml up -d --force-recreate nginx
+```
+
+This removes the public `/scim/` route. Revoke the directory-sync connection in
+the Admin Console as well if the provider must no longer provision users.

--- a/docker-compose.scim.yml
+++ b/docker-compose.scim.yml
@@ -1,0 +1,10 @@
+# Opt-in public SCIM endpoint for AppFlowy Self-hosted Cloud.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.scim.yml up -d
+#
+# The base compose file remains unchanged when this override is not supplied.
+services:
+  nginx:
+    volumes:
+      - ./nginx/optional/scim:/etc/nginx/appflowy-optional:ro

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -12,6 +12,13 @@ http {
     resolver 127.0.0.11 valid=10s;
     #error_log /var/log/nginx/error.log debug;
 
+    # SCIM filters can contain email addresses and external IDs. This format is
+    # available to the opt-in SCIM configuration and deliberately omits query
+    # strings while retaining enough information for request tracing.
+    log_format appflowy_query_safe '$remote_addr [$time_local] '
+                                   '"$request_method $uri $server_protocol" '
+                                   '$status $body_bytes_sent request_id=$request_id';
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         '' close;
@@ -49,6 +56,10 @@ http {
         # Host name for minio, used internally within docker compose
         set $minio_internal_host "minio:9000";
         set $pgadmin_backend "http://pgadmin:80";
+
+        # Optional routes are mounted by explicit Docker Compose overrides.
+        # With the default compose file this glob matches nothing.
+        include /etc/nginx/appflowy-optional/*.conf;
 
         # GoTrue
         location /gotrue/ {

--- a/nginx/optional/scim/scim.conf
+++ b/nginx/optional/scim/scim.conf
@@ -1,0 +1,23 @@
+# This file is mounted only by docker-compose.scim.yml.
+#
+# Apply query-safe logging to the entire virtual server because malformed
+# request lines can be rejected before Nginx selects the /scim/ location.
+access_log /var/log/nginx/access.log appflowy_query_safe;
+error_log /var/log/nginx/error.log crit;
+
+# SCIM bearer tokens grant provisioning access. Reject plaintext requests
+# instead of redirecting a credential that has already crossed the network.
+location ^~ /scim/ {
+    if ($scheme != https) {
+        return 403;
+    }
+
+    proxy_pass $appflowy_cloud_backend;
+    proxy_set_header X-Request-Id $request_id;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+}

--- a/script/check_optional_scim_compose.sh
+++ b/script/check_optional_scim_compose.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$project_root"
+
+# Keep template-only optional values from producing Compose warnings.
+export APPFLOWY_S3_REGION="${APPFLOWY_S3_REGION:-us-east-1}"
+export AZURE_OPENAI_API_KEY="${AZURE_OPENAI_API_KEY:-}"
+export AZURE_OPENAI_ENDPOINT="${AZURE_OPENAI_ENDPOINT:-}"
+export AZURE_OPENAI_API_VERSION="${AZURE_OPENAI_API_VERSION:-}"
+
+base_compose=(
+  docker compose
+  --env-file deploy.env
+  -f docker-compose.yml
+)
+scim_compose=(
+  "${base_compose[@]}"
+  -f docker-compose.scim.yml
+)
+
+default_services="$("${base_compose[@]}" config --services | sort)"
+scim_services="$("${scim_compose[@]}" config --services | sort)"
+
+if [[ "$default_services" != "$scim_services" ]]; then
+  echo "SCIM override must not add or remove services" >&2
+  exit 1
+fi
+
+default_config="$("${base_compose[@]}" config)"
+if grep -q "/etc/nginx/appflowy-optional" <<<"$default_config"; then
+  echo "Default compose configuration unexpectedly enables an optional Nginx route" >&2
+  exit 1
+fi
+
+scim_config="$("${scim_compose[@]}" config)"
+if ! grep -q "/etc/nginx/appflowy-optional" <<<"$scim_config"; then
+  echo "SCIM compose configuration does not mount the optional Nginx route" >&2
+  exit 1
+fi
+
+nginx_image="$(
+  "${base_compose[@]}" config --images \
+    | awk '/(^|\/)nginx(:|$)/ { print; exit }'
+)"
+if [[ -z "$nginx_image" ]]; then
+  echo "Unable to resolve the Nginx image from docker-compose.yml" >&2
+  exit 1
+fi
+
+nginx_mounts=(
+  --mount "type=bind,src=$project_root/nginx/nginx.conf,dst=/etc/nginx/nginx.conf,readonly"
+  --mount "type=bind,src=$project_root/nginx/ssl,dst=/etc/nginx/ssl,readonly"
+)
+
+docker run --rm "${nginx_mounts[@]}" "$nginx_image" nginx -t
+docker run --rm \
+  "${nginx_mounts[@]}" \
+  --mount "type=bind,src=$project_root/nginx/optional/scim,dst=/etc/nginx/appflowy-optional,readonly" \
+  "$nginx_image" \
+  nginx -t
+
+enabled_nginx_config="$(
+  docker run --rm \
+    "${nginx_mounts[@]}" \
+    --mount "type=bind,src=$project_root/nginx/optional/scim,dst=/etc/nginx/appflowy-optional,readonly" \
+    "$nginx_image" \
+    nginx -T 2>&1
+)"
+if ! grep -Fq "location ^~ /scim/" <<<"$enabled_nginx_config" \
+  || ! grep -Fq 'proxy_pass $appflowy_cloud_backend;' <<<"$enabled_nginx_config"; then
+  echo "Enabled Nginx configuration does not contain the SCIM upstream route" >&2
+  exit 1
+fi
+
+test_container="appflowy-scim-nginx-check-$$"
+cleanup() {
+  docker rm --force "$test_container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run --rm --detach \
+  --name "$test_container" \
+  --publish 127.0.0.1::80 \
+  "${nginx_mounts[@]}" \
+  --mount "type=bind,src=$project_root/nginx/optional/scim,dst=/etc/nginx/appflowy-optional,readonly" \
+  "$nginx_image" >/dev/null
+
+host_port="$(docker port "$test_container" 80/tcp | sed 's/.*://')"
+query_marker="scim-query-must-not-appear@example.com"
+http_status=""
+for _ in {1..50}; do
+  http_status="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+      "http://127.0.0.1:${host_port}/scim/v2/Users?filter=userName%20eq%20%22${query_marker}%22" \
+      || true
+  )"
+  [[ "$http_status" != "000" ]] && break
+  sleep 0.1
+done
+
+if [[ "$http_status" != "403" ]]; then
+  echo "Plaintext SCIM request returned $http_status instead of 403" >&2
+  exit 1
+fi
+
+nginx_logs="$(docker logs "$test_container" 2>&1)"
+if grep -q "$query_marker" <<<"$nginx_logs"; then
+  echo "SCIM query value leaked into Nginx logs" >&2
+  exit 1
+fi
+
+cleanup
+trap - EXIT
+
+echo "Default and SCIM-enabled Compose/Nginx configurations are valid"


### PR DESCRIPTION
## Summary

- add a provider-neutral `docker-compose.scim.yml` override that exposes `/scim/v2` through the existing Nginx service
- keep normal `docker compose up -d` behavior unchanged when the override is absent
- require TLS for SCIM bearer-token requests and use query-safe logging for filters that may contain identity data
- document bundled-Nginx and external-proxy deployment paths
- validate the default and enabled Compose models, both Nginx configurations, the loaded SCIM upstream route, HTTP rejection, and query-log redaction in CI

## Opt-in usage

```bash
docker compose \
  -f docker-compose.yml \
  -f docker-compose.scim.yml \
  up -d
```

The override adds no services and mounts only the read-only SCIM Nginx snippet. Without the second `-f`, there is no SCIM mount or public route.

## Security rationale

SCIM bearer tokens and resources require transport security, and SCIM query filters can contain personal information. The route rejects plaintext requests instead of redirecting them, omits query strings from access logs, and limits Nginx error output to critical messages.

- https://www.rfc-editor.org/rfc/rfc7644.html#section-7.2
- https://www.rfc-editor.org/rfc/rfc7644.html#section-7.5.2
- https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/

## Validation

```text
./script/check_optional_scim_compose.sh
Default and SCIM-enabled Compose/Nginx configurations are valid
```

## Summary by Sourcery

Introduce an opt-in SCIM provisioning endpoint exposed via Nginx and validated by CI without altering default deployments.

New Features:
- Add an optional Docker Compose override to mount a provider-neutral /scim/v2 route on the existing Nginx service for SCIM provisioning.

Enhancements:
- Configure Nginx to include optional route snippets and add a query-safe log format that omits SCIM query strings while preserving traceability.

CI:
- Add a CI step that validates default and SCIM-enabled Docker Compose and Nginx configurations, including the SCIM upstream route and logging behavior.

Documentation:
- Add SCIM documentation covering enabling, disabling, and external proxy deployment patterns, and reference the optional SCIM endpoint from existing docs and README.