### PR TITLE
fix(deploy): add healthcheck to appflowy_search and set service_healthy dependency for appflowy_cloud

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,8 @@ services:
     depends_on:
       gotrue:
         condition: service_healthy
+      appflowy_search:
+        condition: service_healthy
 
   admin_frontend:
     restart: on-failure
@@ -275,6 +277,12 @@ services:
       - APPFLOWY_GOTRUE_JWT_SECRET=${GOTRUE_JWT_SECRET}
     volumes:
       - keyword_index_data:/var/lib/appflowy/keyword_index
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -f http://127.0.0.1:$${APPFLOWY_SEARCH_PORT:-4002}/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 40s
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
### 📝 Description of Changes

This PR adds an explicit `healthcheck` definition for the `appflowy_search` service and configures `appflowy_cloud` to wait for `appflowy_search` to become healthy during startup in `docker-compose.yml`.

### 🔗 Related Pull Requests & Issues
- **PR #1637**: Added `NEXT_PUBLIC_DISABLE_SERVER_ACTIONS` option for reverse proxy deployments.
- **PR #1643**: Comprehensive self-hosted documentation and deployment guide.
- **PR #1639** & **Issue #1638**: PostgreSQL trigger for automatic super admin role synchronization.
- **PR #1642** & **Issue #1641**: Improved self-hosted error messaging and guidance for workspace member limits.

---

### 🔍 Problem & Motivation

During container startup in Docker Compose, `appflowy_cloud` attempts to verify search service health at `http://appflowy_search:4002/health`. Because `appflowy_cloud` previously started in parallel without waiting for `appflowy_search` initialization, startup logs frequently contained connection errors:

```text
AppFlowy Search health check failed during startup: error sending request for url (http://appflowy_search:4002/health)
```

### 🛠️ Changes Included:
- **`appflowy_search`**: Added `healthcheck` querying `http://127.0.0.1:4002/health`.
- **`appflowy_cloud`**: Added `appflowy_search: condition: service_healthy` to `depends_on`.

### 🧪 Verification:
- Verified clean container startup ordering in Docker Compose.

## Summary by Sourcery

Add a health check for the appflowy_search service and ensure appflowy_cloud waits for it to become healthy before starting.

Deployment:
- Define a Docker healthcheck for the appflowy_search service to verify its /health endpoint.
- Configure appflowy_cloud to depend on appflowy_search being healthy via Docker Compose service_healthy condition.