### PR TITLE
feat: expose SCIM through self-hosted Nginx

### DIFF
--- a/external_proxy_config/nginx/appflowy.site.conf
+++ b/external_proxy_config/nginx/appflowy.site.conf
@@ -11,6 +11,8 @@ map $http_upgrade $connection_upgrade {
 server {
     server_name appflowy-cloud.example.com;
     listen 80;
+    # Configure a trusted certificate and `listen 443 ssl` on this server before
+    # onboarding an IdP. The SCIM location below intentionally refuses HTTP.
     underscores_in_headers on;
     set $appflowy_cloud_backend "http://127.0.0.1:8000";
     set $gotrue_backend "http://127.0.0.1:9999";
@@ -44,10 +46,28 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # SCIM 2.0 directory sync. Keep this outside /api so /scim/v2 reaches
+    # appflowy-cloud instead of falling through to the web frontend.
+    location /scim {
+        # Never redirect a request carrying a bearer credential: by the time
+        # a redirect is returned, the credential has already crossed plaintext.
+        if ($scheme != https) {
+            return 403;
+        }
+
+        # SCIM filters can contain email addresses and external IDs.
+        access_log off;
+        error_log /dev/null;
+        proxy_pass $appflowy_cloud_backend;
+    }
+
     location /api {
         proxy_pass $appflowy_cloud_backend;
         proxy_set_header X-Request-Id $request_id;
         proxy_set_header Host $http_host;
+        # Replace caller-supplied XFF. LDAP login uses this single trusted
+        # address for per-client throttling.
+        proxy_set_header X-Forwarded-For $remote_addr;
 
         location ~* ^/api/workspace/([a-zA-Z0-9_-]+)/publish$ {
             proxy_pass $appflowy_cloud_backend;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -81,6 +81,9 @@ http {
             proxy_pass $appflowy_cloud_backend;
             proxy_set_header X-Request-Id $request_id;
             proxy_set_header Host $http_host;
+            # Replace caller-supplied XFF. LDAP login uses this single trusted
+            # address for per-client throttling.
+            proxy_set_header X-Forwarded-For $remote_addr;
 
             location ~* ^/api/workspace/([a-zA-Z0-9_-]+)/publish$ {
                 proxy_pass $appflowy_cloud_backend;
@@ -121,6 +124,22 @@ http {
                 proxy_cache off;
                 client_max_body_size 2G;
             }
+        }
+
+        # SCIM 2.0 directory sync (self-hosted). Server-to-server (IdP) traffic,
+        # same upstream as /api. Without this, /scim/v2 falls through to the web
+        # frontend (location /) instead of reaching the SCIM API.
+        location /scim {
+            # Never redirect a request carrying a bearer credential: by the time
+            # a redirect is returned, the credential has already crossed plaintext.
+            if ($scheme != https) {
+                return 403;
+            }
+
+            # SCIM filters can contain email addresses and external IDs.
+            access_log off;
+            error_log /dev/null;
+            proxy_pass $appflowy_cloud_backend;
         }
 
         # Minio Web UI


### PR DESCRIPTION
## Summary

- route `/scim/v2/*` to AppFlowy Cloud in both bundled and external Nginx examples
- refuse plaintext SCIM bearer requests and suppress logs that could contain sensitive filters
- replace caller-supplied `X-Forwarded-For` metadata on `/api` for LDAP per-IP throttling

This is the public self-host follow-up required by AppFlowy-Cloud-Premium#758 because Docker Compose bind-mounts the public Nginx configuration.

## Validation

- bundled `nginx/nginx.conf`: `nginx -t` passed in `nginx:alpine`
- external `appflowy.site.conf`: `nginx -t` passed in `nginx:alpine`
- `git diff --check`

## Summary by Sourcery

Expose and secure SCIM directory sync endpoints in self-hosted Nginx configurations while standardizing request metadata for LDAP-based throttling.

New Features:
- Route /scim/v2 traffic to the AppFlowy Cloud backend in both bundled and external Nginx configurations for self-hosted SCIM support.

Enhancements:
- Enforce HTTPS-only access and disable logging for SCIM requests to prevent plaintext bearer credential exposure and leakage of sensitive filter data.
- Normalize X-Forwarded-For on /api requests to the trusted client IP to support reliable per-client LDAP login throttling.