### PR TITLE
fix(deploy): add non-blocking search healthcheck

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -168,7 +168,7 @@ services:
       gotrue:
         condition: service_healthy
       appflowy_search:
-        condition: service_started
+        condition: service_healthy
 
   admin_frontend:
     restart: on-failure
@@ -265,6 +265,22 @@ services:
       - APPFLOWY_GOTRUE_JWT_SECRET=${GOTRUE_JWT_SECRET}
     volumes:
       - keyword_index_data:/var/lib/appflowy/keyword_index
+    healthcheck:
+      # The runtime image does not ship curl or wget. Bash's /dev/tcp support
+      # keeps this an HTTP readiness check without adding an image dependency.
+      test:
+        - CMD
+        - bash
+        - -ec
+        - |
+          exec 3<>/dev/tcp/127.0.0.1/$${APPFLOWY_SEARCH_PORT:-4002}
+          printf 'GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3
+          read -r _ status _ <&3
+          [ "$$status" = 200 ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 40s
     networks:
       - shared_network
     depends_on:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -167,8 +167,6 @@ services:
     depends_on:
       gotrue:
         condition: service_healthy
-      appflowy_search:
-        condition: service_healthy
 
   admin_frontend:
     restart: on-failure
@@ -267,7 +265,7 @@ services:
       - keyword_index_data:/var/lib/appflowy/keyword_index
     healthcheck:
       # The runtime image does not ship curl or wget. Bash's /dev/tcp support
-      # keeps this an HTTP readiness check without adding an image dependency.
+      # keeps this an HTTP-level check without adding an image dependency.
       test:
         - CMD
         - bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,8 +167,6 @@ services:
     depends_on:
       gotrue:
         condition: service_healthy
-      appflowy_search:
-        condition: service_healthy
 
   admin_frontend:
     restart: on-failure
@@ -279,7 +277,7 @@ services:
       - keyword_index_data:/var/lib/appflowy/keyword_index
     healthcheck:
       # The runtime image does not ship curl or wget. Bash's /dev/tcp support
-      # keeps this an HTTP readiness check without adding an image dependency.
+      # keeps this an HTTP-level check without adding an image dependency.
       test:
         - CMD
         - bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,8 @@ services:
     depends_on:
       gotrue:
         condition: service_healthy
+      appflowy_search:
+        condition: service_healthy
 
   admin_frontend:
     restart: on-failure
@@ -275,6 +277,22 @@ services:
       - APPFLOWY_GOTRUE_JWT_SECRET=${GOTRUE_JWT_SECRET}
     volumes:
       - keyword_index_data:/var/lib/appflowy/keyword_index
+    healthcheck:
+      # The runtime image does not ship curl or wget. Bash's /dev/tcp support
+      # keeps this an HTTP readiness check without adding an image dependency.
+      test:
+        - CMD
+        - bash
+        - -ec
+        - |
+          exec 3<>/dev/tcp/127.0.0.1/$${APPFLOWY_SEARCH_PORT:-4002}
+          printf 'GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3
+          read -r _ status _ <&3
+          [ "$$status" = 200 ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 40s
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What changed

- add an HTTP-level healthcheck for `appflowy_search` in the deployment and CI Compose files
- keep `appflowy_cloud` independent from Search health
- remove the CI-only Search startup dependency so a failed Search container cannot block Cloud
- implement the probe with Bash's built-in TCP support because the published Search image does not include `curl` or `wget`

## Why

Search is an auxiliary service. Its failure should be visible through Docker health status, but it must not prevent AppFlowy Cloud or unrelated services from starting.

PR #1640 added `condition: service_healthy`, which turns Search into a hard startup dependency. It also invokes `curl` inside the Search container even though the current amd64 and arm64 images do not ship that binary.

This change keeps health reporting non-blocking. The probe opens a local TCP connection, requests `/health`, and reports healthy only when the endpoint returns HTTP 200.

## Impact

Operators and CI can observe Search health without coupling overall Cloud availability to Search availability. If Search fails or is slow to initialize, other services continue starting normally.

## Validation

- parsed both `docker-compose.yml` and `docker-compose-ci.yml` with Docker Compose
- verified rendered Cloud dependencies contain only GoTrue, not Search
- verified the rendered container healthcheck preserves runtime port expansion
- ran the probe against the current published `appflowy_search` image and received success from `/health`
- verified the probe fails for a closed port and for a non-200 HTTP response
- `git diff --check`

Related: #1640

## Summary by Sourcery

Add a non-blocking HTTP-level healthcheck for the appflowy_search service and prevent Search from blocking AppFlowy Cloud startup in CI.

New Features:
- Add an HTTP healthcheck for the appflowy_search service in docker-compose and CI compose configurations.

Enhancements:
- Decouple AppFlowy Cloud CI service startup from appflowy_search by removing Search as a startup dependency.